### PR TITLE
fix: repository path in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Configuration
-readonly REPO="jwoirhaye/joule-profiler"
+readonly REPO="joule-profiler/joule-profiler"
 readonly BINARY_NAME="joule-profiler"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 TARGET_VERSION="${TARGET_VERSION:-latest}"


### PR DESCRIPTION
## Description

Fix repository path in installation script because it was pointing to the former repository.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Documentation
* [ ] Other (please specify):

## Changes Made

* Updated repository path in installation script.