### PR TITLE
Bugfix/13 wrong value serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ A modular tool for measuring energy consumption and performance metrics of progr
 ### Installation
 
 ```bash
-# Quick install (recommended)
+# Quick install with cargo
+cargo install joule-profiler-cli
+
+# Quick install with binaries
 curl -fsSL https://raw.githubusercontent.com/joule-profiler/joule-profiler/main/install.sh | bash
 
 # Or build from source

--- a/core/src/aggregate/metric.rs
+++ b/core/src/aggregate/metric.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use crate::unit::MetricUnit;
 
@@ -51,7 +51,7 @@ pub type Metrics = Vec<Metric>;
 /// Enum representing the value of a metric,
 /// with this enum, a metric can be a signed or
 /// unsigned integer or a float.
-#[derive(Debug, Serialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MetricValue {
     UnsignedInteger(u64),
     SignedInteger(i64),
@@ -80,6 +80,19 @@ impl Display for MetricValue {
             Self::UnsignedInteger(v) => v.fmt(f),
             Self::SignedInteger(v) => v.fmt(f),
             Self::Float(v) => v.fmt(f),
+        }
+    }
+}
+
+impl Serialize for MetricValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            MetricValue::UnsignedInteger(v) => serializer.serialize_u64(*v),
+            MetricValue::SignedInteger(v) => serializer.serialize_i64(*v),
+            MetricValue::Float(v) => serializer.serialize_f64(*v),
         }
     }
 }


### PR DESCRIPTION
## Description
Fix the JSON serialization of metric values. Instead of outputting the internal Rust enum variant wrapper (e.g. `{"UnsignedInteger": 74218}`), values are now serialized as plain numbers (e.g. `74218`).

## Type of Change
* [X] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Documentation
* [ ] Other (please specify):

## Related Issues
Fixes #13

## Changes Made
* Replaced the derived `Serialize` implementation on the metric value enum with a manual `Serialize` impl that serializes only the inner value
* JSON output now renders `"value": 74218` instead of `"value": {"UnsignedInteger": 74218}`
* Covered all enum variants (e.g. `UnsignedInteger`, `Float`, etc.) in the custom serializer

## Checklist
* [X] My code follows the project style
* [ ] I have tested my changes
* [X] I have added/updated documentation if needed
* [X] All tests pass

## Additional Notes
The root cause was that `#[derive(Serialize)]` on a Rust enum produces the variant name as a JSON key by default. A manual `Serialize` implementation extracts the inner value directly, matching the expected output described in issue #13.