### PR TITLE
chore/docs/fix: crate metadata, readme sources, serialization fix & repo migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 edition = "2024"
 authors = ["Jérémy Woirhaye <jerem.woirhaye@gmail.com>", "François Gibier <francoisgibier.contact@gmail.com>"]
 license = "MIT"
-repository = "https://github.com/jwoirhaye/joule-profiler"
+repository = "https://github.com/joule-profiler/joule-profiler"
 readme = "README.md"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://www.linux.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](LICENSE)
-[![Documentation](https://img.shields.io/badge/docs-mdbook-blue?style=for-the-badge)](https://jwoirhaye.github.io/joule-profiler/)
+[![Documentation](https://img.shields.io/badge/docs-mdbook-blue?style=for-the-badge)](https://joule-profiler.github.io/joule-profiler-docs/)
 
 A modular tool for measuring energy consumption and performance metrics of programs on Linux systems.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ A modular tool for measuring energy consumption and performance metrics of progr
 ### Installation
 
 ```bash
-# Quick install (recommended)
+# Quick install with cargo
+cargo install joule-profiler-cli
+
+# Quick install with binaries
 curl -fsSL https://raw.githubusercontent.com/joule-profiler/joule-profiler/main/install.sh | bash
 
 # Or build from source

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ sudo cp target/release/joule-profiler /usr/local/bin/
 
 ```bash
 # Phase-based profiling
-sudo joule-profiler phases -- python workload.py
+sudo joule-profiler profile -- python workload.py
 
 # JSON output
-sudo joule-profiler --json phases -- ./benchmark
+sudo joule-profiler --json profile -- ./benchmark
 
 # GPU profiling (NVIDIA)
-sudo joule-profiler --gpu phases-- ./gpu-workload
+sudo joule-profiler --gpu profile-- ./gpu-workload
 ```
 
 ## Documentation
@@ -68,7 +68,7 @@ print("__CLEANUP__")
 ```
 
 ```bash
-sudo joule-profiler phases -- python example.py
+sudo joule-profiler profile -- python example.py
 ```
 
 ### Multiple Metric Sources

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://www.linux.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](LICENSE)
-[![Documentation](https://img.shields.io/badge/docs-mdbook-blue?style=for-the-badge)](https://joule-profiler.github.io/joule-profiler-docs/)
+[![Documentation](https://img.shields.io/badge/docs-mdbook-blue?style=for-the-badge)](https://joule-profiler.github.io)
 
 A modular tool for measuring energy consumption and performance metrics of programs on Linux systems.
 
@@ -48,11 +48,11 @@ sudo joule-profiler --gpu profile-- ./gpu-workload
 
 ## Documentation
 
-**[Full Documentation](https://joule-profiler.github.io/joule-profiler-docs/)**
+**[Full Documentation](https://joule-profiler.github.io/)**
 
-- [Quickstart](https://joule-profiler.github.io/joule-profiler-docs/quickstart.html)
-- [Metric Sources](https://joule-profiler.github.io/joule-profiler-docs/sources/overview.html)
-- [Examples](https://joule-profiler.github.io/joule-profiler-docs/examples/overview.html)
+- [Quickstart](https://joule-profiler.github.io/quickstart.html)
+- [Metric Sources](https://joule-profiler.github.io/sources/overview.html)
+- [Examples](https://joule-profiler.github.io/examples/overview.html)
 
 ## What Makes Joule Profiler Different?
 
@@ -99,7 +99,7 @@ sudo joule-profiler profile -- python example.py
 
 ## Contributing
 
-Contributions are welcome! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
+Contributions are welcome! Please see our [Contributing Guide](https://github.com/joule-profiler/.github/blob/main/CONTRIBUTING.md) for details.
 
 ## License
 
@@ -116,5 +116,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-**[Read the Full Documentation](https://joule-profiler.github.io/joule-profiler-docs/)** | *
+**[Read the Full Documentation](https://joule-profiler.github.io)** | *
 *[⭐ Star on GitHub](https://github.com/joule-profiler/joule-profiler/)**

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "CLI tool to measure program energy consumption"
 keywords = ["energy", "profiling", "rapl", "nvml", "cli"]
+readme = "../README.md"
 
 [[bin]]
 name = "joule-profiler"

--- a/core/src/aggregate/metric.rs
+++ b/core/src/aggregate/metric.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use crate::unit::MetricUnit;
 
@@ -51,7 +51,7 @@ pub type Metrics = Vec<Metric>;
 /// Enum representing the value of a metric,
 /// with this enum, a metric can be a signed or
 /// unsigned integer or a float.
-#[derive(Debug, Serialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MetricValue {
     UnsignedInteger(u64),
     SignedInteger(i64),
@@ -80,6 +80,19 @@ impl Display for MetricValue {
             Self::UnsignedInteger(v) => v.fmt(f),
             Self::SignedInteger(v) => v.fmt(f),
             Self::Float(v) => v.fmt(f),
+        }
+    }
+}
+
+impl Serialize for MetricValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            MetricValue::UnsignedInteger(v) => serializer.serialize_u64(*v),
+            MetricValue::SignedInteger(v) => serializer.serialize_i64(*v),
+            MetricValue::Float(v) => serializer.serialize_f64(*v),
         }
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Configuration
-readonly REPO="jwoirhaye/joule-profiler"
+readonly REPO="joule-profiler/joule-profiler"
 readonly BINARY_NAME="joule-profiler"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 TARGET_VERSION="${TARGET_VERSION:-latest}"

--- a/sources/nvml/Cargo.toml
+++ b/sources/nvml/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Intel RAPL energy measurement source for joule-profiler"
+description = "NVIDIA NVML-based GPU energy measurement source for joule-profiler"
 keywords = ["energy", "nvml", "nvidia", "GPU", "hardware"]
 
 [dependencies]

--- a/sources/nvml/Cargo.toml
+++ b/sources/nvml/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "NVIDIA NVML-based GPU energy measurement source for joule-profiler"
 keywords = ["energy", "nvml", "nvidia", "GPU", "hardware"]
+readme = "README.md"
 
 [dependencies]
 joule-profiler-core.workspace = true

--- a/sources/nvml/README.md
+++ b/sources/nvml/README.md
@@ -1,0 +1,34 @@
+# joule-profiler-source-nvml
+
+
+NVIDIA GPU energy source for `joule-profiler` using the NVIDIA Management Library (NVML).
+
+This crate implements MetricSource from joule-profiler-core by querying NVIDIA GPU energy counters through the nvml-wrapper Rust crate,
+
+## Overview
+
+NVML is the C-based API used internally by 'nvidia-smi'. It provides direct access to the NVIDIA GPU driver and exposes hardware energy counters, power draw, utilisation, clock speeds, memory usage, and more.
+`joule-profiler` uses NVML exclusively for energy measurement: it reads the cumulative energy counter (nvmlDeviceGetTotalEnergyConsumption) at each phase boundary and reports the delta in millijoules (mJ)
+
+---
+
+## Metrics collected
+
+| Metric | Unit | Description |
+|---|---|---|
+| Energy consumption | µJ | Cumulative energy delta per phase (from NVML energy counter) |
+
+---
+## Requirements
+
+| Requirement | Details |
+|---|---|
+| OS | Linux |
+| GPU | NVIDIA GPU |
+| Driver | NVIDIA driver with `libnvidia-ml.so` (included in standard driver packages) |
+| Permissions | Typically no extra permissions beyond driver access |
+
+
+## See also
+
+> Main project: [joule-profiler](https://github.com/joule-profiler/joule-profiler)

--- a/sources/perf_event/Cargo.toml
+++ b/sources/perf_event/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "perf_event counters source for joule-profiler"
 keywords = ["energy", "perf_event", "performance_counters"]
+readme = "README.md"
 
 [dependencies]
 joule-profiler-core.workspace = true

--- a/sources/perf_event/README.md
+++ b/sources/perf_event/README.md
@@ -1,0 +1,43 @@
+# joule-profiler-source-perf_event
+
+Performance counter source for `joule-profiler`. using the Linux perf_event subsystem.
+This crate implements MetricSource from `joule-profiler-core` and collects hardware and software performance counters (CPU cycles, instructions, cache misses, branch mispredictions…) via the perf_event_open(2) syscall, per phase.
+
+## Overview
+
+`perf_event` is the Linux kernel's performance monitoring API, available since kernel 2.6.31. It provides access to a wide range of hardware PMU counters, software counters, and kernel tracepoints. In the context of `joule-profiler`, these counters complement energy measurements by revealing the execution characteristics of each phase allowing you to correlate energy with IPC, cache efficiency, etc.
+
+---
+
+## Requirements
+
+| Requirement | Details |
+|---|---|
+| OS | Linux kernel 2.6.31+ |
+| CPU | Any architecture with PMU support (x86, ARM, RISC-V…) |
+| Permissions | Root, or `kernel.perf_event_paranoid ≤ 1` |
+
+### Adjusting perf_event_paranoid
+
+```bash
+# Check current value
+cat /proc/sys/kernel/perf_event_paranoid
+ 
+# Allow per-process counters for unprivileged users (temporary)
+sudo sysctl -w kernel.perf_event_paranoid=1
+ 
+# Persistent
+echo 'kernel.perf_event_paranoid=1' | sudo tee /etc/sysctl.d/99-perf.conf
+sudo sysctl --system
+```
+---
+
+## Scope
+
+At the moment, Joule Profiler attaches `perf_event` counters to the **monitored process** only (per-process mode).
+
+---
+
+## See also
+
+> Main project: [joule-profiler](https://github.com/joule-profiler/joule-profiler)

--- a/sources/rapl/Cargo.toml
+++ b/sources/rapl/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Intel RAPL energy measurement source for joule-profiler"
 keywords = ["energy", "rapl", "hardware", "powercap", "perf_event"]
+readme = "README.md"
 
 [dependencies]
 joule-profiler-core.workspace = true

--- a/sources/rapl/README.md
+++ b/sources/rapl/README.md
@@ -1,0 +1,34 @@
+# joule-profiler-source-rapl
+
+RAPL energy source for [joule-profiler](https://github.com/joule-profiler/joule-profiler).
+
+This crate implements `MetricSource` from `joule-profiler-core` and measures Intel RAPL energy counters via two interchangeable backends: **powercap** (sysfs) and **perf_event** (syscall). The CLI selects the backend automatically or on demand via `--rapl-backend`.
+
+## What is RAPL?
+
+RAPL (Running Average Power Limit) is an Intel processor feature available since the **Sandy Bridge** generation. It exposes accumulated energy counters for different hardware domains, accessible through model-specific registers (MSRs). Linux makes these counters available through two kernel interfaces: the **powercap** sysfs framework and the **perf_event** subsystem.
+
+### Domains
+
+| Domain | Description |
+|---|---|
+| **Package / PKG** | Entire CPU socket (cores + uncore) |
+| **Core / PP0** | CPU cores only |
+| **Uncore / PP1** | Integrated GPU (desktop CPUs) |
+| **DRAM** | Memory subsystem |
+| **PSYS** | Full SoC (Skylake+, laptops only) |
+
+> Available domains depend on the processor model. Both backends auto-discover domains at startup.
+
+---
+## Requirements
+
+| | powercap | perf_event |
+|---|---|---|
+| OS | Linux 3.13+ | Linux 3.14+ |
+| CPU | Intel Sandy Bridge+ | Intel Sandy Bridge+ |
+| Permissions | Root (kernel ≥ 5.10) | Root or `paranoid ≤ 0` |
+---
+## See also
+
+> Main project: [joule-profiler](https://github.com/joule-profiler/joule-p


### PR DESCRIPTION
## Description
This PR bundles several crate metadata improvements, the addition of READMEs for each source, a JSON serialization fix for `MetricValue`, and the migration of all links to the new `joule-profiler` GitHub organization.

## Type of Change
* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [x] Documentation
* [x] Other : chore (Cargo metadata, repo migration)

## Related Issues
N/A

## Changes Made
* Fix `MetricValue` serialization to inline primitive values in JSON (replaced `#[derive(Serialize)]` with a manual implementation)
* Migrate all links (repo, docs, install.sh) from `jwoirhaye/joule-profiler` to `joule-profiler/joule-profiler`
* Add READMEs for `rapl`, `nvml` and `perf_event` crates (collected metrics, requirements, permissions)
* Fix `nvml` crate description (was incorrectly set to "Intel RAPL")
* Add `readme` field in `Cargo.toml` for `cli`, `nvml`, `perf_event` and `rapl`
* Add `cargo install joule-profiler-cli` installation method to the main README
* Fix repository path in `install.sh`
* Update command examples (`phase` → `profile`)

## Checklist
* [x] My code follows the project style
* [x] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass

## Additional Notes
The `MetricValue::serialize` fix is functionally important: without it, the JSON output produced with `--json` was wrapping values in a typed object (e.g. `{"Float": 1.5}`) instead of inlining the raw value (`1.5`).