### PR TITLE
fix: force stdin to /dev/tty (current terminal) to fix entry when pip…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ set -e
 
 # Configuration
 readonly REPO="joule-profiler/joule-profiler"
+readonly DOCUMENTATION_QUICKSTART_URL="https://joule-profiler.github.io/quickstart.html"
 readonly BINARY_NAME="joule-profiler"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 TARGET_VERSION="${TARGET_VERSION:-latest}"
@@ -578,11 +579,12 @@ print_usage() {
     echo "  # Show help" >&2
     echo -e "  ${COLOR_BLUE}joule-profiler --help${COLOR_RESET}" >&2
     echo "" >&2
-    echo "If you want to launch Joule Profiler without root privileges (root), configure the perf_event_paranoid level:" >&2
+    echo "  Note: Joule Profiler requires root privileges. To run without sudo, configure the perf_event_paranoid level:" >&2
     echo -e "  ${COLOR_BLUE}sudo sysctl kernel.perf_event_paranoid=0${COLOR_RESET}" >&2
     echo "" >&2
-    echo "For more information, visit:" >&2
-    echo "  https://github.com/$REPO" >&2
+    echo "For more information:" >&2
+    echo "  QuickStart:  $DOCUMENTATION_QUICKSTART_URL" >&2
+    echo "  Source code: https://github.com/$REPO" >&2
     echo "" >&2
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # joule-profiler installer
-# https://github.com/jwoirhaye/joule-profiler
+# https://github.com/joule-profiler/joule-profiler
 #
 set -e
 
@@ -567,22 +567,19 @@ print_usage() {
     echo "" >&2
     echo -e "${COLOR_GREEN}Installation complete!${COLOR_RESET}" >&2
     echo "" >&2
-    echo "To get started with joule-profiler:" >&2
+    echo "To get started with Joule Profiler:" >&2
     echo "" >&2
-    echo "  # List available RAPL domains" >&2
-    echo -e "  ${COLOR_BLUE}sudo joule-profiler list-domains${COLOR_RESET}" >&2
+    echo "  # List available sensors" >&2
+    echo -e "  ${COLOR_BLUE}joule-profiler list-sensors${COLOR_RESET}" >&2
     echo "" >&2
-    echo "  # Measure energy consumption (simple mode)" >&2
-    echo -e "  ${COLOR_BLUE}sudo joule-profiler simple -- <your-command>${COLOR_RESET}" >&2
-    echo "" >&2
-    echo "  # Measure with phase detection" >&2
-    echo -e "  ${COLOR_BLUE}sudo joule-profiler phases -- <your-command>${COLOR_RESET}" >&2
-    echo "" >&2
-    echo "  # Export to JSON" >&2
-    echo -e "  ${COLOR_BLUE}sudo joule-profiler simple --json -- <your-command>${COLOR_RESET}" >&2
+    echo "  # Phase-based profiling" >&2
+    echo -e "  ${COLOR_BLUE}sudo joule-profiler profile -- <your-command>${COLOR_RESET}" >&2
     echo "" >&2
     echo "  # Show help" >&2
     echo -e "  ${COLOR_BLUE}joule-profiler --help${COLOR_RESET}" >&2
+    echo "" >&2
+    echo "If you want to launch Joule Profiler without root privileges (root), configure the perf_event_paranoid level:" >&2
+    echo -e "  ${COLOR_BLUE}sudo sysctl kernel.perf_event_paranoid=0${COLOR_RESET}" >&2
     echo "" >&2
     echo "For more information, visit:" >&2
     echo "  https://github.com/$REPO" >&2
@@ -594,10 +591,10 @@ main() {
     parse_args "$@"
 
     echo "" >&2
-    echo "╔══════════════════════════════════════════╗" >&2
-    echo "║   joule-profiler installer v0.1.0        ║" >&2
-    echo "║   github.com/jwoirhaye/joule-profiler    ║" >&2
-    echo "╚══════════════════════════════════════════╝" >&2
+    echo "╔════════════════════════════════════════════╗" >&2
+    echo "║          Joule Profiler installer          ║" >&2
+    echo "║  github.com/joule-profiler/joule-profiler  ║" >&2
+    echo "╚════════════════════════════════════════════╝" >&2
     echo "" >&2
 
     log_debug "Installation directory: $INSTALL_DIR"

--- a/install.sh
+++ b/install.sh
@@ -530,7 +530,8 @@ check_existing_installation() {
 
         if [ "$SKIP_CONFIRM" = false ]; then
             echo -n "Do you want to overwrite it? [y/N] " >&2
-            read -r reply
+            read -r reply </dev/tty
+            
             if [[ ! $reply =~ ^[Yy]$ ]]; then
                 log_info "Installation cancelled"
                 exit 0


### PR DESCRIPTION
…ed to bash

## Description

When the install script is piped to bash and Joule Profiler is already installed on the system, the user must validate the re-installation of Joule Profiler.
The problem is that when the installation script is piped to bash, the install script crashed because the stdin is not linked to the current terminal.

Now, the script waits for the /dev/tty stdin and not the program's.
Also the documentation printed after the installation has been updated.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [x] Documentation

## Related Issues

The related issue is #20.

## Changes Made

* Fixed stdin for re-install validation.
* Updated quickstart documentation.
