### PR TITLE
fix: crash when inheriting program's stderr with non-blocking I/O fix

### DIFF
--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -1,6 +1,7 @@
 use crate::orchestrator::error::OrchestratorError;
 use crate::source::error::MetricSourceError;
 use thiserror::Error;
+use tokio::task::JoinError;
 
 /// Top-level error type for `JouleProfiler`.
 ///
@@ -27,6 +28,18 @@ pub enum JouleProfilerError {
     /// Failed to capture the profiled command's stdout.
     #[error("Stdout capture failed")]
     StdOutCaptureFail,
+
+    /// Failed to capture the profiled command's stderr.
+    #[error("Stderr capture failed")]
+    StdErrCaptureFail,
+
+    /// Failed to join the stderr tokio task handle.
+    #[error("Join error")]
+    StdErrHandleJoinError(
+        #[from]
+        #[source]
+        JoinError,
+    ),
 
     /// Failed to retrieve `SUDO_USER` environment variable.
     #[error(

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -13,6 +13,7 @@ use std::{
     io::{BufRead, BufReader, ErrorKind, Write},
     process::{self, Stdio},
 };
+use tokio::task::{JoinHandle, spawn_blocking};
 
 pub mod error;
 
@@ -204,6 +205,25 @@ impl JouleProfiler {
             .take()
             .ok_or(JouleProfilerError::StdOutCaptureFail)?;
 
+        let child_stderr = child
+            .stderr
+            .take()
+            .ok_or(JouleProfilerError::StdErrCaptureFail)?;
+
+        let err_handle: JoinHandle<Result<()>> = spawn_blocking(move || {
+            let reader = BufReader::new(child_stderr);
+
+            let mut stderr = BufWriter::new(std::io::stderr().lock());
+
+            for line in reader.lines() {
+                writeln!(stderr, "{}", line?)?;
+            }
+
+            stderr.flush()?;
+
+            Ok(())
+        });
+
         let reader = BufReader::new(child_stdout);
         let mut detected_phases = Vec::with_capacity(2);
 
@@ -223,6 +243,8 @@ impl JouleProfiler {
             &mut sink,
         )
         .await?;
+
+        err_handle.await??;
 
         sink.flush()?;
 
@@ -284,8 +306,6 @@ impl JouleProfiler {
                     line.pop();
                 }
             }
-
-            trace!("STDOUT[{line_number}]: {line}");
 
             writeln!(sink, "{line}")?;
 
@@ -360,7 +380,7 @@ pub fn init_command(cmd: &[String], use_root: bool) -> Result<Command> {
     }
 
     command.stdout(Stdio::piped());
-    command.stderr(Stdio::inherit());
+    command.stderr(Stdio::piped());
 
     Ok(command)
 }


### PR DESCRIPTION
## Description

This pull request fixes the crash of Joule Profiler when the profiled program is using non-blocking I/O in stderr.
The problem was that Joule Profiler was inheriting the child's stderr and Rust stdlib is not made for non-blocking I/O by default.
Now, Joule Profiler will pipe the stderr and read it with blocking I/O and print it with a BufReader.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Documentation
* [ ] Other (please specify):

## Related Issues

The issue related is #24.

## Changes Made

* Piped stderr instead of inheriting it.
* Print child stderr in Joule Profiler stderr with BufReader in a separate tokio task

## Checklist

* [x] My code follows the project style
* [x] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass