### PR TITLE
feat(cli): removed per-source cli option and replaced it with comma-s…

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use joule_profiler_cli::{
-    CliArgs, ProfilerCommand, RaplBackend, init_logging, output_format_to_displayer,
+    CliArgs, ProfilerCommand, RaplBackend, Source, init_logging, output_format_to_displayer,
     parse_sockets_spec,
 };
 use joule_profiler_core::JouleProfiler;
@@ -25,28 +25,30 @@ async fn main() -> Result<()> {
         ProfilerCommand::ListSensors => None,
     };
 
-    match cli.rapl_backend {
-        RaplBackend::Perf => {
-            if let Err(err) = perf::Rapl::check_perf_access() {
-                warn!("Cannot initialize RAPL with perf_event, switching to powercap: {err}");
+    if cli.sources.contains(&Source::Rapl) {
+        match cli.rapl_backend {
+            RaplBackend::Perf => {
+                if let Err(err) = perf::Rapl::check_perf_access() {
+                    warn!("Cannot initialize RAPL with perf_event, switching to powercap: {err}");
+                    let rapl_powercap =
+                        powercap::Rapl::new(rapl_path, rapl_sockets_spec.as_ref(), rapl_polling)?;
+                    profiler.add_source(rapl_powercap);
+                } else {
+                    trace!("Using perf_event for RAPL profiling");
+                    let perf_rapl = perf::Rapl::new(rapl_sockets_spec.as_ref())?;
+                    profiler.add_source(perf_rapl);
+                }
+            }
+            RaplBackend::Powercap => {
+                trace!("Using Powercap for RAPL profiling");
                 let rapl_powercap =
                     powercap::Rapl::new(rapl_path, rapl_sockets_spec.as_ref(), rapl_polling)?;
                 profiler.add_source(rapl_powercap);
-            } else {
-                trace!("Using perf_event for RAPL profiling");
-                let perf_rapl = perf::Rapl::new(rapl_sockets_spec.as_ref())?;
-                profiler.add_source(perf_rapl);
             }
-        }
-        RaplBackend::Powercap => {
-            trace!("Using Powercap for RAPL profiling");
-            let rapl_powercap =
-                powercap::Rapl::new(rapl_path, rapl_sockets_spec.as_ref(), rapl_polling)?;
-            profiler.add_source(rapl_powercap);
         }
     }
 
-    if cli.gpu {
+    if cli.sources.contains(&Source::Nvml) {
         match Nvml::new() {
             Ok(nvml) => {
                 trace!("Using NVML for Nvidia GPU profiling");
@@ -56,7 +58,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    if cli.perf {
+    if cli.sources.contains(&Source::Perf) {
         trace!("Initializing perf_event source");
         let perf_event = PerfEvent::new()?;
         profiler.add_source(perf_event);

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -13,6 +13,8 @@ use log::{trace, warn};
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = CliArgs::from_args();
+    cli.validate()?;
+
     init_logging(cli.verbose);
 
     let mut displayer = output_format_to_displayer(&cli)?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use clap::{ArgAction, Parser, ValueEnum};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 pub use commands::ProfilerCommand;
 use joule_profiler_core::config::{Command, Config, ProfileConfig};
 
@@ -74,6 +74,18 @@ impl CliArgs {
     pub fn from_args() -> Self {
         Self::parse()
     }
+
+    pub fn validate(&self) -> Result<()> {
+        let mut seen = HashSet::new();
+
+        for source in &self.sources {
+            if !seen.insert(source) {
+                bail!("Duplicate source specified: {source}");
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl From<CliArgs> for Config {
@@ -102,6 +114,17 @@ pub enum Source {
     Nvml,
     #[value(alias = "perf_event")]
     Perf,
+}
+
+impl std::fmt::Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Source::Rapl => "rapl",
+            Source::Nvml => "nvml",
+            Source::Perf => "perf | perf_event",
+        };
+        write!(f, "{s}")
+    }
 }
 
 #[derive(Clone, Debug, ValueEnum)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -41,7 +41,7 @@ pub struct CliArgs {
     #[arg(long = "rapl-path")]
     pub rapl_path: Option<String>,
 
-    /// Sockets to measure (e.g. 0 or 0,1)
+    /// Sockets to measure (e.g., 0 or 0,1)
     #[arg(short = 's', long = "sockets")]
     pub sockets: Option<String>,
 
@@ -57,17 +57,13 @@ pub struct CliArgs {
     #[arg(short = 'o', long = "output-file")]
     pub output_file: Option<String>,
 
-    /// GPU support
-    #[arg(long)]
-    pub gpu: bool,
-
-    /// `perf_event` counters support
-    #[arg(long)]
-    pub perf: bool,
-
     /// Choose RAPL backend between powercap or perf
     #[arg(long = "rapl-backend", value_enum, default_value_t = RaplBackend::Perf)]
     pub rapl_backend: RaplBackend,
+
+    /// Sources activation list. All sources must be separated with a comma (e.g., "perf,nvml").
+    #[arg(long, value_delimiter = ',', default_value = "rapl")]
+    pub sources: Vec<Source>,
 
     /// The command to execute
     #[command(subcommand)]
@@ -98,6 +94,14 @@ impl From<CliArgs> for Config {
             rapl_path: cli_args.rapl_path,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, ValueEnum)]
+pub enum Source {
+    Rapl,
+    Nvml,
+    #[value(alias = "perf_event")]
+    Perf,
 }
 
 #[derive(Clone, Debug, ValueEnum)]


### PR DESCRIPTION
…eparated list

## Description

This pull request replace all per-source CLI options like --perf or --gpu by a comma separated list in the --sources CLI option.

It enables to activate sources more easily.

Example:
```
joule-profiler --sources rapl,perf,nvml ...
```

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Improvement
* [ ] Documentation
* [ ] Other (please specify):

## Related Issues

The related issue is #26.

## Changes Made

* Remove former per-source CLI options like --perf or --gpu
* Added comma-separated list to activate the sources. (e.g., "--sources rapl,perf,nvml")

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass

## Additional Notes

By default, rapl is activated but it is disabled if it is not mentionned in the sources list, when provided.
