### PR TITLE
Feat/23 cgroup source

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ joule-profiler-source-rapl = { path = "../sources/rapl", version = "1.0.2" }
 joule-profiler-source-nvml = { path = "../sources/nvml", version = "1.0.2" }
 joule-profiler-source-perf_event = { path = "../sources/perf_event", version = "1.0.2" }
 joule-profiler-source-procfs = { path = "../sources/procfs", version = "0.1.0" }
+joule-profiler-source-cgroup = { path = "../sources/cgroup", version = "0.1.0" }
 
 joule-profiler-core.workspace = true
 log.workspace = true

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
         let procfs = Procfs::new(ProcfsConfig::default())?;
         profiler.add_source(procfs);
     }
-    
+
     if cli.sources.contains(&Source::Cgroup) {
         trace!("Initializing CGroup v2 source");
         let cgroup = CgroupSource::new(CgroupConfig {

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use joule_profiler_cli::{
     CliArgs, ProfilerCommand, RaplBackend, Source, init_logging, output_format_to_displayer,
@@ -5,13 +7,13 @@ use joule_profiler_cli::{
 };
 use joule_profiler_core::JouleProfiler;
 use joule_profiler_core::config::{Command, Config};
+use joule_profiler_source_cgroup::{CgroupConfig, CgroupSource};
 use joule_profiler_source_nvml::Nvml;
 use joule_profiler_source_perf_event::PerfEvent;
 use joule_profiler_source_procfs::Procfs;
 use joule_profiler_source_procfs::config::ProcfsConfig;
 use joule_profiler_source_rapl::{perf, powercap};
 use log::{trace, warn};
-use joule_profiler_source_cgroup::{CgroupConfig, CgroupSource};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -77,7 +79,10 @@ async fn main() -> Result<()> {
     
     if cli.sources.contains(&Source::Cgroup) {
         trace!("Initializing CGroup v2 source");
-        let cgroup = CgroupSource::new(CgroupConfig::default())?;
+        let cgroup = CgroupSource::new(CgroupConfig {
+            poll_interval: Some(Duration::from_millis(1)),
+            ..Default::default()
+        })?;
         profiler.add_source(cgroup);
     }
 

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::Result;
 use joule_profiler_cli::{
     CliArgs, ProfilerCommand, RaplBackend, Source, init_logging, output_format_to_displayer,
@@ -79,10 +77,7 @@ async fn main() -> Result<()> {
 
     if cli.sources.contains(&Source::Cgroup) {
         trace!("Initializing CGroup v2 source");
-        let cgroup = CgroupSource::new(CgroupConfig {
-            poll_interval: Some(Duration::from_millis(1)),
-            ..Default::default()
-        })?;
+        let cgroup = CgroupSource::new(CgroupConfig::default())?;
         profiler.add_source(cgroup);
     }
 

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -11,6 +11,7 @@ use joule_profiler_source_procfs::Procfs;
 use joule_profiler_source_procfs::config::ProcfsConfig;
 use joule_profiler_source_rapl::{perf, powercap};
 use log::{trace, warn};
+use joule_profiler_source_cgroup::{CgroupConfig, CgroupSource};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -72,6 +73,12 @@ async fn main() -> Result<()> {
         trace!("Initializing procfs source");
         let procfs = Procfs::new(ProcfsConfig::default())?;
         profiler.add_source(procfs);
+    }
+    
+    if cli.sources.contains(&Source::Cgroup) {
+        trace!("Initializing CGroup v2 source");
+        let cgroup = CgroupSource::new(CgroupConfig::default())?;
+        profiler.add_source(cgroup);
     }
 
     let config = Config::try_from(cli)?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -123,6 +123,7 @@ pub enum Source {
     #[value(alias = "perf_event")]
     Perf,
     Procfs,
+    Cgroup,
 }
 
 impl std::fmt::Display for Source {
@@ -132,6 +133,7 @@ impl std::fmt::Display for Source {
             Source::Nvml => "nvml",
             Source::Perf => "perf | perf_event",
             Source::Procfs => "procfs",
+            Source::Cgroup => "cgroup",
         };
         write!(f, "{s}")
     }

--- a/core/src/aggregate/metric.rs
+++ b/core/src/aggregate/metric.rs
@@ -74,19 +74,15 @@ impl From<f64> for MetricValue {
     }
 }
 
-impl From<(f64, u8)> for MetricValue {
-    fn from((v, dec): (f64, u8)) -> Self {
-        Self::Float(v, Some(dec))
-    }
-}
-
 impl Display for MetricValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::UnsignedInteger(v) => v.fmt(f),
             Self::SignedInteger(v) => v.fmt(f),
             Self::Float(v, None) => v.fmt(f),
-            Self::Float(v, Some(decimal)) => write!(f, "{:.prec$}", v, prec = *decimal as usize),
+            Self::Float(v, Some(precision)) => {
+                write!(f, "{:.prec$}", v, prec = *precision as usize)
+            }
         }
     }
 }
@@ -99,11 +95,7 @@ impl Serialize for MetricValue {
         match self {
             MetricValue::UnsignedInteger(v) => serializer.serialize_u64(*v),
             MetricValue::SignedInteger(v) => serializer.serialize_i64(*v),
-            MetricValue::Float(v, None) => serializer.serialize_f64(*v),
-            MetricValue::Float(v, Some(dec)) => {
-                let factor = 10f64.powi(i32::from(*dec));
-                serializer.serialize_f64((v * factor).round() / factor)
-            }
+            MetricValue::Float(v, _) => serializer.serialize_f64(*v),
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod sensor;
 
 mod util;
 pub use util::fs;
+pub use util::time;
 
 pub mod source;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,8 +6,7 @@ mod profiler;
 pub mod sensor;
 
 mod util;
-pub use util::fs;
-pub use util::time;
+pub use util::{fs, sys, time};
 
 pub mod source;
 

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -23,7 +23,7 @@ use crate::profiler::types::{MeasurePhasesReturnType, Phase, ProfilerResults, Re
 use crate::sensor::{Sensor, Sensors};
 use crate::source::{MetricReader, MetricSource, MetricSourceError};
 use crate::util::fs::create_file_with_user_permissions;
-use crate::util::sys::{get_uid_from_username, geteuid, signal};
+use crate::util::sys::{get_uid_from_username, is_root, signal};
 use crate::util::time::get_timestamp_micros;
 pub use error::JouleProfilerError;
 
@@ -361,7 +361,7 @@ pub fn init_command(cmd: &[String], use_root: bool) -> Result<Command> {
         command.args(&cmd[1..]);
     }
 
-    if geteuid() == 0 && !use_root {
+    if is_root() && !use_root {
         let username =
             std::env::var("SUDO_USER").map_err(|_| JouleProfilerError::CannotRetrieveSudoUser)?;
         let uid = get_uid_from_username(&username)?;

--- a/core/src/source/types.rs
+++ b/core/src/source/types.rs
@@ -7,8 +7,7 @@ use std::fmt::Debug;
 /// Trait for types returned by a [`MetricReader`](`super::MetricReader`).
 ///
 /// Any type implementing this trait represents the result of a metric measurement.
-/// It must implement `Debug` for logging and debugging, `Send` to be safely
-/// transferred across threads, and `Default` for easy initialization.
+/// It must implement `Send` to be safely.
 pub trait MetricReaderTypeBound: Send {}
 
 impl<T> MetricReaderTypeBound for T where T: Send {}

--- a/core/src/source/types.rs
+++ b/core/src/source/types.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 /// Trait for types returned by a [`MetricReader`](`super::MetricReader`).
 ///
 /// Any type implementing this trait represents the result of a metric measurement.
-/// It must implement `Send` to be safely.
+/// It must implement `Send` to be safely transferred across threads.
 pub trait MetricReaderTypeBound: Send {}
 
 impl<T> MetricReaderTypeBound for T where T: Send {}

--- a/core/src/util/sys.rs
+++ b/core/src/util/sys.rs
@@ -47,6 +47,11 @@ pub fn geteuid() -> u32 {
     unsafe { libc::geteuid() }
 }
 
+/// True if the current user is root, else False.
+pub fn is_root() -> bool {
+    geteuid() == 0
+}
+
 /// Gets the current process' user id from its username.
 ///
 /// SAFETY

--- a/sources/cgroup/Cargo.toml
+++ b/sources/cgroup/Cargo.toml
@@ -17,6 +17,10 @@ log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-timerfd = "0.2.0"
+tokio-util = "0.7.18"
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/sources/cgroup/Cargo.toml
+++ b/sources/cgroup/Cargo.toml
@@ -12,9 +12,11 @@ readme = "README.md"
 
 [dependencies]
 joule-profiler-core.workspace = true
+futures.workspace = true
 log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-timerfd = "0.2.0"
 
 [lints]
 workspace = true

--- a/sources/cgroup/Cargo.toml
+++ b/sources/cgroup/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "joule-profiler-source-cgroup"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CGroup v2 metrics source for joule-profiler"
+keywords = ["cgroup", "memory", "profiling", "linux", "process"]
+readme = "README.md"
+
+
+[dependencies]
+joule-profiler-core.workspace = true
+log.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/sources/cgroup/README.md
+++ b/sources/cgroup/README.md
@@ -1,0 +1,6 @@
+# joule-profiler-sources-cgroup
+
+CGroup v2 metric source for [joule-profiler](https://github.com/joule-profiler/joule-profiler).
+
+Places the profiled process (and **all its children**) into a dedicated cgroup and
+samples memory, CPU and I/O.

--- a/sources/cgroup/README.md
+++ b/sources/cgroup/README.md
@@ -45,8 +45,8 @@ Here is the list of the metrics implemented.
 
 | Metric | Description |
 | - | - |
-| `rbytes` | Total number of bytes read by the cgroup |
-| `wbytes` | Total number of bytes written by the cgroup |
+| `read_bytes` | Total number of bytes read by the cgroup |
+| `write_bytes` | Total number of bytes written by the cgroup |
 
 ## Requirements
 

--- a/sources/cgroup/README.md
+++ b/sources/cgroup/README.md
@@ -1,6 +1,56 @@
-# joule-profiler-sources-cgroup
+# Cgroup metric source
 
-CGroup v2 metric source for [joule-profiler](https://github.com/joule-profiler/joule-profiler).
+Cgroup v2 metric source for [joule-profiler](https://github.com/joule-profiler/joule-profiler).
 
-Places the profiled process (and **all its children**) into a dedicated cgroup and
-samples memory, CPU and I/O.
+This crate implements a `MetricReader` from `joule-profiler-core` and collects **process-level** and **system-wide** metrics using Linux **cgroup v2** interfaces.
+
+Control groups (cgroups v2) are a Linux kernel feature that allows grouping processes and tracking/limiting their resource usage.
+This source uses cgroup files exposed under `/sys/fs/cgroup`.
+
+## Implemented metrics
+
+All metrics are reported for both the process cgroup and the root cgroup, thus they are prefixed with a `proc` or a `global`.
+
+Here is the list of the metrics implemented.
+
+### CPU
+
+| Metric | Description |
+| - | - |
+| `usage_usec` | Total CPU time consumed (user + kernel) |
+| `user_usec` | CPU time spent in user space |
+| `system_usec` | CPU time spent in kernel space |
+| `nr_periods` | Number of scheduling periods |
+| `nr_throttled` | Number of CPU throttling events |
+| `throttled_usec` | Total time spent throttled |
+| `nr_bursts` | Number of burst events (burstable cgroups) |
+| `burst_usec` | Total time spent in burst mode |
+| `cpu_usage` | CPU usage in percentage |
+
+### Memory
+
+| Metric | Description |
+| - | - |
+| `current` | Total current memory usage of the cgroup |
+| `swap_current` | Current swap usage |
+| `anon` | Anonymous memory (heap, stack, anonymous mmap) |
+| `file` | File-backed memory (page cache) |
+| `peak` | Peak memory usage observed for the cgroup |
+| `shmem` | Shared memory usage (tmpfs, /dev/shm) |
+| `kernel` | Kernel memory used by the cgroup |
+| `kernel_stack` | Kernel stack memory usage |
+| `slab` | Slab allocator memory usage |
+
+### I/O
+
+| Metric | Description |
+| - | - |
+| `rbytes` | Total number of bytes read by the cgroup |
+| `wbytes` | Total number of bytes written by the cgroup |
+
+## Requirements
+
+| Requirement | Version |
+| - | - |
+| Linux kernel | cgroup v2 enabled (Linux 4.5) |
+| Permissions | write access to cgroup filesystem (usually root privileges) |

--- a/sources/cgroup/README.md
+++ b/sources/cgroup/README.md
@@ -7,6 +7,41 @@ This crate implements a `MetricReader` from `joule-profiler-core` and collects *
 Control groups (cgroups v2) are a Linux kernel feature that allows grouping processes and tracking/limiting their resource usage.
 This source uses cgroup files exposed under `/sys/fs/cgroup`.
 
+## Setup
+
+Before using this source, the required cgroup controllers `cpu`, `memory`, `io` must be enabled on the cgroup hierarchy. This source does **not** enables them automatically, it is your responsibility to ensure controllers are active.
+
+To enable them on the root cgroup:
+
+```bash
+echo "+cpu +memory +io" | sudo tee /sys/fs/cgroup/cgroup.subtree_control
+```
+
+To verify which controllers are currently enabled:
+
+```bash
+cat /sys/fs/cgroup/cgroup.subtree_control
+```
+
+To enable the required controllers for the root cgroup:
+
+```bash
+echo "+cpu +memory +io" | sudo tee /sys/fs/cgroup/cgroup.subtree_control
+```
+
+If you are using a nested cgroup, each ancestor must propagate the controllers down. For example, if your cgroup lives under `/sys/fs/cgroup/nested_cgroup/mycgroup`:
+
+```bash
+echo "+cpu +memory +io" | sudo tee /sys/fs/cgroup/cgroup.subtree_control
+echo "+cpu +memory +io" | sudo tee /sys/fs/cgroup/nested_cgroup/cgroup.subtree_control
+```
+
+> [!IMPORTANT]
+> By default, a nested cgroup inherit its parent controllers files. Nonetheless, the parent of the nested cgroup must enable the controllers.
+
+> [!NOTE]
+> On systemd-based systems, some controllers may already be enabled. Check `/sys/fs/cgroup/cgroup.subtree_control` first.
+
 ## Implemented metrics
 
 All metrics are reported for both the process cgroup and the root cgroup, thus they are prefixed with a `proc` or a `global`.

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -1,0 +1,170 @@
+use std::{fmt::Display, fs, path::PathBuf};
+
+use log::{debug, warn};
+
+use crate::{
+    Result,
+    error::CgroupError::{self},
+    snapshot::{CpuSnapshot, IoSnapshot, MemorySnapshot},
+    util::{read_flat_keyed_file, read_io_stat, read_u64, read_u64_opt},
+};
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Controller {
+    Io,
+    Mem,
+    Cpu,
+}
+
+impl Display for Controller {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Controller::Io => "io",
+            Controller::Mem => "memory",
+            Controller::Cpu => "cpu",
+        })
+    }
+}
+
+pub struct Cgroup {
+    cgroup_root: PathBuf,
+    cgroup_path: PathBuf,
+}
+
+impl Cgroup {
+    pub fn new(cgroup_root: PathBuf, cgroup_name: &str) -> Result<Self> {
+        let cgroup_path = cgroup_root.join(cgroup_name);
+        if cgroup_path.exists() {
+            return Err(CgroupError::AlreadyCreated(cgroup_name.to_owned()));
+        }
+
+        Ok(Self {
+            cgroup_root,
+            cgroup_path,
+        })
+    }
+
+    pub fn initialize_cgroup(&self) -> Result<()> {
+        debug!("Creating cgroup at \"{}\"", self.cgroup_path.display());
+        fs::create_dir_all(&self.cgroup_path)?;
+        Ok(())
+    }
+
+    pub fn activate_controller(&self, controller: Controller) -> Result<()> {
+        let subtree_control_path = self.cgroup_root.join("cgroup.subtree_control");
+        fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
+            CgroupError::FailedToCreateController {
+                controller,
+                path: subtree_control_path,
+                source: err,
+            }
+        })?;
+        Ok(())
+    }
+
+    pub fn attach_pid(&self, pid: i32) -> Result<()> {
+        let procs_path = self.cgroup_path.join("cgroup.procs");
+        fs::write(&procs_path, pid.to_string()).map_err(|err| CgroupError::FailedToAttachPid {
+            pid,
+            path: procs_path,
+            source: err,
+        })?;
+        debug!(
+            "Attached PID {pid} to cgroup {}",
+            self.cgroup_path.display()
+        );
+        Ok(())
+    }
+
+    pub fn read_memory(&self) -> Result<MemorySnapshot> {
+        let mut memory_stat = read_flat_keyed_file(&self.cgroup_path.join("memory.stat"))?;
+        let current = read_u64(&self.cgroup_path.join("memory.current"))?;
+        let swap_current = read_u64_opt(&self.cgroup_path.join("memory.swap.current"))?;
+        let peak = read_u64_opt(&self.cgroup_path.join("memory.peak"))?;
+
+        let anon = memory_stat.remove("anon");
+        let file = memory_stat.remove("file");
+        let shmem = memory_stat.remove("shmem");
+        let kernel = memory_stat.remove("kernel");
+        let kernel_stack = memory_stat.remove("kernel_stack");
+        let slab = memory_stat.remove("slab");
+
+        Ok(MemorySnapshot {
+            current,
+            swap_current,
+            anon,
+            file,
+            peak,
+            shmem,
+            kernel,
+            kernel_stack,
+            slab,
+        })
+    }
+
+    pub fn read_io(&self) -> Result<IoSnapshot> {
+        let (rbytes, wbytes) = read_io_stat(&self.cgroup_path.join("io.stat"))?;
+        Ok(IoSnapshot { rbytes, wbytes })
+    }
+
+    pub fn read_cpu(&self) -> Result<CpuSnapshot> {
+        let mut cpu_stat = read_flat_keyed_file(&self.cgroup_path.join("cpu.stat"))?;
+
+        let usage_usec = cpu_stat
+            .remove("usage_usec")
+            .ok_or(CgroupError::MissingAlwaysPresentMetric("usage_usec"))?;
+        let user_usec = cpu_stat
+            .remove("user_usec")
+            .ok_or(CgroupError::MissingAlwaysPresentMetric("user_usec"))?;
+        let system_usec = cpu_stat
+            .remove("system_usec")
+            .ok_or(CgroupError::MissingAlwaysPresentMetric("system_usec"))?;
+
+        let nr_periods = cpu_stat.remove("nr_periods");
+        let nr_throttled = cpu_stat.remove("nr_throttled");
+        let throttled_usec = cpu_stat.remove("throttled_usec");
+        let nr_bursts = cpu_stat.remove("nr_bursts");
+        let burst_usec = cpu_stat.remove("burst_usec");
+
+        Ok(CpuSnapshot {
+            usage_usec,
+            user_usec,
+            system_usec,
+            nr_periods,
+            nr_throttled,
+            throttled_usec,
+            nr_bursts,
+            burst_usec,
+        })
+    }
+
+    fn get_pids(&self) -> Result<Vec<i32>> {
+        let path = self.cgroup_path.join("cgroup.procs");
+        let content = fs::read_to_string(&path)?;
+        let pids = content
+            .lines()
+            .filter_map(|l| l.trim().parse::<i32>().ok())
+            .collect();
+        Ok(pids)
+    }
+
+    pub fn cleanup(&self) -> Result<()> {
+        let root_procs = self.cgroup_path.join("cgroup.procs");
+        for pid in self.get_pids()? {
+            if let Err(e) = fs::write(&root_procs, pid.to_string()) {
+                warn!("Could not move PID {pid} back to root cgroup: {e}");
+            }
+        }
+        if self.cgroup_path.exists() {
+            if let Err(e) = fs::remove_dir(&self.cgroup_path) {
+                warn!(
+                    "Could not remove cgroup {} (may still have live tasks): {e}",
+                    self.cgroup_path.display()
+                );
+            } else {
+                debug!("Removed cgroup {}", self.cgroup_path.display());
+            }
+        }
+        Ok(())
+    }
+}

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -6,7 +6,12 @@
 //! - process attachment to cgroups;
 //! - CPU, memory, and I/O statistics collection.
 
-use std::{collections::HashSet, fmt::Display, fs, path::PathBuf};
+use std::{
+    collections::HashSet,
+    fmt::Display,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use log::{debug, warn};
 
@@ -43,117 +48,40 @@ impl Display for Controller {
 /// Interface for reading cgroup statistics.
 pub trait CgroupBackend: Send + Sync + 'static {
     /// Initializes the backend.
-    fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()>;
-
-    /// Returns memory statistics.
-    fn memory(&self) -> Result<MemorySnapshot>;
-
-    /// Returns CPU statistics.
-    fn cpu(&self) -> Result<CpuSnapshot>;
-
-    /// Returns I/O statistics.
-    fn io(&self) -> Result<IoSnapshot>;
+    fn initialize(
+        &self,
+        path: &Path,
+        root: &Path,
+        pid: i32,
+        controllers: &HashSet<Controller>,
+    ) -> Result<()>;
 
     /// Cleanup the backend.
-    fn cleanup(&self) -> Result<()>;
+    fn cleanup(&self, path: &Path, root: &Path) -> Result<()>;
+
+    /// Returns memory statistics.
+    fn memory(&self, path: &Path) -> Result<MemorySnapshot>;
+
+    /// Returns CPU statistics.
+    fn cpu(&self, path: &Path) -> Result<CpuSnapshot>;
+
+    /// Returns I/O statistics.
+    fn io(&self, path: &Path) -> Result<IoSnapshot>;
 }
 
-/// A cgroup node. If `parent` is `None`, this is the root cgroup.
-pub struct Cgroup<B: CgroupBackend = SysFsBackend> {
-    pub path: PathBuf,
-    parent: Option<PathBuf>,
-    backend: B,
-}
-
-impl Cgroup {
-    /// Gets the root cgroup in sys fs `/sys/fs/cgroup`.
-    pub fn root() -> Self {
-        let path = PathBuf::from("/sys/fs/cgroup");
-        Self::at(path)
-    }
-
-    /// Builds a cgroup handle based on the provided directory.
-    pub fn at(path: PathBuf) -> Self {
-        let backend = SysFsBackend {
-            path: path.clone(),
-            root: path.clone(),
-        };
-        Self {
-            path,
-            parent: None,
-            backend,
-        }
-    }
-
-    /// Gets a child handle of the current cgroup based on its name.
-    pub fn child(&self, name: &str) -> Cgroup {
-        let child_path = self.path.join(name);
-        Cgroup {
-            parent: Some(self.path.clone()),
-            backend: SysFsBackend {
-                root: self.path.clone(),
-                path: child_path.clone(),
-            },
-            path: child_path,
-        }
-    }
-}
-
-impl<B: CgroupBackend> Cgroup<B> {
-    pub fn new(path: PathBuf, parent: Option<PathBuf>, backend: B) -> Self {
-        Self {
-            path,
-            parent,
-            backend,
-        }
-    }
-
-    /// True if the cgroup is the root cgroup, else false.
-    pub fn is_root(&self) -> bool {
-        self.parent.is_none()
-    }
-
-    /// Return the backend for stats querying.
-    pub fn stats(&self) -> &B {
-        &self.backend
-    }
-
-    /// Initializes the cgroup backend.
-    pub fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()> {
-        self.backend.initialize(pid, controllers)
-    }
-
-    /// Cleanup the cgroup backend.
-    pub fn cleanup(&self) -> Result<()> {
-        self.backend.cleanup()
-    }
-}
-
-/// Cleans up the cgroup if not done already (cleanup not called or error).
-impl<B: CgroupBackend> Drop for Cgroup<B> {
-    fn drop(&mut self) {
-        if self.parent.is_some() && self.path.exists() {
-            let _ = self.backend.cleanup();
-        }
-    }
-}
-
-/// cgroup statistics accessor.
-pub struct SysFsBackend {
-    path: PathBuf,
-    root: PathBuf,
-}
+/// Cgroup sysfs backend.
+pub struct SysFsBackend;
 
 impl SysFsBackend {
     /// Enables a controller in `cgroup.subtree_control`.
     ///
     /// If the provided controller is already activated, then nothing happens.
-    pub fn activate_controller(&self, controller: Controller) -> Result<()> {
+    fn activate_controller(root_path: &Path, controller: Controller) -> Result<()> {
         debug!(
             "Activating controller for root cgroup `{}`.",
-            self.path.display()
+            root_path.display()
         );
-        let subtree_control_path = self.root.join("cgroup.subtree_control");
+        let subtree_control_path = root_path.join("cgroup.subtree_control");
         fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
             CgroupError::FailedToCreateController {
                 controller,
@@ -165,21 +93,21 @@ impl SysFsBackend {
     }
 
     /// Attaches a process PID to the cgroup.
-    pub fn attach_pid(&self, pid: i32) -> Result<()> {
-        let procs_path = self.path.join("cgroup.procs");
+    fn attach_pid(path: &Path, pid: i32) -> Result<()> {
+        let procs_path = path.join("cgroup.procs");
         fs::write(&procs_path, pid.to_string()).map_err(|err| CgroupError::FailedToAttachPid {
             pid,
             path: procs_path,
             source: err,
         })?;
-        debug!("Attached PID {pid} to cgroup {}", self.path.display());
+        debug!("Attached PID {pid} to cgroup {}", path.display());
         Ok(())
     }
 
     /// Returns all PIDs attached to the cgroup.
-    fn pids(&self) -> Result<Vec<i32>> {
-        debug!("Retrieving cgroup `{}` PIDs.", self.path.display());
-        let path = self.path.join("cgroup.procs");
+    fn pids(path: &Path) -> Result<Vec<i32>> {
+        debug!("Retrieving cgroup `{}` PIDs.", path.display());
+        let path = path.join("cgroup.procs");
         let content = fs::read_to_string(&path)?;
         Ok(content
             .lines()
@@ -190,101 +118,191 @@ impl SysFsBackend {
 
 impl CgroupBackend for SysFsBackend {
     /// Creates the cgroup directory on disk.
-    fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()> {
-        debug!("Initializing cgroup at \"{}\"", self.path.display());
+    fn initialize(
+        &self,
+        path: &Path,
+        root: &Path,
+        pid: i32,
+        controllers: &HashSet<Controller>,
+    ) -> Result<()> {
+        debug!("Initializing cgroup at \"{}\"", path.display());
 
-        fs::create_dir_all(&self.path)?;
+        fs::create_dir_all(path)?;
 
         for controller in controllers {
-            self.activate_controller(*controller)?;
+            Self::activate_controller(root, *controller)?;
         }
 
-        self.attach_pid(pid)?;
+        Self::attach_pid(path, pid)?;
 
         Ok(())
     }
 
     /// Moves processes back to the root cgroup and removes the directory.
-    fn cleanup(&self) -> Result<()> {
-        debug!("Cleaning cgroup `{}`.", self.path.display());
+    fn cleanup(&self, path: &Path, root: &Path) -> Result<()> {
+        debug!("Cleaning cgroup `{}`.", path.display());
 
-        let root_procs = self.root.join("cgroup.procs");
-        for pid in self.pids()? {
+        let root_procs = root.join("cgroup.procs");
+        for pid in Self::pids(path)? {
             if let Err(e) = fs::write(&root_procs, pid.to_string()) {
                 warn!("Could not move PID {pid} back to root cgroup: {e}");
             }
         }
-        if self.path.exists() {
-            if let Err(e) = fs::remove_dir(&self.path) {
+        if path.exists() {
+            if let Err(e) = fs::remove_dir(path) {
                 warn!(
                     "Could not remove cgroup {} (may still have live tasks): {e}",
-                    self.path.display()
+                    path.display()
                 );
             } else {
-                debug!("Removed cgroup {}", self.path.display());
+                debug!("Removed cgroup {}", path.display());
             }
         }
         Ok(())
     }
 
     /// Reads memory statistics from cgroup memory files.
-    fn memory(&self) -> Result<MemorySnapshot> {
-        debug!(
-            "Reading memory metrics for cgroup `{}`.",
-            self.path.display()
-        );
-
-        let mut memory_stat = read_flat_keyed_file(&self.path.join("memory.stat"))?;
-        let current = read_u64_opt(&self.path.join("memory.current"))?;
-        let swap_current = read_u64_opt(&self.path.join("memory.swap.current"))?;
-        let peak = read_u64_opt(&self.path.join("memory.peak"))?;
-
+    fn memory(&self, path: &Path) -> Result<MemorySnapshot> {
+        let mut stat = read_flat_keyed_file(&path.join("memory.stat"))?;
         Ok(MemorySnapshot {
-            current,
-            swap_current,
-            peak,
-            anon: memory_stat.remove("anon"),
-            file: memory_stat.remove("file"),
-            shmem: memory_stat.remove("shmem"),
-            kernel: memory_stat.remove("kernel"),
-            kernel_stack: memory_stat.remove("kernel_stack"),
-            slab: memory_stat.remove("slab"),
+            current: read_u64_opt(&path.join("memory.current"))?,
+            swap_current: read_u64_opt(&path.join("memory.swap.current"))?,
+            peak: read_u64_opt(&path.join("memory.peak"))?,
+            anon: stat.remove("anon"),
+            file: stat.remove("file"),
+            shmem: stat.remove("shmem"),
+            kernel: stat.remove("kernel"),
+            kernel_stack: stat.remove("kernel_stack"),
+            slab: stat.remove("slab"),
+        })
+    }
+
+    /// Reads CPU statistics from `cpu.stat`.
+    fn cpu(&self, path: &Path) -> Result<CpuSnapshot> {
+        let mut stat = read_flat_keyed_file(&path.join("cpu.stat"))?;
+
+        Ok(CpuSnapshot {
+            usage_usec: stat
+                .remove("usage_usec")
+                .ok_or(CgroupError::MissingAlwaysPresentMetric("usage_usec"))?,
+            user_usec: stat
+                .remove("user_usec")
+                .ok_or(CgroupError::MissingAlwaysPresentMetric("user_usec"))?,
+            system_usec: stat
+                .remove("system_usec")
+                .ok_or(CgroupError::MissingAlwaysPresentMetric("system_usec"))?,
+            nr_periods: stat.remove("nr_periods"),
+            nr_throttled: stat.remove("nr_throttled"),
+            throttled_usec: stat.remove("throttled_usec"),
+            nr_bursts: stat.remove("nr_bursts"),
+            burst_usec: stat.remove("burst_usec"),
         })
     }
 
     /// Reads I/O statistics from `io.stat`.
-    fn io(&self) -> Result<IoSnapshot> {
-        debug!("Reading I/O metrics for cgroup `{}`.", self.path.display());
-        let (rbytes, wbytes) = read_io_stat(&self.path.join("io.stat"))?;
+    fn io(&self, path: &Path) -> Result<IoSnapshot> {
+        let (rbytes, wbytes) = read_io_stat(&path.join("io.stat"))?;
         Ok(IoSnapshot { rbytes, wbytes })
     }
+}
 
-    /// Reads CPU statistics from `cpu.stat`.
-    fn cpu(&self) -> Result<CpuSnapshot> {
-        debug!("Reading cpu metrics for cgroup `{}`.", self.path.display());
+/// Structure representing the root cgroup.
+pub struct RootCgroup<B: CgroupBackend = SysFsBackend> {
+    /// The path to the cgroup.
+    path: PathBuf,
 
-        let mut cpu_stat = read_flat_keyed_file(&self.path.join("cpu.stat"))?;
+    /// The backend to use to query cgroup interface (used mainly for testing).
+    backend: B,
+}
 
-        let usage_usec = cpu_stat
-            .remove("usage_usec")
-            .ok_or(CgroupError::MissingAlwaysPresentMetric("usage_usec"))?;
-        let user_usec = cpu_stat
-            .remove("user_usec")
-            .ok_or(CgroupError::MissingAlwaysPresentMetric("user_usec"))?;
-        let system_usec = cpu_stat
-            .remove("system_usec")
-            .ok_or(CgroupError::MissingAlwaysPresentMetric("system_usec"))?;
+impl RootCgroup {
+    /// Builds a cgroup handle based on the provided directory.
+    pub fn at(path: PathBuf) -> Self {
+        Self {
+            path,
+            backend: SysFsBackend,
+        }
+    }
 
-        Ok(CpuSnapshot {
-            usage_usec,
-            user_usec,
-            system_usec,
-            nr_periods: cpu_stat.remove("nr_periods"),
-            nr_throttled: cpu_stat.remove("nr_throttled"),
-            throttled_usec: cpu_stat.remove("throttled_usec"),
-            nr_bursts: cpu_stat.remove("nr_bursts"),
-            burst_usec: cpu_stat.remove("burst_usec"),
-        })
+    /// Gets a child handle of the current cgroup based on its name.
+    pub fn child(&self, name: &str) -> ChildCgroup {
+        let child_path = self.path.join(name);
+        ChildCgroup::new(child_path.clone(), self.path.clone(), SysFsBackend)
+    }
+}
+
+impl<B: CgroupBackend> RootCgroup<B> {
+    pub fn new(path: PathBuf, backend: B) -> Self {
+        Self { path, backend }
+    }
+
+    /// Get memory stats.
+    pub fn memory(&self) -> Result<MemorySnapshot> {
+        self.backend.memory(&self.path)
+    }
+
+    /// Get CPU stats.
+    pub fn cpu(&self) -> Result<CpuSnapshot> {
+        self.backend.cpu(&self.path)
+    }
+
+    /// Get I/O stats.
+    pub fn io(&self) -> Result<IoSnapshot> {
+        self.backend.io(&self.path)
+    }
+}
+
+impl Default for RootCgroup {
+    fn default() -> Self {
+        Self::at(PathBuf::from("/sys/fs/cgroup"))
+    }
+}
+
+/// Structure representing a child cgroup.
+pub struct ChildCgroup<B: CgroupBackend = SysFsBackend> {
+    /// The path to the cgroup.
+    path: PathBuf,
+
+    /// The path to the root cgroup.
+    root: PathBuf,
+
+    /// The backend to use to query cgroup interface (used mainly for testing).
+    backend: B,
+}
+
+impl<B: CgroupBackend> ChildCgroup<B> {
+    pub fn new(path: PathBuf, root: PathBuf, backend: B) -> Self {
+        Self {
+            path,
+            root,
+            backend,
+        }
+    }
+
+    /// Get memory stats.
+    pub fn memory(&self) -> Result<MemorySnapshot> {
+        self.backend.memory(&self.path)
+    }
+
+    /// Get CPU stats.
+    pub fn cpu(&self) -> Result<CpuSnapshot> {
+        self.backend.cpu(&self.path)
+    }
+
+    /// Get I/O stats.
+    pub fn io(&self) -> Result<IoSnapshot> {
+        self.backend.io(&self.path)
+    }
+
+    /// Initializes the cgroup backend.
+    pub fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()> {
+        self.backend
+            .initialize(&self.path, &self.root, pid, controllers)
+    }
+
+    /// Cleanup the cgroup backend.
+    pub fn cleanup(&self) -> Result<()> {
+        self.backend.cleanup(&self.path, &self.root)
     }
 }
 
@@ -300,32 +318,38 @@ mod tests {
     }
 
     impl CgroupBackend for MockCgroupBackend {
-        fn memory(&self) -> Result<MemorySnapshot> {
+        fn memory(&self, _path: &Path) -> Result<MemorySnapshot> {
             Ok(self.memory.clone())
         }
 
-        fn cpu(&self) -> Result<CpuSnapshot> {
+        fn cpu(&self, _path: &Path) -> Result<CpuSnapshot> {
             Ok(self.cpu.clone())
         }
 
-        fn io(&self) -> Result<IoSnapshot> {
+        fn io(&self, _path: &Path) -> Result<IoSnapshot> {
             Ok(self.io.clone())
         }
 
-        fn initialize(&self, _pid: i32, _controllers: &HashSet<Controller>) -> Result<()> {
+        fn initialize(
+            &self,
+            _path: &Path,
+            _root: &Path,
+            _pid: i32,
+            _controllers: &HashSet<Controller>,
+        ) -> Result<()> {
             Ok(())
         }
 
-        fn cleanup(&self) -> Result<()> {
+        fn cleanup(&self, _path: &Path, _root: &Path) -> Result<()> {
             Ok(())
         }
     }
 
-    fn mock_cgroup(name: &str, backend: MockCgroupBackend) -> Cgroup<MockCgroupBackend> {
-        let path = std::env::temp_dir().join(format!("cgroup_test_{name}"));
-        Cgroup {
+    fn mock_cgroup(name: &str, backend: MockCgroupBackend) -> ChildCgroup<MockCgroupBackend> {
+        let path = PathBuf::from(name);
+        ChildCgroup {
             path: path.clone(),
-            parent: Some(path),
+            root: path,
             backend,
         }
     }
@@ -347,9 +371,9 @@ mod tests {
             ..Default::default()
         };
 
-        let cg = mock_cgroup("mock_mem", backend);
+        let cg = mock_cgroup("memory", backend);
 
-        let stats = cg.stats().memory().unwrap();
+        let stats = cg.memory().unwrap();
 
         assert_eq!(stats.current, Some(123));
         assert_eq!(stats.swap_current, Some(456));
@@ -375,9 +399,9 @@ mod tests {
             ..Default::default()
         };
 
-        let cg = mock_cgroup("mock_cpu", backend);
+        let cg = mock_cgroup("cpu", backend);
 
-        let stats = cg.stats().cpu().unwrap();
+        let stats = cg.cpu().unwrap();
 
         assert_eq!(stats.usage_usec, 1000);
         assert_eq!(stats.user_usec, 400);
@@ -396,9 +420,9 @@ mod tests {
             ..Default::default()
         };
 
-        let cg = mock_cgroup("mock_io", backend);
+        let cg = mock_cgroup("io", backend);
 
-        let stats = cg.stats().io().unwrap();
+        let stats = cg.io().unwrap();
 
         assert_eq!(stats.rbytes, Some(120));
         assert_eq!(stats.wbytes, Some(80));

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -6,12 +6,7 @@
 //! - process attachment to cgroups;
 //! - CPU, memory, and I/O statistics collection.
 
-use std::{
-    collections::HashSet,
-    fmt::Display,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashSet, fmt::Display, fs, path::PathBuf};
 
 use log::{debug, warn};
 
@@ -46,7 +41,10 @@ impl Display for Controller {
 }
 
 /// Interface for reading cgroup statistics.
-pub trait StatsReader {
+pub trait CgroupBackend: Send + Sync + 'static {
+    /// Initializes the backend.
+    fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()>;
+
     /// Returns memory statistics.
     fn memory(&self) -> Result<MemorySnapshot>;
 
@@ -55,82 +53,114 @@ pub trait StatsReader {
 
     /// Returns I/O statistics.
     fn io(&self) -> Result<IoSnapshot>;
+
+    /// Cleanup the backend.
+    fn cleanup(&self) -> Result<()>;
 }
 
-/// Root cgroup manager.
-///
-/// Used to enable controllers and create child cgroups.
-pub struct RootCgroup {
-    /// The path of the root cgroup, default is `/sys/fs/cgroup` (override for testing).
+/// A cgroup node. If `parent` is `None`, this is the root cgroup.
+pub struct Cgroup<B: CgroupBackend = SysFsBackend> {
     pub path: PathBuf,
-
-    /// List of controllers activated for the root cgroup.
-    controllers: HashSet<Controller>,
+    parent: Option<PathBuf>,
+    backend: B,
 }
 
-impl Default for RootCgroup {
-    fn default() -> Self {
-        Self {
-            path: PathBuf::from("/sys/fs/cgroup"),
-            controllers: HashSet::new(),
-        }
+impl Cgroup {
+    /// Gets the root cgroup in sys fs `/sys/fs/cgroup`.
+    pub fn root() -> Self {
+        let path = PathBuf::from("/sys/fs/cgroup");
+        Self::at(path)
     }
-}
 
-impl RootCgroup {
-    /// Creates a new root cgroup manager from a custom path.
-    pub fn new(path: PathBuf) -> Self {
+    /// Builds a cgroup handle based on the provided directory.
+    pub fn at(path: PathBuf) -> Self {
+        let backend = SysFsBackend {
+            path: path.clone(),
+            root: path.clone(),
+        };
         Self {
             path,
-            ..Default::default()
+            parent: None,
+            backend,
         }
     }
 
+    /// Gets a child handle of the current cgroup based on its name.
+    pub fn child(&self, name: &str) -> Cgroup {
+        let child_path = self.path.join(name);
+        Cgroup {
+            parent: Some(self.path.clone()),
+            backend: SysFsBackend {
+                root: self.path.clone(),
+                path: child_path.clone(),
+            },
+            path: child_path,
+        }
+    }
+}
+
+impl<B: CgroupBackend> Cgroup<B> {
+    pub fn new(path: PathBuf, parent: Option<PathBuf>, backend: B) -> Self {
+        Self {
+            path,
+            parent,
+            backend,
+        }
+    }
+
+    /// True if the cgroup is the root cgroup, else false.
+    pub fn is_root(&self) -> bool {
+        self.parent.is_none()
+    }
+
+    /// Return the backend for stats querying.
+    pub fn stats(&self) -> &B {
+        &self.backend
+    }
+
+    /// Initializes the cgroup backend.
+    pub fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()> {
+        self.backend.initialize(pid, controllers)
+    }
+
+    /// Cleanup the cgroup backend.
+    pub fn cleanup(&self) -> Result<()> {
+        self.backend.cleanup()
+    }
+}
+
+/// Cleans up the cgroup if not done already (cleanup not called or error).
+impl<B: CgroupBackend> Drop for Cgroup<B> {
+    fn drop(&mut self) {
+        if self.parent.is_some() && self.path.exists() {
+            let _ = self.backend.cleanup();
+        }
+    }
+}
+
+/// cgroup statistics accessor.
+pub struct SysFsBackend {
+    path: PathBuf,
+    root: PathBuf,
+}
+
+impl SysFsBackend {
     /// Enables a controller in `cgroup.subtree_control`.
     ///
     /// If the provided controller is already activated, then nothing happens.
     pub fn activate_controller(&self, controller: Controller) -> Result<()> {
-        if !self.controllers.contains(&controller) {
-            let subtree_control_path = self.path.join("cgroup.subtree_control");
-            fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
-                CgroupError::FailedToCreateController {
-                    controller,
-                    path: subtree_control_path,
-                    source: err,
-                }
-            })?;
-        }
-        Ok(())
-    }
-
-    /// Creates a child cgroup handle.
-    pub fn child(&self, name: &str) -> Cgroup {
-        Cgroup {
-            path: self.path.join(name),
-            root: self.path.clone(),
-        }
-    }
-
-    /// Returns a statistics reader for the root cgroup.
-    pub fn stats(&self) -> CgroupStat<'_> {
-        CgroupStat { path: &self.path }
-    }
-}
-
-/// Represents a child cgroup.
-pub struct Cgroup {
-    /// The path of the cgroup, normally it is `/sys/fs/cgroup/{cgroup_name}` but it can be override for testing.
-    pub path: PathBuf,
-
-    /// The path of the root cgroup, default is `/sys/fs/cgroup` (override for testing).
-    pub root: PathBuf,
-}
-
-impl Cgroup {
-    /// Creates the cgroup directory on disk.
-    pub fn initialize(&self) -> Result<()> {
-        debug!("Creating cgroup at \"{}\"", self.path.display());
-        fs::create_dir_all(&self.path)?;
+        debug!(
+            "Activating controller for root cgroup `{}`.",
+            self.path.display()
+        );
+        let subtree_control_path = self.root.join("cgroup.subtree_control");
+        fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
+            CgroupError::FailedToCreateController {
+                controller,
+                path: subtree_control_path,
+                source: err,
+            }
+        })?;
         Ok(())
     }
 
@@ -146,13 +176,9 @@ impl Cgroup {
         Ok(())
     }
 
-    /// Returns a statistics reader for this cgroup.
-    pub fn stats(&self) -> CgroupStat<'_> {
-        CgroupStat { path: &self.path }
-    }
-
     /// Returns all PIDs attached to the cgroup.
     fn pids(&self) -> Result<Vec<i32>> {
+        debug!("Retrieving cgroup `{}` PIDs.", self.path.display());
         let path = self.path.join("cgroup.procs");
         let content = fs::read_to_string(&path)?;
         Ok(content
@@ -160,9 +186,28 @@ impl Cgroup {
             .filter_map(|l| l.trim().parse::<i32>().ok())
             .collect())
     }
+}
+
+impl CgroupBackend for SysFsBackend {
+    /// Creates the cgroup directory on disk.
+    fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()> {
+        debug!("Initializing cgroup at \"{}\"", self.path.display());
+
+        fs::create_dir_all(&self.path)?;
+
+        for controller in controllers {
+            self.activate_controller(*controller)?;
+        }
+
+        self.attach_pid(pid)?;
+
+        Ok(())
+    }
 
     /// Moves processes back to the root cgroup and removes the directory.
-    pub fn cleanup(&self) -> Result<()> {
+    fn cleanup(&self) -> Result<()> {
+        debug!("Cleaning cgroup `{}`.", self.path.display());
+
         let root_procs = self.root.join("cgroup.procs");
         for pid in self.pids()? {
             if let Err(e) = fs::write(&root_procs, pid.to_string()) {
@@ -181,25 +226,14 @@ impl Cgroup {
         }
         Ok(())
     }
-}
 
-/// Cleans up the cgroup if not done already (cleanup not called or error).
-impl Drop for Cgroup {
-    fn drop(&mut self) {
-        if self.path.exists() {
-            let _ = self.cleanup();
-        }
-    }
-}
-
-/// cgroup statistics accessor.
-pub struct CgroupStat<'a> {
-    path: &'a Path,
-}
-
-impl StatsReader for CgroupStat<'_> {
     /// Reads memory statistics from cgroup memory files.
     fn memory(&self) -> Result<MemorySnapshot> {
+        debug!(
+            "Reading memory metrics for cgroup `{}`.",
+            self.path.display()
+        );
+
         let mut memory_stat = read_flat_keyed_file(&self.path.join("memory.stat"))?;
         let current = read_u64_opt(&self.path.join("memory.current"))?;
         let swap_current = read_u64_opt(&self.path.join("memory.swap.current"))?;
@@ -220,12 +254,15 @@ impl StatsReader for CgroupStat<'_> {
 
     /// Reads I/O statistics from `io.stat`.
     fn io(&self) -> Result<IoSnapshot> {
+        debug!("Reading I/O metrics for cgroup `{}`.", self.path.display());
         let (rbytes, wbytes) = read_io_stat(&self.path.join("io.stat"))?;
         Ok(IoSnapshot { rbytes, wbytes })
     }
 
     /// Reads CPU statistics from `cpu.stat`.
     fn cpu(&self) -> Result<CpuSnapshot> {
+        debug!("Reading cpu metrics for cgroup `{}`.", self.path.display());
+
         let mut cpu_stat = read_flat_keyed_file(&self.path.join("cpu.stat"))?;
 
         let usage_usec = cpu_stat
@@ -254,85 +291,63 @@ impl StatsReader for CgroupStat<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, io::Write, path::PathBuf};
 
-    fn temp_cgroup_dir(name: &str) -> PathBuf {
-        let mut path = std::env::temp_dir();
-        path.push(format!("cgroup_test_{name}"));
-        let _ = fs::create_dir_all(&path);
-        path
+    #[derive(Default)]
+    struct MockCgroupBackend {
+        memory: MemorySnapshot,
+        cpu: CpuSnapshot,
+        io: IoSnapshot,
     }
 
-    fn write_file(path: &Path, content: &str) {
-        let mut f = fs::File::create(path).unwrap();
-        writeln!(f, "{content}").unwrap();
+    impl CgroupBackend for MockCgroupBackend {
+        fn memory(&self) -> Result<MemorySnapshot> {
+            Ok(self.memory.clone())
+        }
+
+        fn cpu(&self) -> Result<CpuSnapshot> {
+            Ok(self.cpu.clone())
+        }
+
+        fn io(&self) -> Result<IoSnapshot> {
+            Ok(self.io.clone())
+        }
+
+        fn initialize(&self, _pid: i32, _controllers: &HashSet<Controller>) -> Result<()> {
+            Ok(())
+        }
+
+        fn cleanup(&self) -> Result<()> {
+            Ok(())
+        }
     }
 
-    fn setup_root(name: &str) -> RootCgroup {
-        let root = temp_cgroup_dir(name);
-        RootCgroup::new(root)
-    }
-
-    #[test]
-    fn test_initialize_and_attach_pid() {
-        let root = setup_root("init");
-        let cg = root.child("test_group");
-
-        cg.initialize().unwrap();
-
-        let pid_file = cg.path.join("cgroup.procs");
-        write_file(&pid_file, "1234");
-
-        cg.attach_pid(42).unwrap();
-
-        let content = fs::read_to_string(&pid_file).unwrap();
-        assert!(content.contains("42"));
-
-        let _ = cg.cleanup();
-    }
-
-    #[test]
-    fn test_pids_parsing() {
-        let root = setup_root("pids");
-        let cg = root.child("pids_group");
-
-        cg.initialize().unwrap();
-
-        write_file(&cg.path.join("cgroup.procs"), "1\n2\n3");
-
-        let pids = cg.pids().unwrap();
-        assert_eq!(pids, vec![1, 2, 3]);
-
-        let _ = cg.cleanup();
+    fn mock_cgroup(name: &str, backend: MockCgroupBackend) -> Cgroup<MockCgroupBackend> {
+        let path = std::env::temp_dir().join(format!("cgroup_test_{name}"));
+        Cgroup {
+            path: path.clone(),
+            parent: Some(path),
+            backend,
+        }
     }
 
     #[test]
-    fn test_cleanup_moves_pids() {
-        let root = setup_root("cleanup");
-        let cg = root.child("cleanup_group");
+    fn test_stats_reader_memory() {
+        let backend = MockCgroupBackend {
+            memory: MemorySnapshot {
+                current: Some(123),
+                swap_current: Some(456),
+                peak: Some(789),
+                anon: Some(100),
+                file: Some(200),
+                shmem: None,
+                kernel: None,
+                kernel_stack: None,
+                slab: Some(300),
+            },
+            ..Default::default()
+        };
 
-        cg.initialize().unwrap();
-
-        let root_procs = root.path.join("cgroup.procs");
-        write_file(&cg.path.join("cgroup.procs"), "99");
-
-        cg.cleanup().unwrap();
-
-        let moved = fs::read_to_string(root_procs).unwrap();
-        assert!(moved.contains("99"));
-    }
-
-    #[test]
-    fn test_memory_stats() {
-        let root = setup_root("mem");
-        let cg = root.child("mem_group");
-
-        cg.initialize().unwrap();
-
-        write_file(&cg.path.join("memory.stat"), "anon 100\nfile 200\nslab 300");
-        write_file(&cg.path.join("memory.current"), "123");
-        write_file(&cg.path.join("memory.swap.current"), "456");
-        write_file(&cg.path.join("memory.peak"), "789");
+        let cg = mock_cgroup("mock_mem", backend);
 
         let stats = cg.stats().memory().unwrap();
 
@@ -342,27 +357,25 @@ mod tests {
         assert_eq!(stats.anon, Some(100));
         assert_eq!(stats.file, Some(200));
         assert_eq!(stats.slab, Some(300));
-
-        let _ = cg.cleanup();
     }
 
     #[test]
-    fn test_cpu_stats() {
-        let root = setup_root("cpu");
-        let cg = root.child("cpu_group");
+    fn test_stats_reader_cpu() {
+        let backend = MockCgroupBackend {
+            cpu: CpuSnapshot {
+                usage_usec: 1000,
+                user_usec: 400,
+                system_usec: 600,
+                nr_periods: Some(10),
+                nr_throttled: Some(2),
+                throttled_usec: None,
+                nr_bursts: None,
+                burst_usec: None,
+            },
+            ..Default::default()
+        };
 
-        cg.initialize().unwrap();
-
-        write_file(
-            &cg.path.join("cpu.stat"),
-            "\
-usage_usec 1000
-user_usec 400
-system_usec 600
-nr_periods 10
-nr_throttled 2
-",
-        );
+        let cg = mock_cgroup("mock_cpu", backend);
 
         let stats = cg.stats().cpu().unwrap();
 
@@ -371,41 +384,23 @@ nr_throttled 2
         assert_eq!(stats.system_usec, 600);
         assert_eq!(stats.nr_periods, Some(10));
         assert_eq!(stats.nr_throttled, Some(2));
-
-        let _ = cg.cleanup();
     }
 
     #[test]
-    fn test_io_stats() {
-        let root = setup_root("io");
-        let cg = root.child("io_group");
+    fn test_stats_reader_io() {
+        let backend = MockCgroupBackend {
+            io: IoSnapshot {
+                rbytes: Some(120),
+                wbytes: Some(80),
+            },
+            ..Default::default()
+        };
 
-        cg.initialize().unwrap();
-
-        write_file(
-            &cg.path.join("io.stat"),
-            "\
-8:0 rbytes=100 wbytes=50
-8:1 rbytes=20 wbytes=30
-",
-        );
+        let cg = mock_cgroup("mock_io", backend);
 
         let stats = cg.stats().io().unwrap();
 
         assert_eq!(stats.rbytes, Some(120));
         assert_eq!(stats.wbytes, Some(80));
-
-        let _ = cg.cleanup();
-    }
-
-    #[test]
-    fn test_activate_controller_does_not_crash() {
-        let root = setup_root("ctrl");
-
-        let ctrl_file = root.path.join("cgroup.subtree_control");
-        write_file(&ctrl_file, "");
-
-        let res = root.activate_controller(Controller::Cpu);
-        assert!(res.is_ok());
     }
 }

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -1,12 +1,16 @@
-use std::{fmt::Display, fs, path::PathBuf};
+use std::{
+    fmt::Display,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use log::{debug, warn};
 
 use crate::{
     Result,
-    error::CgroupError::{self},
+    error::CgroupError,
     snapshot::{CpuSnapshot, IoSnapshot, MemorySnapshot},
-    util::{read_flat_keyed_file, read_io_stat, read_u64, read_u64_opt},
+    util::{read_flat_keyed_file, read_io_stat, read_u64_opt},
 };
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -26,32 +30,31 @@ impl Display for Controller {
     }
 }
 
-pub struct Cgroup {
-    cgroup_root: PathBuf,
-    cgroup_path: PathBuf,
+pub trait StatsReader {
+    fn memory(&self) -> Result<MemorySnapshot>;
+    fn cpu(&self) -> Result<CpuSnapshot>;
+    fn io(&self) -> Result<IoSnapshot>;
 }
 
-impl Cgroup {
-    pub fn new(cgroup_root: PathBuf, cgroup_name: &str) -> Result<Self> {
-        let cgroup_path = cgroup_root.join(cgroup_name);
-        if cgroup_path.exists() {
-            return Err(CgroupError::AlreadyCreated(cgroup_name.to_owned()));
+pub struct RootCgroup {
+    path: PathBuf,
+}
+
+impl Default for RootCgroup {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::from("/sys/fs/cgroup"),
         }
-
-        Ok(Self {
-            cgroup_root,
-            cgroup_path,
-        })
     }
+}
 
-    pub fn initialize_cgroup(&self) -> Result<()> {
-        debug!("Creating cgroup at \"{}\"", self.cgroup_path.display());
-        fs::create_dir_all(&self.cgroup_path)?;
-        Ok(())
+impl RootCgroup {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
     }
 
     pub fn activate_controller(&self, controller: Controller) -> Result<()> {
-        let subtree_control_path = self.cgroup_root.join("cgroup.subtree_control");
+        let subtree_control_path = self.path.join("cgroup.subtree_control");
         fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
             CgroupError::FailedToCreateController {
                 controller,
@@ -62,53 +65,114 @@ impl Cgroup {
         Ok(())
     }
 
+    pub fn child(&self, name: &str) -> Cgroup {
+        Cgroup {
+            path: self.path.join(name),
+            root: self.path.clone(),
+        }
+    }
+
+    pub fn stats(&self) -> CgroupStat<'_> {
+        CgroupStat { path: &self.path }
+    }
+}
+
+pub struct Cgroup {
+    path: PathBuf,
+    root: PathBuf,
+}
+
+impl Cgroup {
+    pub fn initialize(&self) -> Result<()> {
+        debug!("Creating cgroup at \"{}\"", self.path.display());
+        fs::create_dir_all(&self.path)?;
+        Ok(())
+    }
+
     pub fn attach_pid(&self, pid: i32) -> Result<()> {
-        let procs_path = self.cgroup_path.join("cgroup.procs");
+        let procs_path = self.path.join("cgroup.procs");
         fs::write(&procs_path, pid.to_string()).map_err(|err| CgroupError::FailedToAttachPid {
             pid,
             path: procs_path,
             source: err,
         })?;
-        debug!(
-            "Attached PID {pid} to cgroup {}",
-            self.cgroup_path.display()
-        );
+        debug!("Attached PID {pid} to cgroup {}", self.path.display());
         Ok(())
     }
 
-    pub fn read_memory(&self) -> Result<MemorySnapshot> {
-        let mut memory_stat = read_flat_keyed_file(&self.cgroup_path.join("memory.stat"))?;
-        let current = read_u64(&self.cgroup_path.join("memory.current"))?;
-        let swap_current = read_u64_opt(&self.cgroup_path.join("memory.swap.current"))?;
-        let peak = read_u64_opt(&self.cgroup_path.join("memory.peak"))?;
+    pub fn stats(&self) -> CgroupStat<'_> {
+        CgroupStat { path: &self.path }
+    }
 
-        let anon = memory_stat.remove("anon");
-        let file = memory_stat.remove("file");
-        let shmem = memory_stat.remove("shmem");
-        let kernel = memory_stat.remove("kernel");
-        let kernel_stack = memory_stat.remove("kernel_stack");
-        let slab = memory_stat.remove("slab");
+    fn pids(&self) -> Result<Vec<i32>> {
+        let path = self.path.join("cgroup.procs");
+        let content = fs::read_to_string(&path)?;
+        Ok(content
+            .lines()
+            .filter_map(|l| l.trim().parse::<i32>().ok())
+            .collect())
+    }
+
+    pub fn cleanup(&self) -> Result<()> {
+        let root_procs = self.root.join("cgroup.procs");
+        for pid in self.pids()? {
+            if let Err(e) = fs::write(&root_procs, pid.to_string()) {
+                warn!("Could not move PID {pid} back to root cgroup: {e}");
+            }
+        }
+        if self.path.exists() {
+            if let Err(e) = fs::remove_dir(&self.path) {
+                warn!(
+                    "Could not remove cgroup {} (may still have live tasks): {e}",
+                    self.path.display()
+                );
+            } else {
+                debug!("Removed cgroup {}", self.path.display());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Cgroup {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = self.cleanup();
+        }
+    }
+}
+
+pub struct CgroupStat<'a> {
+    path: &'a Path,
+}
+
+impl StatsReader for CgroupStat<'_> {
+    fn memory(&self) -> Result<MemorySnapshot> {
+        let mut memory_stat = read_flat_keyed_file(&self.path.join("memory.stat"))?;
+        let current = read_u64_opt(&self.path.join("memory.current"))?;
+        let swap_current = read_u64_opt(&self.path.join("memory.swap.current"))?;
+        let peak = read_u64_opt(&self.path.join("memory.peak"))?;
 
         Ok(MemorySnapshot {
             current,
             swap_current,
-            anon,
-            file,
             peak,
-            shmem,
-            kernel,
-            kernel_stack,
-            slab,
+            anon: memory_stat.remove("anon"),
+            file: memory_stat.remove("file"),
+            shmem: memory_stat.remove("shmem"),
+            kernel: memory_stat.remove("kernel"),
+            kernel_stack: memory_stat.remove("kernel_stack"),
+            slab: memory_stat.remove("slab"),
         })
     }
 
-    pub fn read_io(&self) -> Result<IoSnapshot> {
-        let (rbytes, wbytes) = read_io_stat(&self.cgroup_path.join("io.stat"))?;
+    fn io(&self) -> Result<IoSnapshot> {
+        let (rbytes, wbytes) = read_io_stat(&self.path.join("io.stat"))?;
         Ok(IoSnapshot { rbytes, wbytes })
     }
 
-    pub fn read_cpu(&self) -> Result<CpuSnapshot> {
-        let mut cpu_stat = read_flat_keyed_file(&self.cgroup_path.join("cpu.stat"))?;
+    fn cpu(&self) -> Result<CpuSnapshot> {
+        let mut cpu_stat = read_flat_keyed_file(&self.path.join("cpu.stat"))?;
 
         let usage_usec = cpu_stat
             .remove("usage_usec")
@@ -120,51 +184,15 @@ impl Cgroup {
             .remove("system_usec")
             .ok_or(CgroupError::MissingAlwaysPresentMetric("system_usec"))?;
 
-        let nr_periods = cpu_stat.remove("nr_periods");
-        let nr_throttled = cpu_stat.remove("nr_throttled");
-        let throttled_usec = cpu_stat.remove("throttled_usec");
-        let nr_bursts = cpu_stat.remove("nr_bursts");
-        let burst_usec = cpu_stat.remove("burst_usec");
-
         Ok(CpuSnapshot {
             usage_usec,
             user_usec,
             system_usec,
-            nr_periods,
-            nr_throttled,
-            throttled_usec,
-            nr_bursts,
-            burst_usec,
+            nr_periods: cpu_stat.remove("nr_periods"),
+            nr_throttled: cpu_stat.remove("nr_throttled"),
+            throttled_usec: cpu_stat.remove("throttled_usec"),
+            nr_bursts: cpu_stat.remove("nr_bursts"),
+            burst_usec: cpu_stat.remove("burst_usec"),
         })
-    }
-
-    fn get_pids(&self) -> Result<Vec<i32>> {
-        let path = self.cgroup_path.join("cgroup.procs");
-        let content = fs::read_to_string(&path)?;
-        let pids = content
-            .lines()
-            .filter_map(|l| l.trim().parse::<i32>().ok())
-            .collect();
-        Ok(pids)
-    }
-
-    pub fn cleanup(&self) -> Result<()> {
-        let root_procs = self.cgroup_path.join("cgroup.procs");
-        for pid in self.get_pids()? {
-            if let Err(e) = fs::write(&root_procs, pid.to_string()) {
-                warn!("Could not move PID {pid} back to root cgroup: {e}");
-            }
-        }
-        if self.cgroup_path.exists() {
-            if let Err(e) = fs::remove_dir(&self.cgroup_path) {
-                warn!(
-                    "Could not remove cgroup {} (may still have live tasks): {e}",
-                    self.cgroup_path.display()
-                );
-            } else {
-                debug!("Removed cgroup {}", self.cgroup_path.display());
-            }
-        }
-        Ok(())
     }
 }

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -1,4 +1,13 @@
+//! cgroup v2 management utilities.
+//!
+//! This module provides:
+//! - controller activation (`cpu`, `memory`, `io`);
+//! - child cgroup creation and cleanup;
+//! - process attachment to cgroups;
+//! - CPU, memory, and I/O statistics collection.
+
 use std::{
+    collections::HashSet,
     fmt::Display,
     fs,
     path::{Path, PathBuf},
@@ -13,10 +22,16 @@ use crate::{
     util::{read_flat_keyed_file, read_io_stat, read_u64_opt},
 };
 
+/// Available cgroup v2 controllers.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Controller {
+    /// I/O controller.
     Io,
-    Mem,
+
+    /// Memory controller.
+    Memory,
+
+    /// CPU controller.
     Cpu,
 }
 
@@ -24,47 +39,71 @@ impl Display for Controller {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
             Controller::Io => "io",
-            Controller::Mem => "memory",
+            Controller::Memory => "memory",
             Controller::Cpu => "cpu",
         })
     }
 }
 
+/// Interface for reading cgroup statistics.
 pub trait StatsReader {
+    /// Returns memory statistics.
     fn memory(&self) -> Result<MemorySnapshot>;
+
+    /// Returns CPU statistics.
     fn cpu(&self) -> Result<CpuSnapshot>;
+
+    /// Returns I/O statistics.
     fn io(&self) -> Result<IoSnapshot>;
 }
 
+/// Root cgroup manager.
+///
+/// Used to enable controllers and create child cgroups.
 pub struct RootCgroup {
+    /// The path of the root cgroup, default is `/sys/fs/cgroup` (override for testing).
     path: PathBuf,
+
+    /// List of controllers activated for the root cgroup.
+    controllers: HashSet<Controller>,
 }
 
 impl Default for RootCgroup {
     fn default() -> Self {
         Self {
             path: PathBuf::from("/sys/fs/cgroup"),
+            controllers: HashSet::new(),
         }
     }
 }
 
 impl RootCgroup {
+    /// Creates a new root cgroup manager from a custom path.
     pub fn new(path: PathBuf) -> Self {
-        Self { path }
+        Self {
+            path,
+            ..Default::default()
+        }
     }
 
+    /// Enables a controller in `cgroup.subtree_control`.
+    ///
+    /// If the provided controller is already activated, then nothing happens.
     pub fn activate_controller(&self, controller: Controller) -> Result<()> {
-        let subtree_control_path = self.path.join("cgroup.subtree_control");
-        fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
-            CgroupError::FailedToCreateController {
-                controller,
-                path: subtree_control_path,
-                source: err,
-            }
-        })?;
+        if !self.controllers.contains(&controller) {
+            let subtree_control_path = self.path.join("cgroup.subtree_control");
+            fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
+                CgroupError::FailedToCreateController {
+                    controller,
+                    path: subtree_control_path,
+                    source: err,
+                }
+            })?;
+        }
         Ok(())
     }
 
+    /// Creates a child cgroup handle.
     pub fn child(&self, name: &str) -> Cgroup {
         Cgroup {
             path: self.path.join(name),
@@ -72,23 +111,30 @@ impl RootCgroup {
         }
     }
 
+    /// Returns a statistics reader for the root cgroup.
     pub fn stats(&self) -> CgroupStat<'_> {
         CgroupStat { path: &self.path }
     }
 }
 
+/// Represents a child cgroup.
 pub struct Cgroup {
+    /// The path of the cgroup, normally it is `/sys/fs/cgroup/{cgroup_name}` but it can be override for testing.
     path: PathBuf,
+
+    /// The path of the root cgroup, default is `/sys/fs/cgroup` (override for testing).
     root: PathBuf,
 }
 
 impl Cgroup {
+    /// Creates the cgroup directory on disk.
     pub fn initialize(&self) -> Result<()> {
         debug!("Creating cgroup at \"{}\"", self.path.display());
         fs::create_dir_all(&self.path)?;
         Ok(())
     }
 
+    /// Attaches a process PID to the cgroup.
     pub fn attach_pid(&self, pid: i32) -> Result<()> {
         let procs_path = self.path.join("cgroup.procs");
         fs::write(&procs_path, pid.to_string()).map_err(|err| CgroupError::FailedToAttachPid {
@@ -100,10 +146,12 @@ impl Cgroup {
         Ok(())
     }
 
+    /// Returns a statistics reader for this cgroup.
     pub fn stats(&self) -> CgroupStat<'_> {
         CgroupStat { path: &self.path }
     }
 
+    /// Returns all PIDs attached to the cgroup.
     fn pids(&self) -> Result<Vec<i32>> {
         let path = self.path.join("cgroup.procs");
         let content = fs::read_to_string(&path)?;
@@ -113,6 +161,7 @@ impl Cgroup {
             .collect())
     }
 
+    /// Moves processes back to the root cgroup and removes the directory.
     pub fn cleanup(&self) -> Result<()> {
         let root_procs = self.root.join("cgroup.procs");
         for pid in self.pids()? {
@@ -134,6 +183,7 @@ impl Cgroup {
     }
 }
 
+/// Cleans up the cgroup if not done already (cleanup not called or error).
 impl Drop for Cgroup {
     fn drop(&mut self) {
         if self.path.exists() {
@@ -142,11 +192,13 @@ impl Drop for Cgroup {
     }
 }
 
+/// cgroup statistics accessor.
 pub struct CgroupStat<'a> {
     path: &'a Path,
 }
 
 impl StatsReader for CgroupStat<'_> {
+    /// Reads memory statistics from cgroup memory files.
     fn memory(&self) -> Result<MemorySnapshot> {
         let mut memory_stat = read_flat_keyed_file(&self.path.join("memory.stat"))?;
         let current = read_u64_opt(&self.path.join("memory.current"))?;
@@ -166,11 +218,13 @@ impl StatsReader for CgroupStat<'_> {
         })
     }
 
+    /// Reads I/O statistics from `io.stat`.
     fn io(&self) -> Result<IoSnapshot> {
         let (rbytes, wbytes) = read_io_stat(&self.path.join("io.stat"))?;
         Ok(IoSnapshot { rbytes, wbytes })
     }
 
+    /// Reads CPU statistics from `cpu.stat`.
     fn cpu(&self) -> Result<CpuSnapshot> {
         let mut cpu_stat = read_flat_keyed_file(&self.path.join("cpu.stat"))?;
 

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -62,7 +62,7 @@ pub trait StatsReader {
 /// Used to enable controllers and create child cgroups.
 pub struct RootCgroup {
     /// The path of the root cgroup, default is `/sys/fs/cgroup` (override for testing).
-    path: PathBuf,
+    pub path: PathBuf,
 
     /// List of controllers activated for the root cgroup.
     controllers: HashSet<Controller>,
@@ -120,10 +120,10 @@ impl RootCgroup {
 /// Represents a child cgroup.
 pub struct Cgroup {
     /// The path of the cgroup, normally it is `/sys/fs/cgroup/{cgroup_name}` but it can be override for testing.
-    path: PathBuf,
+    pub path: PathBuf,
 
     /// The path of the root cgroup, default is `/sys/fs/cgroup` (override for testing).
-    root: PathBuf,
+    pub root: PathBuf,
 }
 
 impl Cgroup {
@@ -248,5 +248,164 @@ impl StatsReader for CgroupStat<'_> {
             nr_bursts: cpu_stat.remove("nr_bursts"),
             burst_usec: cpu_stat.remove("burst_usec"),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, io::Write, path::PathBuf};
+
+    fn temp_cgroup_dir(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("cgroup_test_{name}"));
+        let _ = fs::create_dir_all(&path);
+        path
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        let mut f = fs::File::create(path).unwrap();
+        writeln!(f, "{content}").unwrap();
+    }
+
+    fn setup_root(name: &str) -> RootCgroup {
+        let root = temp_cgroup_dir(name);
+        RootCgroup::new(root)
+    }
+
+    #[test]
+    fn test_initialize_and_attach_pid() {
+        let root = setup_root("init");
+        let cg = root.child("test_group");
+
+        cg.initialize().unwrap();
+
+        let pid_file = cg.path.join("cgroup.procs");
+        write_file(&pid_file, "1234");
+
+        cg.attach_pid(42).unwrap();
+
+        let content = fs::read_to_string(&pid_file).unwrap();
+        assert!(content.contains("42"));
+
+        let _ = cg.cleanup();
+    }
+
+    #[test]
+    fn test_pids_parsing() {
+        let root = setup_root("pids");
+        let cg = root.child("pids_group");
+
+        cg.initialize().unwrap();
+
+        write_file(&cg.path.join("cgroup.procs"), "1\n2\n3");
+
+        let pids = cg.pids().unwrap();
+        assert_eq!(pids, vec![1, 2, 3]);
+
+        let _ = cg.cleanup();
+    }
+
+    #[test]
+    fn test_cleanup_moves_pids() {
+        let root = setup_root("cleanup");
+        let cg = root.child("cleanup_group");
+
+        cg.initialize().unwrap();
+
+        let root_procs = root.path.join("cgroup.procs");
+        write_file(&cg.path.join("cgroup.procs"), "99");
+
+        cg.cleanup().unwrap();
+
+        let moved = fs::read_to_string(root_procs).unwrap();
+        assert!(moved.contains("99"));
+    }
+
+    #[test]
+    fn test_memory_stats() {
+        let root = setup_root("mem");
+        let cg = root.child("mem_group");
+
+        cg.initialize().unwrap();
+
+        write_file(&cg.path.join("memory.stat"), "anon 100\nfile 200\nslab 300");
+        write_file(&cg.path.join("memory.current"), "123");
+        write_file(&cg.path.join("memory.swap.current"), "456");
+        write_file(&cg.path.join("memory.peak"), "789");
+
+        let stats = cg.stats().memory().unwrap();
+
+        assert_eq!(stats.current, Some(123));
+        assert_eq!(stats.swap_current, Some(456));
+        assert_eq!(stats.peak, Some(789));
+        assert_eq!(stats.anon, Some(100));
+        assert_eq!(stats.file, Some(200));
+        assert_eq!(stats.slab, Some(300));
+
+        let _ = cg.cleanup();
+    }
+
+    #[test]
+    fn test_cpu_stats() {
+        let root = setup_root("cpu");
+        let cg = root.child("cpu_group");
+
+        cg.initialize().unwrap();
+
+        write_file(
+            &cg.path.join("cpu.stat"),
+            "\
+usage_usec 1000
+user_usec 400
+system_usec 600
+nr_periods 10
+nr_throttled 2
+",
+        );
+
+        let stats = cg.stats().cpu().unwrap();
+
+        assert_eq!(stats.usage_usec, 1000);
+        assert_eq!(stats.user_usec, 400);
+        assert_eq!(stats.system_usec, 600);
+        assert_eq!(stats.nr_periods, Some(10));
+        assert_eq!(stats.nr_throttled, Some(2));
+
+        let _ = cg.cleanup();
+    }
+
+    #[test]
+    fn test_io_stats() {
+        let root = setup_root("io");
+        let cg = root.child("io_group");
+
+        cg.initialize().unwrap();
+
+        write_file(
+            &cg.path.join("io.stat"),
+            "\
+8:0 rbytes=100 wbytes=50
+8:1 rbytes=20 wbytes=30
+",
+        );
+
+        let stats = cg.stats().io().unwrap();
+
+        assert_eq!(stats.rbytes, Some(120));
+        assert_eq!(stats.wbytes, Some(80));
+
+        let _ = cg.cleanup();
+    }
+
+    #[test]
+    fn test_activate_controller_does_not_crash() {
+        let root = setup_root("ctrl");
+
+        let ctrl_file = root.path.join("cgroup.subtree_control");
+        write_file(&ctrl_file, "");
+
+        let res = root.activate_controller(Controller::Cpu);
+        assert!(res.is_ok());
     }
 }

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -13,7 +13,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use log::{debug, warn};
+use log::{debug, trace, warn};
 
 use crate::{
     Result,
@@ -48,13 +48,11 @@ impl Display for Controller {
 /// Interface for reading cgroup statistics.
 pub trait CgroupBackend: Send + Sync + 'static {
     /// Initializes the backend.
-    fn initialize(
-        &self,
-        path: &Path,
-        root: &Path,
-        pid: i32,
-        controllers: &HashSet<Controller>,
-    ) -> Result<()>;
+    fn create(&self, path: &Path) -> Result<()>;
+
+    fn attach_pid(&self, path: &Path, pid: i32) -> Result<()>;
+
+    fn enable_controllers(&self, root: &Path, controllers: &HashSet<Controller>) -> Result<()>;
 
     /// Cleanup the backend.
     fn cleanup(&self, path: &Path, root: &Path) -> Result<()>;
@@ -73,37 +71,6 @@ pub trait CgroupBackend: Send + Sync + 'static {
 pub struct SysFsBackend;
 
 impl SysFsBackend {
-    /// Enables a controller in `cgroup.subtree_control`.
-    ///
-    /// If the provided controller is already activated, then nothing happens.
-    fn activate_controller(root_path: &Path, controller: Controller) -> Result<()> {
-        debug!(
-            "Activating controller for root cgroup `{}`.",
-            root_path.display()
-        );
-        let subtree_control_path = root_path.join("cgroup.subtree_control");
-        fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
-            CgroupError::FailedToCreateController {
-                controller,
-                path: subtree_control_path,
-                source: err,
-            }
-        })?;
-        Ok(())
-    }
-
-    /// Attaches a process PID to the cgroup.
-    fn attach_pid(path: &Path, pid: i32) -> Result<()> {
-        let procs_path = path.join("cgroup.procs");
-        fs::write(&procs_path, pid.to_string()).map_err(|err| CgroupError::FailedToAttachPid {
-            pid,
-            path: procs_path,
-            source: err,
-        })?;
-        debug!("Attached PID {pid} to cgroup {}", path.display());
-        Ok(())
-    }
-
     /// Returns all PIDs attached to the cgroup.
     fn pids(path: &Path) -> Result<Vec<i32>> {
         debug!("Retrieving cgroup `{}` PIDs.", path.display());
@@ -118,23 +85,43 @@ impl SysFsBackend {
 
 impl CgroupBackend for SysFsBackend {
     /// Creates the cgroup directory on disk.
-    fn initialize(
-        &self,
-        path: &Path,
-        root: &Path,
-        pid: i32,
-        controllers: &HashSet<Controller>,
-    ) -> Result<()> {
+    fn create(&self, path: &Path) -> Result<()> {
         debug!("Initializing cgroup at \"{}\"", path.display());
-
         fs::create_dir_all(path)?;
+        Ok(())
+    }
 
+    /// Attaches a process PID to the cgroup.
+    fn attach_pid(&self, path: &Path, pid: i32) -> Result<()> {
+        let procs_path = path.join("cgroup.procs");
+        fs::write(&procs_path, pid.to_string()).map_err(|err| CgroupError::FailedToAttachPid {
+            pid,
+            path: procs_path,
+            source: err,
+        })?;
+        debug!("Attached PID {pid} to cgroup {}", path.display());
+        Ok(())
+    }
+
+    /// Enables the provided controllers in `cgroup.subtree_control`.
+    ///
+    /// If a controller is already activated, then nothing happens for it.
+    fn enable_controllers(&self, root: &Path, controllers: &HashSet<Controller>) -> Result<()> {
+        debug!("Enabling cgroup controllers {controllers:?}.");
+        let subtree_control_path = root.join("cgroup.subtree_control");
         for controller in controllers {
-            Self::activate_controller(root, *controller)?;
+            trace!(
+                "Activating controller for root cgroup `{}`.",
+                root.display()
+            );
+            fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
+                CgroupError::FailedToCreateController {
+                    controller: *controller,
+                    path: subtree_control_path.clone(),
+                    source: err,
+                }
+            })?;
         }
-
-        Self::attach_pid(path, pid)?;
-
         Ok(())
     }
 
@@ -250,6 +237,11 @@ impl<B: CgroupBackend> RootCgroup<B> {
     pub fn io(&self) -> Result<IoSnapshot> {
         self.backend.io(&self.path)
     }
+
+    /// Enables the provided controllers.
+    pub fn enable_controllers(&self, controllers: &HashSet<Controller>) -> Result<()> {
+        self.backend.enable_controllers(&self.path, controllers)
+    }
 }
 
 impl Default for RootCgroup {
@@ -295,9 +287,13 @@ impl<B: CgroupBackend> ChildCgroup<B> {
     }
 
     /// Initializes the cgroup backend.
-    pub fn initialize(&self, pid: i32, controllers: &HashSet<Controller>) -> Result<()> {
-        self.backend
-            .initialize(&self.path, &self.root, pid, controllers)
+    pub fn create(&self) -> Result<()> {
+        self.backend.create(&self.path)
+    }
+
+    /// Attaches a process PID to the cgroup.
+    pub fn attach_pid(&self, pid: i32) -> Result<()> {
+        self.backend.attach_pid(&self.path, pid)
     }
 
     /// Cleanup the cgroup backend.
@@ -330,11 +326,17 @@ mod tests {
             Ok(self.io.clone())
         }
 
-        fn initialize(
+        fn create(&self, _path: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        fn attach_pid(&self, _path: &Path, _pid: i32) -> Result<()> {
+            Ok(())
+        }
+
+        fn enable_controllers(
             &self,
-            _path: &Path,
             _root: &Path,
-            _pid: i32,
             _controllers: &HashSet<Controller>,
         ) -> Result<()> {
             Ok(())

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -1,19 +1,17 @@
 //! cgroup v2 management utilities.
 //!
 //! This module provides:
-//! - controller activation (`cpu`, `memory`, `io`);
 //! - child cgroup creation and cleanup;
 //! - process attachment to cgroups;
 //! - CPU, memory, and I/O statistics collection.
 
 use std::{
-    collections::HashSet,
-    fmt::Display,
     fs,
+    io::ErrorKind,
     path::{Path, PathBuf},
 };
 
-use log::{debug, trace, warn};
+use log::{debug, warn};
 
 use crate::{
     Result,
@@ -22,37 +20,13 @@ use crate::{
     util::{read_flat_keyed_file, read_io_stat, read_u64_opt},
 };
 
-/// Available cgroup v2 controllers.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub enum Controller {
-    /// I/O controller.
-    Io,
-
-    /// Memory controller.
-    Memory,
-
-    /// CPU controller.
-    Cpu,
-}
-
-impl Display for Controller {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Controller::Io => "io",
-            Controller::Memory => "memory",
-            Controller::Cpu => "cpu",
-        })
-    }
-}
-
 /// Interface for reading cgroup statistics.
 pub trait CgroupBackend: Send + Sync + 'static {
     /// Initializes the backend.
     fn create(&self, path: &Path) -> Result<()>;
 
+    /// Attaches the provided pid to the cgroup.
     fn attach_pid(&self, path: &Path, pid: i32) -> Result<()>;
-
-    fn enable_controllers(&self, root: &Path, controllers: &HashSet<Controller>) -> Result<()>;
 
     /// Cleanup the backend.
     fn cleanup(&self, path: &Path, root: &Path) -> Result<()>;
@@ -84,44 +58,32 @@ impl SysFsBackend {
 }
 
 impl CgroupBackend for SysFsBackend {
-    /// Creates the cgroup directory on disk.
+    /// Creates the cgroup directory.
     fn create(&self, path: &Path) -> Result<()> {
         debug!("Initializing cgroup at \"{}\"", path.display());
-        fs::create_dir_all(path)?;
+        fs::create_dir_all(path).map_err(|err| match err.kind() {
+            ErrorKind::PermissionDenied => {
+                CgroupError::PermissionDenied("creating a cgroup requires root privileges.")
+            }
+            _ => err.into(),
+        })?;
         Ok(())
     }
 
     /// Attaches a process PID to the cgroup.
     fn attach_pid(&self, path: &Path, pid: i32) -> Result<()> {
         let procs_path = path.join("cgroup.procs");
-        fs::write(&procs_path, pid.to_string()).map_err(|err| CgroupError::FailedToAttachPid {
-            pid,
-            path: procs_path,
-            source: err,
+        fs::write(&procs_path, pid.to_string()).map_err(|err| match err.kind() {
+            ErrorKind::PermissionDenied => CgroupError::PermissionDenied(
+                "attaching a process to this cgroup requires root privileges.",
+            ),
+            _ => CgroupError::FailedToAttachPid {
+                pid,
+                path: procs_path,
+                source: err,
+            },
         })?;
         debug!("Attached PID {pid} to cgroup {}", path.display());
-        Ok(())
-    }
-
-    /// Enables the provided controllers in `cgroup.subtree_control`.
-    ///
-    /// If a controller is already activated, then nothing happens for it.
-    fn enable_controllers(&self, root: &Path, controllers: &HashSet<Controller>) -> Result<()> {
-        debug!("Enabling cgroup controllers {controllers:?}.");
-        let subtree_control_path = root.join("cgroup.subtree_control");
-        for controller in controllers {
-            trace!(
-                "Activating controller for root cgroup `{}`.",
-                root.display()
-            );
-            fs::write(&subtree_control_path, format!("+{controller}")).map_err(|err| {
-                CgroupError::FailedToCreateController {
-                    controller: *controller,
-                    path: subtree_control_path.clone(),
-                    source: err,
-                }
-            })?;
-        }
         Ok(())
     }
 
@@ -150,7 +112,8 @@ impl CgroupBackend for SysFsBackend {
 
     /// Reads memory statistics from cgroup memory files.
     fn memory(&self, path: &Path) -> Result<MemorySnapshot> {
-        let mut stat = read_flat_keyed_file(&path.join("memory.stat"))?;
+        let mut stat = read_flat_keyed_file(&path.join("memory.stat"))
+            .map_err(|e| e.into_controller_error("memory", path))?;
         Ok(MemorySnapshot {
             current: read_u64_opt(&path.join("memory.current"))?,
             swap_current: read_u64_opt(&path.join("memory.swap.current"))?,
@@ -166,7 +129,8 @@ impl CgroupBackend for SysFsBackend {
 
     /// Reads CPU statistics from `cpu.stat`.
     fn cpu(&self, path: &Path) -> Result<CpuSnapshot> {
-        let mut stat = read_flat_keyed_file(&path.join("cpu.stat"))?;
+        let mut stat = read_flat_keyed_file(&path.join("cpu.stat"))
+            .map_err(|e| e.into_controller_error("cpu", path))?;
 
         Ok(CpuSnapshot {
             usage_usec: stat
@@ -188,7 +152,8 @@ impl CgroupBackend for SysFsBackend {
 
     /// Reads I/O statistics from `io.stat`.
     fn io(&self, path: &Path) -> Result<IoSnapshot> {
-        let (rbytes, wbytes) = read_io_stat(&path.join("io.stat"))?;
+        let (rbytes, wbytes) =
+            read_io_stat(&path.join("io.stat")).map_err(|e| e.into_controller_error("io", path))?;
         Ok(IoSnapshot { rbytes, wbytes })
     }
 }
@@ -236,11 +201,6 @@ impl<B: CgroupBackend> RootCgroup<B> {
     /// Get I/O stats.
     pub fn io(&self) -> Result<IoSnapshot> {
         self.backend.io(&self.path)
-    }
-
-    /// Enables the provided controllers.
-    pub fn enable_controllers(&self, controllers: &HashSet<Controller>) -> Result<()> {
-        self.backend.enable_controllers(&self.path, controllers)
     }
 }
 
@@ -331,14 +291,6 @@ mod tests {
         }
 
         fn attach_pid(&self, _path: &Path, _pid: i32) -> Result<()> {
-            Ok(())
-        }
-
-        fn enable_controllers(
-            &self,
-            _root: &Path,
-            _controllers: &HashSet<Controller>,
-        ) -> Result<()> {
             Ok(())
         }
 

--- a/sources/cgroup/src/config.rs
+++ b/sources/cgroup/src/config.rs
@@ -6,7 +6,7 @@ use crate::cgroup::Controller;
 #[derive(Debug, Clone)]
 pub struct CgroupConfig {
     /// Path to cgroup v2 hierarchy (usually `/sys/fs/cgroup`).
-    pub cgroup_root: PathBuf,
+    pub cgroup_root: Option<PathBuf>,
 
     /// Name of the created cgroup for the monitored process.
     pub cgroup_name: String,
@@ -21,7 +21,7 @@ pub struct CgroupConfig {
 impl Default for CgroupConfig {
     fn default() -> Self {
         Self {
-            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
+            cgroup_root: None,
             cgroup_name: format!("joule-profiler-{}", std::process::id()),
             poll_interval: None,
             controllers: vec![Controller::Io, Controller::Memory, Controller::Cpu]

--- a/sources/cgroup/src/config.rs
+++ b/sources/cgroup/src/config.rs
@@ -1,0 +1,32 @@
+use std::{collections::HashSet, path::PathBuf, time::Duration};
+
+use crate::cgroup::Controller;
+
+/// Configuration for the cgroup metric source.
+#[derive(Debug, Clone)]
+pub struct CgroupConfig {
+    /// Path to cgroup v2 hierarchy (usually `/sys/fs/cgroup`).
+    pub cgroup_root: PathBuf,
+
+    /// Name of the created cgroup for the monitored process.
+    pub cgroup_name: String,
+
+    /// Optional background polling interval.
+    pub poll_interval: Option<Duration>,
+
+    /// Enabled cgroup controllers (cpu, memory, io).
+    pub controllers: HashSet<Controller>,
+}
+
+impl Default for CgroupConfig {
+    fn default() -> Self {
+        Self {
+            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
+            cgroup_name: format!("joule-profiler-{}", std::process::id()),
+            poll_interval: None,
+            controllers: vec![Controller::Io, Controller::Memory, Controller::Cpu]
+                .into_iter()
+                .collect(),
+        }
+    }
+}

--- a/sources/cgroup/src/config.rs
+++ b/sources/cgroup/src/config.rs
@@ -16,6 +16,12 @@ pub struct CgroupConfig {
 
     /// Enabled cgroup controllers (cpu, memory, io).
     pub controllers: HashSet<Controller>,
+
+    /// Whether the source must attach the process pid to the cgroup or not.
+    pub attach_pid: bool,
+
+    /// Whether the cgroup is already created or if the source must create it itself.
+    pub create_cgroup: bool,
 }
 
 impl Default for CgroupConfig {
@@ -27,6 +33,8 @@ impl Default for CgroupConfig {
             controllers: vec![Controller::Io, Controller::Memory, Controller::Cpu]
                 .into_iter()
                 .collect(),
+            attach_pid: true,
+            create_cgroup: true,
         }
     }
 }

--- a/sources/cgroup/src/config.rs
+++ b/sources/cgroup/src/config.rs
@@ -1,6 +1,4 @@
-use std::{collections::HashSet, path::PathBuf, time::Duration};
-
-use crate::cgroup::Controller;
+use std::{path::PathBuf, time::Duration};
 
 /// Configuration for the cgroup metric source.
 #[derive(Debug, Clone)]
@@ -13,9 +11,6 @@ pub struct CgroupConfig {
 
     /// Optional background polling interval.
     pub poll_interval: Option<Duration>,
-
-    /// Enabled cgroup controllers (cpu, memory, io).
-    pub controllers: HashSet<Controller>,
 
     /// Whether the source must attach the process pid to the cgroup or not.
     pub attach_pid: bool,
@@ -30,9 +25,6 @@ impl Default for CgroupConfig {
             cgroup_root: None,
             cgroup_name: format!("joule-profiler-{}", std::process::id()),
             poll_interval: None,
-            controllers: vec![Controller::Io, Controller::Memory, Controller::Cpu]
-                .into_iter()
-                .collect(),
             attach_pid: true,
             create_cgroup: true,
         }

--- a/sources/cgroup/src/config.rs
+++ b/sources/cgroup/src/config.rs
@@ -9,8 +9,8 @@ pub struct CgroupConfig {
     /// Name of the created cgroup for the monitored process.
     pub cgroup_name: String,
 
-    /// Optional background polling interval.
-    pub poll_interval: Option<Duration>,
+    /// Background polling interval.
+    pub poll_interval: Duration,
 
     /// Whether the source must attach the process pid to the cgroup or not.
     pub attach_pid: bool,
@@ -24,7 +24,7 @@ impl Default for CgroupConfig {
         Self {
             cgroup_root: None,
             cgroup_name: format!("joule-profiler-{}", std::process::id()),
-            poll_interval: None,
+            poll_interval: Duration::from_millis(1),
             attach_pid: true,
             create_cgroup: true,
         }

--- a/sources/cgroup/src/counters.rs
+++ b/sources/cgroup/src/counters.rs
@@ -27,17 +27,26 @@ impl MinMax {
 
 /// Tracks the beginning and latest values of a cumulative counter for a phase.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct BeginEnd(u64, u64);
+pub struct BeginEnd(Option<u64>, Option<u64>);
 
 impl BeginEnd {
     /// Updates the latest counter value.
     pub fn update(&mut self, value: u64) {
-        self.1 = value;
+        if self.0.is_none() {
+            self.0 = Some(value);
+        }
+        self.1 = Some(value);
     }
 
     /// Returns the difference between end and begin values.
     pub fn diff(&self) -> u64 {
-        self.1.saturating_sub(self.0)
+        if let Some(begin) = self.0
+            && let Some(end) = self.1
+        {
+            end.saturating_sub(begin)
+        } else {
+            0
+        }
     }
 
     /// Starts a new measurement phase by setting begin to end.
@@ -248,4 +257,7 @@ pub struct Counters {
     pub global_cpu: CpuCounters,
 
     pub global_io: IoCounters,
+
+    pub begin_timestamp: u128,
+    pub end_timestamp: u128,
 }

--- a/sources/cgroup/src/counters.rs
+++ b/sources/cgroup/src/counters.rs
@@ -82,7 +82,7 @@ impl UpdateOpt for Option<MinMax> {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MemoryCounters {
-    pub current: MinMax,
+    pub current: Option<MinMax>,
     pub swap_current: Option<MinMax>,
     pub anon: Option<MinMax>,
     pub file: Option<MinMax>,
@@ -107,7 +107,7 @@ impl MemoryCounters {
     }
 
     pub fn reset(&mut self) {
-        self.current.reset();
+        self.current = None;
         self.swap_current = None;
         self.anon = None;
         self.file = None;
@@ -186,7 +186,11 @@ impl IoCounters {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Counters {
-    pub memory: MemoryCounters,
-    pub cpu: CpuCounters,
-    pub io: IoCounters,
+    pub proc_memory: MemoryCounters,
+    pub proc_cpu: CpuCounters,
+    pub proc_io: IoCounters,
+
+    pub global_memory: MemoryCounters,
+    pub global_cpu: CpuCounters,
+    pub global_io: IoCounters,
 }

--- a/sources/cgroup/src/counters.rs
+++ b/sources/cgroup/src/counters.rs
@@ -1,0 +1,192 @@
+use crate::snapshot::{CpuSnapshot, IoSnapshot, MemorySnapshot};
+
+/// A min/max accumulator for a single metric.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MinMax(Option<u64>, Option<u64>);
+
+impl MinMax {
+    /// Updates the min/max bounds with the provided value.
+    pub fn update(&mut self, value: u64) {
+        self.0 = Some(self.0.map_or(value, |m| m.min(value)));
+        self.1 = Some(self.1.map_or(value, |m| m.max(value)));
+    }
+
+    pub fn reset(&mut self) {
+        self.0 = None;
+        self.1 = None;
+    }
+
+    pub fn min(&self) -> Option<u64> {
+        self.0
+    }
+
+    pub fn max(&self) -> Option<u64> {
+        self.1
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BeginEnd(u64, u64);
+
+impl BeginEnd {
+    pub fn update(&mut self, value: u64) {
+        self.1 = value;
+    }
+
+    pub fn diff(&self) -> u64 {
+        self.1.saturating_sub(self.0)
+    }
+
+    pub fn new_phase(&mut self) {
+        self.0 = self.1;
+    }
+}
+
+trait NewPhase {
+    fn new_phase(&mut self);
+}
+
+impl NewPhase for BeginEnd {
+    fn new_phase(&mut self) {
+        self.0 = self.1;
+    }
+}
+
+impl NewPhase for Option<BeginEnd> {
+    fn new_phase(&mut self) {
+        if let Some(v) = self {
+            v.new_phase();
+        }
+    }
+}
+
+trait UpdateOpt {
+    fn update(&mut self, value: Option<u64>);
+}
+
+impl UpdateOpt for Option<BeginEnd> {
+    fn update(&mut self, value: Option<u64>) {
+        if let Some(v) = value {
+            self.get_or_insert_default().update(v);
+        }
+    }
+}
+
+impl UpdateOpt for Option<MinMax> {
+    fn update(&mut self, value: Option<u64>) {
+        if let Some(v) = value {
+            self.get_or_insert_default().update(v);
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemoryCounters {
+    pub current: MinMax,
+    pub swap_current: Option<MinMax>,
+    pub anon: Option<MinMax>,
+    pub file: Option<MinMax>,
+    pub peak: Option<MinMax>,
+    pub shmem: Option<MinMax>,
+    pub kernel: Option<MinMax>,
+    pub kernel_stack: Option<MinMax>,
+    pub slab: Option<MinMax>,
+}
+
+impl MemoryCounters {
+    pub fn update(&mut self, snapshot: &MemorySnapshot) {
+        self.current.update(snapshot.current);
+        self.swap_current.update(snapshot.swap_current);
+        self.anon.update(snapshot.anon);
+        self.file.update(snapshot.file);
+        self.peak.update(snapshot.peak);
+        self.shmem.update(snapshot.shmem);
+        self.kernel.update(snapshot.kernel);
+        self.kernel_stack.update(snapshot.kernel_stack);
+        self.slab.update(snapshot.slab);
+    }
+
+    pub fn reset(&mut self) {
+        self.current.reset();
+        self.swap_current = None;
+        self.anon = None;
+        self.file = None;
+        self.peak = None;
+        self.shmem = None;
+        self.kernel = None;
+        self.kernel_stack = None;
+        self.slab = None;
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CpuCounters {
+    pub usage_usec: BeginEnd,
+    pub user_usec: BeginEnd,
+    pub system_usec: BeginEnd,
+
+    pub nr_periods: Option<BeginEnd>,
+    pub nr_throttled: Option<BeginEnd>,
+    pub throttled_usec: Option<BeginEnd>,
+    pub nr_bursts: Option<BeginEnd>,
+    pub burst_usec: Option<BeginEnd>,
+}
+
+impl CpuCounters {
+    pub fn update(&mut self, snapshot: &CpuSnapshot) {
+        self.usage_usec.update(snapshot.usage_usec);
+        self.user_usec.update(snapshot.user_usec);
+        self.system_usec.update(snapshot.system_usec);
+        self.nr_periods.update(snapshot.nr_periods);
+        self.nr_throttled.update(snapshot.nr_throttled);
+        self.throttled_usec.update(snapshot.throttled_usec);
+        self.nr_bursts.update(snapshot.nr_bursts);
+        self.burst_usec.update(snapshot.burst_usec);
+    }
+
+    pub fn new_phase(&mut self) {
+        self.usage_usec.new_phase();
+        self.user_usec.new_phase();
+        self.system_usec.new_phase();
+        self.nr_periods.new_phase();
+        self.nr_throttled.new_phase();
+        self.throttled_usec.new_phase();
+        self.nr_bursts.new_phase();
+        self.burst_usec.new_phase();
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct IoCounters {
+    pub rbytes: Option<BeginEnd>,
+    pub wbytes: Option<BeginEnd>,
+}
+
+impl IoCounters {
+    pub fn update(&mut self, snapshot: &IoSnapshot) {
+        if let Some(v) = snapshot.rbytes {
+            self.rbytes.get_or_insert_default().update(v);
+        }
+
+        if let Some(v) = snapshot.wbytes {
+            self.wbytes.get_or_insert_default().update(v);
+        }
+    }
+
+    pub fn new_phase(&mut self) {
+        if let Some(v) = &mut self.rbytes {
+            v.new_phase();
+        }
+
+        if let Some(v) = &mut self.wbytes {
+            v.new_phase();
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Counters {
+    pub memory: MemoryCounters,
+    pub cpu: CpuCounters,
+    pub io: IoCounters,
+}

--- a/sources/cgroup/src/counters.rs
+++ b/sources/cgroup/src/counters.rs
@@ -25,24 +25,30 @@ impl MinMax {
     }
 }
 
+/// Tracks the beginning and latest values of a cumulative counter for a phase.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct BeginEnd(u64, u64);
 
 impl BeginEnd {
+    /// Updates the latest counter value.
     pub fn update(&mut self, value: u64) {
         self.1 = value;
     }
 
+    /// Returns the difference between end and begin values.
     pub fn diff(&self) -> u64 {
         self.1.saturating_sub(self.0)
     }
 
+    /// Starts a new measurement phase by setting begin to end.
     pub fn new_phase(&mut self) {
         self.0 = self.1;
     }
 }
 
+/// Internal trait for phase-based counters.
 trait NewPhase {
+    /// Starts a new measurement phase.
     fn new_phase(&mut self);
 }
 
@@ -60,7 +66,9 @@ impl NewPhase for Option<BeginEnd> {
     }
 }
 
+/// Internal trait for updating optional counters.
 trait UpdateOpt {
+    /// Updates the counter if a value is present.
     fn update(&mut self, value: Option<u64>);
 }
 
@@ -82,18 +90,36 @@ impl UpdateOpt for Option<MinMax> {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MemoryCounters {
+    /// Current memory usage.
     pub current: Option<MinMax>,
+
+    /// Current swap usage.
     pub swap_current: Option<MinMax>,
+
+    /// Anonymous memory usage (stack, heap, anon memory mappings).
     pub anon: Option<MinMax>,
+
+    /// File-backed memory usage.
     pub file: Option<MinMax>,
+
+    /// Peak memory usage.
     pub peak: Option<MinMax>,
+
+    /// Shared memory usage.
     pub shmem: Option<MinMax>,
+
+    /// Kernel memory usage.
     pub kernel: Option<MinMax>,
+
+    /// Kernel stack usage.
     pub kernel_stack: Option<MinMax>,
+
+    /// Slab allocator usage.
     pub slab: Option<MinMax>,
 }
 
 impl MemoryCounters {
+    /// Updates counters from a memory snapshot.
     pub fn update(&mut self, snapshot: &MemorySnapshot) {
         self.current.update(snapshot.current);
         self.swap_current.update(snapshot.swap_current);
@@ -106,6 +132,7 @@ impl MemoryCounters {
         self.slab.update(snapshot.slab);
     }
 
+    /// Resets all tracked memory metrics.
     pub fn reset(&mut self) {
         self.current = None;
         self.swap_current = None;
@@ -121,18 +148,33 @@ impl MemoryCounters {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CpuCounters {
+    /// Total CPU usage time.
     pub usage_usec: BeginEnd,
+
+    /// User-space CPU usage time.
     pub user_usec: BeginEnd,
+
+    /// Kernel-space CPU usage time.
     pub system_usec: BeginEnd,
 
+    /// Number of scheduler periods.
     pub nr_periods: Option<BeginEnd>,
+
+    /// Number of throttled periods.
     pub nr_throttled: Option<BeginEnd>,
+
+    /// Total throttled time.
     pub throttled_usec: Option<BeginEnd>,
+
+    /// Number of CPU bursts.
     pub nr_bursts: Option<BeginEnd>,
+
+    /// Total burst time.
     pub burst_usec: Option<BeginEnd>,
 }
 
 impl CpuCounters {
+    /// Updates counters from a CPU snapshot.
     pub fn update(&mut self, snapshot: &CpuSnapshot) {
         self.usage_usec.update(snapshot.usage_usec);
         self.user_usec.update(snapshot.user_usec);
@@ -144,6 +186,7 @@ impl CpuCounters {
         self.burst_usec.update(snapshot.burst_usec);
     }
 
+    /// Starts a new measurement phase.
     pub fn new_phase(&mut self) {
         self.usage_usec.new_phase();
         self.user_usec.new_phase();
@@ -158,11 +201,15 @@ impl CpuCounters {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct IoCounters {
+    /// Bytes read.
     pub rbytes: Option<BeginEnd>,
+
+    /// Bytes written.
     pub wbytes: Option<BeginEnd>,
 }
 
 impl IoCounters {
+    /// Updates counters from an I/O snapshot.
     pub fn update(&mut self, snapshot: &IoSnapshot) {
         if let Some(v) = snapshot.rbytes {
             self.rbytes.get_or_insert_default().update(v);
@@ -173,6 +220,7 @@ impl IoCounters {
         }
     }
 
+    /// Starts a new measurement phase.
     pub fn new_phase(&mut self) {
         if let Some(v) = &mut self.rbytes {
             v.new_phase();
@@ -184,13 +232,20 @@ impl IoCounters {
     }
 }
 
+/// Global application counters.
+///
+/// Stores both process-level and global system metrics.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Counters {
     pub proc_memory: MemoryCounters,
+
     pub proc_cpu: CpuCounters,
+
     pub proc_io: IoCounters,
 
     pub global_memory: MemoryCounters,
+
     pub global_cpu: CpuCounters,
+
     pub global_io: IoCounters,
 }

--- a/sources/cgroup/src/counters.rs
+++ b/sources/cgroup/src/counters.rs
@@ -259,5 +259,6 @@ pub struct Counters {
     pub global_io: IoCounters,
 
     pub begin_timestamp: u128,
+
     pub end_timestamp: u128,
 }

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -5,14 +5,18 @@ use tokio::task::JoinError;
 
 use crate::cgroup::Controller;
 
+/// Main error type for all cgroup-related operations.
 #[derive(Debug, Error)]
 pub enum CgroupError {
+    /// cgroup v2 is not available or not mounted as a unified hierarchy.
     #[error("CGroup v2 not available at `{0}` - is the unified hierarchy mounted?")]
     NotAvailable(String),
 
+    /// Attempted to create a cgroup that already exists.
     #[error("Cgroup with name \"{0}\" already created.")]
     AlreadyCreated(String),
 
+    /// Failed to enable a controller in `cgroup.subtree_control`.
     #[error("Failed to create controller `{controller}` on path `{path}`, cause: {source}")]
     FailedToCreateController {
         controller: Controller,
@@ -21,7 +25,8 @@ pub enum CgroupError {
         source: std::io::Error,
     },
 
-    #[error("Failed to attach pid `{pid}` to cgroup on path `{path}`, cause: {source}")]
+    /// Failed to attach a PID to a cgroup.
+    #[error("Failed to attach PID `{pid}` to cgroup on path `{path}`, cause: {source}")]
     FailedToAttachPid {
         pid: i32,
         path: PathBuf,
@@ -29,9 +34,11 @@ pub enum CgroupError {
         source: std::io::Error,
     },
 
+    /// A metric expected to always exist in kernel stats was missing.
     #[error("Missing always present metric `{0}`")]
     MissingAlwaysPresentMetric(&'static str),
 
+    /// Generic I/O error.
     #[error("I/O error")]
     Io(
         #[from]
@@ -39,6 +46,7 @@ pub enum CgroupError {
         std::io::Error,
     ),
 
+    /// I/O error tied to a specific file path.
     #[error("I/O error on `{path}`: {source}")]
     IoPath {
         path: PathBuf,
@@ -46,6 +54,7 @@ pub enum CgroupError {
         source: std::io::Error,
     },
 
+    /// Failed to parse a numeric value from a cgroup file.
     #[error("Failed to parse `{path}`: {source}")]
     Parse {
         path: PathBuf,
@@ -53,6 +62,7 @@ pub enum CgroupError {
         source: ParseIntError,
     },
 
+    /// Tokio task join error (async execution failure).
     #[error("Failed to join tokio task: {0}")]
     JoinError(
         #[from]

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -6,11 +6,18 @@ pub enum CgroupError {
     NotAvailable(String),
 
     #[error("I/O error on `{path}`: {source}")]
-    Io {
+    IoPath {
         path: String,
         #[source]
         source: std::io::Error,
     },
+
+    #[error("I/O error")]
+    Io(
+        #[from]
+        #[source]
+        std::io::Error,
+    ),
 
     #[error("Failed to parse `{path}`: expected {expected}, got `{got}`")]
     Parse {

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -1,16 +1,36 @@
+use std::{num::ParseIntError, path::PathBuf};
+
 use thiserror::Error;
+use tokio::task::JoinError;
+
+use crate::cgroup::Controller;
 
 #[derive(Debug, Error)]
 pub enum CgroupError {
-    #[error("CGroup v2 not available at `{0}` — is the unified hierarchy mounted?")]
+    #[error("CGroup v2 not available at `{0}` - is the unified hierarchy mounted?")]
     NotAvailable(String),
 
-    #[error("I/O error on `{path}`: {source}")]
-    IoPath {
-        path: String,
+    #[error("Cgroup with name \"{0}\" already created.")]
+    AlreadyCreated(String),
+
+    #[error("Failed to create controller `{controller}` on path `{path}`, cause: {source}")]
+    FailedToCreateController {
+        controller: Controller,
+        path: PathBuf,
         #[source]
         source: std::io::Error,
     },
+
+    #[error("Failed to attach pid `{pid}` to cgroup on path `{path}`, cause: {source}")]
+    FailedToAttachPid {
+        pid: i32,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Missing always present metric `{0}`")]
+    MissingAlwaysPresentMetric(&'static str),
 
     #[error("I/O error")]
     Io(
@@ -19,25 +39,24 @@ pub enum CgroupError {
         std::io::Error,
     ),
 
-    #[error("Failed to parse `{path}`: expected {expected}, got `{got}`")]
+    #[error("I/O error on `{path}`: {source}")]
+    IoPath {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to parse `{path}`: {source}")]
     Parse {
-        path: String,
-        expected: &'static str,
-        got: String,
+        path: PathBuf,
+        #[source]
+        source: ParseIntError,
     },
 
-    #[error("Failed to write PID {pid} to cgroup.procs: {source}")]
-    Attach {
-        pid: i32,
+    #[error("Failed to join tokio task: {0}")]
+    JoinError(
+        #[from]
         #[source]
-        source: std::io::Error,
-    },
-
-    #[error("Failed to enable cgroup controller `{controller}` in `{path}`: {source}")]
-    EnableController {
-        controller: &'static str,
-        path: String,
-        #[source]
-        source: std::io::Error,
-    },
+        JoinError,
+    ),
 }

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -1,0 +1,36 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CgroupError {
+    #[error("CGroup v2 not available at `{0}` — is the unified hierarchy mounted?")]
+    NotAvailable(String),
+
+    #[error("I/O error on `{path}`: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to parse `{path}`: expected {expected}, got `{got}`")]
+    Parse {
+        path: String,
+        expected: &'static str,
+        got: String,
+    },
+
+    #[error("Failed to write PID {pid} to cgroup.procs: {source}")]
+    Attach {
+        pid: i32,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to enable cgroup controller `{controller}` in `{path}`: {source}")]
+    EnableController {
+        controller: &'static str,
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -79,15 +79,14 @@ pub enum CgroupError {
 
 impl CgroupError {
     pub(crate) fn into_controller_error(self, controller: &'static str, cgroup: &Path) -> Self {
-        if let CgroupError::IoPath { ref source, .. } = self {
-            if source.kind() == ErrorKind::NotFound {
-                if let Some(parent) = cgroup.parent() {
-                    return CgroupError::ControllerNotEnabled {
-                        controller,
-                        path: parent.to_path_buf(),
-                    };
-                }
-            }
+        if let CgroupError::IoPath { ref source, .. } = self
+            && source.kind() == ErrorKind::NotFound
+            && let Some(parent) = cgroup.parent()
+        {
+            return CgroupError::ControllerNotEnabled {
+                controller,
+                path: parent.to_path_buf(),
+            };
         }
         self
     }

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -1,37 +1,40 @@
-use std::{num::ParseIntError, path::PathBuf};
+use std::{
+    io::ErrorKind,
+    num::ParseIntError,
+    path::{Path, PathBuf},
+};
 
 use thiserror::Error;
 use tokio::task::JoinError;
-
-use crate::cgroup::Controller;
 
 /// Main error type for all cgroup-related operations.
 #[derive(Debug, Error)]
 pub enum CgroupError {
     /// cgroup v2 is not available or not mounted as a unified hierarchy.
-    #[error("CGroup v2 not available at `{0}` - is the unified hierarchy mounted?")]
+    #[error("Cgroup v2 not available at `{0}`. Check if the unified hierarchy is mounted.")]
     NotAvailable(String),
 
     /// Attempted to create a cgroup that already exists.
     #[error("Cgroup with name \"{0}\" already created.")]
     AlreadyCreated(String),
 
-    /// Failed to enable a controller in `cgroup.subtree_control`.
-    #[error("Failed to create controller `{controller}` on path `{path}`, cause: {source}")]
-    FailedToCreateController {
-        controller: Controller,
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-
     /// Failed to attach a PID to a cgroup.
-    #[error("Failed to attach PID `{pid}` to cgroup on path `{path}`, cause: {source}")]
+    #[error("Failed to attach PID `{pid}` to cgroup on path `{path}`. Cause: {source}")]
     FailedToAttachPid {
         pid: i32,
         path: PathBuf,
         #[source]
         source: std::io::Error,
+    },
+
+    /// A cgroup controller is not enabled in `cgroup.subtree_control`.
+    #[error(
+        "Cgroup controller `{controller}` is not enabled for the parent cgroup. \
+        Enable it with: echo \"+{controller}\" | sudo tee {path}/cgroup.subtree_control"
+    )]
+    ControllerNotEnabled {
+        controller: &'static str,
+        path: PathBuf,
     },
 
     /// A metric expected to always exist in kernel stats was missing.
@@ -62,6 +65,9 @@ pub enum CgroupError {
         source: ParseIntError,
     },
 
+    #[error("Permission denied. Cause: {0}")]
+    PermissionDenied(&'static str),
+
     /// Tokio task join error (async execution failure).
     #[error("Failed to join tokio task: {0}")]
     JoinError(
@@ -69,4 +75,20 @@ pub enum CgroupError {
         #[source]
         JoinError,
     ),
+}
+
+impl CgroupError {
+    pub(crate) fn into_controller_error(self, controller: &'static str, cgroup: &Path) -> Self {
+        if let CgroupError::IoPath { ref source, .. } = self {
+            if source.kind() == ErrorKind::NotFound {
+                if let Some(parent) = cgroup.parent() {
+                    return CgroupError::ControllerNotEnabled {
+                        controller,
+                        path: parent.to_path_buf(),
+                    };
+                }
+            }
+        }
+        self
+    }
 }

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -13,7 +13,7 @@ use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 use tokio_util::sync::CancellationToken;
 
-use crate::cgroup::{Cgroup, Controller};
+use crate::cgroup::{Cgroup, Controller, RootCgroup, StatsReader};
 use crate::counters::{Counters, CpuCounters, IoCounters, MemoryCounters};
 use crate::error::CgroupError;
 
@@ -67,32 +67,40 @@ impl Default for CgroupConfig {
 pub struct CgroupSource {
     config: CgroupConfig,
     handle: Option<WorkerHandle>,
-    cgroup: Arc<Cgroup>,
-    shared_memory_counters: Arc<Mutex<MemoryCounters>>,
-    cpu_counters: CpuCounters,
-    io_counters: IoCounters,
+    proc_cgroup: Arc<Cgroup>,
+    root_cgroup: Arc<RootCgroup>,
+    proc_memory_counters: Arc<Mutex<MemoryCounters>>,
+    global_memory_counters: Arc<Mutex<MemoryCounters>>,
+    proc_cpu_counters: CpuCounters,
+    global_cpu_counters: CpuCounters,
+    proc_io_counters: IoCounters,
+    global_io_counters: IoCounters,
 }
 
 impl CgroupSource {
     pub fn new(config: CgroupConfig) -> Result<Self> {
-        let cgroup = Arc::new(Cgroup::new(
-            config.cgroup_root.clone(),
-            &config.cgroup_name,
-        )?);
+        let root_cgroup = Arc::new(RootCgroup::new(config.cgroup_root.clone()));
+        let proc_cgroup = Arc::new(root_cgroup.child(&config.cgroup_name));
 
         Ok(Self {
             config,
             handle: None,
-            cgroup,
-            shared_memory_counters: Arc::default(),
-            cpu_counters: CpuCounters::default(),
-            io_counters: IoCounters::default(),
+            root_cgroup,
+            proc_cgroup,
+            proc_memory_counters: Arc::default(),
+            global_memory_counters: Arc::default(),
+            proc_cpu_counters: CpuCounters::default(),
+            global_cpu_counters: CpuCounters::default(),
+            proc_io_counters: IoCounters::default(),
+            global_io_counters: IoCounters::default(),
         })
     }
 
     pub fn create_worker(
-        cgroup: Arc<Cgroup>,
-        shared_memory_counters: Arc<Mutex<MemoryCounters>>,
+        root_cgroup: Arc<RootCgroup>,
+        proc_cgroup: Arc<Cgroup>,
+        proc_memory_counters: Arc<Mutex<MemoryCounters>>,
+        global_memory_counters: Arc<Mutex<MemoryCounters>>,
         poll_interval: Duration,
     ) -> Result<WorkerHandle> {
         let mut ticker = Interval::new_interval(poll_interval)?;
@@ -107,9 +115,16 @@ impl CgroupSource {
                 tokio::select! {
                     _ = ticker.next() => {
                         trace!("Polled cgroup source.");
-                        let memory_snapshot = cgroup.read_memory()?;
-                        let mut lock = shared_memory_counters.lock().await;
-                        lock.update(&memory_snapshot);
+                        {
+                            let snapshot = proc_cgroup.stats().memory()?;
+                            let mut lock = proc_memory_counters.lock().await;
+                            lock.update(&snapshot);
+                        }
+                        {
+                            let snapshot = root_cgroup.stats().memory()?;
+                            let mut lock = global_memory_counters.lock().await;
+                            lock.update(&snapshot);
+                        }
                     }
 
                     () = cancellation_token.cancelled() => {
@@ -131,17 +146,19 @@ impl MetricReader for CgroupSource {
     type Error = CgroupError;
 
     async fn init(&mut self, pid: i32) -> Result<()> {
-        self.cgroup.initialize_cgroup()?;
+        self.proc_cgroup.initialize()?;
         for controller in &self.config.controllers {
-            self.cgroup.activate_controller(*controller)?;
+            self.root_cgroup.activate_controller(*controller)?;
         }
 
-        self.cgroup.attach_pid(pid)?;
+        self.proc_cgroup.attach_pid(pid)?;
 
         if let Some(poll_interval) = self.config.poll_interval {
             self.handle = Some(Self::create_worker(
-                self.cgroup.clone(),
-                self.shared_memory_counters.clone(),
+                self.root_cgroup.clone(),
+                self.proc_cgroup.clone(),
+                self.proc_memory_counters.clone(),
+                self.global_memory_counters.clone(),
                 poll_interval,
             )?);
         }
@@ -151,35 +168,64 @@ impl MetricReader for CgroupSource {
     }
 
     async fn measure(&mut self) -> Result<()> {
-        let memory_snapshot = self.cgroup.read_memory()?;
         {
-            let mut lock = self.shared_memory_counters.lock().await;
-            lock.update(&memory_snapshot);
+            let snapshot = self.proc_cgroup.stats().memory()?;
+            let mut lock = self.proc_memory_counters.lock().await;
+            lock.update(&snapshot);
         }
-        let cpu_snapshot = self.cgroup.read_cpu()?;
-        self.cpu_counters.update(&cpu_snapshot);
+        self.proc_cpu_counters
+            .update(&self.proc_cgroup.stats().cpu()?);
+        self.proc_io_counters
+            .update(&self.proc_cgroup.stats().io()?);
 
-        let io_snapshot = self.cgroup.read_io()?;
-        self.io_counters.update(&io_snapshot);
+        {
+            let snapshot = self.root_cgroup.stats().memory()?;
+            let mut lock = self.global_memory_counters.lock().await;
+            lock.update(&snapshot);
+        }
+        self.global_cpu_counters
+            .update(&self.root_cgroup.stats().cpu()?);
+        self.global_io_counters
+            .update(&self.root_cgroup.stats().io()?);
 
         Ok(())
     }
 
     async fn retrieve(&mut self) -> Result<Self::Type> {
-        let memory = {
-            let mut lock = self.shared_memory_counters.lock().await;
-            let memory_counters = *lock;
+        let proc_memory = {
+            let mut lock = self.proc_memory_counters.lock().await;
+            let counters = *lock;
             lock.reset();
-            memory_counters
+            counters
         };
 
-        let cpu = self.cpu_counters;
-        self.cpu_counters.new_phase();
+        let proc_cpu = self.proc_cpu_counters;
+        self.proc_cpu_counters.new_phase();
 
-        let io = self.io_counters;
-        self.io_counters.new_phase();
+        let proc_io = self.proc_io_counters;
+        self.proc_io_counters.new_phase();
 
-        Ok(Counters { memory, cpu, io })
+        let global_memory = {
+            let mut lock = self.global_memory_counters.lock().await;
+            let counters = *lock;
+            lock.reset();
+            counters
+        };
+
+        let global_cpu = self.global_cpu_counters;
+        self.global_cpu_counters.new_phase();
+
+        let global_io = self.global_io_counters;
+        self.global_io_counters.new_phase();
+
+        Ok(Counters {
+            proc_memory,
+            proc_cpu,
+            proc_io,
+            global_memory,
+            global_cpu,
+            global_io,
+        })
     }
 
     async fn join(&mut self) -> Result<()> {
@@ -187,7 +233,7 @@ impl MetricReader for CgroupSource {
             cancellation_token.cancel();
             handle.await??;
         }
-        self.cgroup.cleanup()?;
+        self.proc_cgroup.cleanup()?;
         Ok(())
     }
 
@@ -223,92 +269,114 @@ impl MetricReader for CgroupSource {
     }
 
     fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
-        macro_rules! push {
-            ($metrics:expr, $name:expr, $value:expr, $unit:expr) => {
-                $metrics.push(Metric::new($name, $value, $unit, Self::get_name()));
-            };
-        }
-
-        macro_rules! push_minmax {
-            ($metrics:expr, $field:expr, $name:expr, $unit:expr) => {
-                if let Some(mm) = $field {
-                    push!(
-                        $metrics,
-                        concat!($name, "_min"),
-                        mm.min().unwrap_or_default(),
-                        $unit
-                    );
-                    push!(
-                        $metrics,
-                        concat!($name, "_max"),
-                        mm.max().unwrap_or_default(),
-                        $unit
-                    );
-                }
-            };
-        }
-
-        macro_rules! push_begin_end {
-            ($metrics:expr, $field:expr, $name:expr, $unit:expr) => {
-                if let Some(be) = $field {
-                    push!($metrics, $name, be.diff(), $unit);
-                }
-            };
-        }
-
-        let mut metrics = Vec::new();
-        let m = counters.memory;
-
-        push_minmax!(metrics, m.anon, "anon", BYTE_UNIT);
-        push_minmax!(metrics, m.file, "file", BYTE_UNIT);
-        push_minmax!(metrics, m.kernel, "kernel", BYTE_UNIT);
-        push_minmax!(metrics, m.kernel_stack, "kernel_stack", BYTE_UNIT);
-        push_minmax!(metrics, m.peak, "peak", BYTE_UNIT);
-        push_minmax!(metrics, m.shmem, "shmem", BYTE_UNIT);
-        push_minmax!(metrics, m.slab, "slab", BYTE_UNIT);
-        push_minmax!(metrics, m.swap_current, "swap_current", BYTE_UNIT);
-
-        let cpu = counters.cpu;
-
-        push!(
-            metrics,
-            "usage_usec",
-            cpu.usage_usec.diff(),
-            MICRO_SECOND_UNIT
-        );
-        push!(
-            metrics,
-            "user_usec",
-            cpu.user_usec.diff(),
-            MICRO_SECOND_UNIT
-        );
-        push!(
-            metrics,
-            "system_usec",
-            cpu.system_usec.diff(),
-            MICRO_SECOND_UNIT
-        );
-
-        push_begin_end!(metrics, cpu.nr_periods, "nr_periods", COUNT_UNIT);
-        push_begin_end!(metrics, cpu.nr_throttled, "nr_throttled", COUNT_UNIT);
-        push_begin_end!(
-            metrics,
-            cpu.throttled_usec,
-            "throttled_usec",
-            MICRO_SECOND_UNIT
-        );
-        push_begin_end!(metrics, cpu.nr_bursts, "nr_bursts", COUNT_UNIT);
-        push_begin_end!(metrics, cpu.burst_usec, "burst_usec", MICRO_SECOND_UNIT);
-
-        let io = counters.io;
-
-        push_begin_end!(metrics, io.rbytes, "read_bytes", BYTE_UNIT);
-        push_begin_end!(metrics, io.wbytes, "write_bytes", BYTE_UNIT);
-
-        Ok(metrics)
+        Ok(to_metrics(
+            &counters.proc_memory,
+            &counters.proc_cpu,
+            &counters.proc_io,
+            "proc",
+        )
+        .into_iter()
+        .chain(to_metrics(
+            &counters.global_memory,
+            &counters.global_cpu,
+            &counters.global_io,
+            "global",
+        ))
+        .collect())
     }
 
     fn get_name() -> &'static str {
         SOURCE_NAME
     }
+}
+
+fn to_metrics(
+    memory: &MemoryCounters,
+    cpu: &CpuCounters,
+    io: &IoCounters,
+    prefix: &str,
+) -> Metrics {
+    macro_rules! push {
+        ($metrics:expr, $name:expr, $value:expr, $unit:expr) => {
+            $metrics.push(Metric::new(
+                format!("{prefix}_{}", $name),
+                $value,
+                $unit,
+                CgroupSource::get_name(),
+            ));
+        };
+    }
+
+    macro_rules! push_minmax {
+        ($metrics:expr, $field:expr, $name:expr, $unit:expr) => {
+            if let Some(mm) = $field {
+                push!(
+                    $metrics,
+                    concat!($name, "_min"),
+                    mm.min().unwrap_or_default(),
+                    $unit
+                );
+                push!(
+                    $metrics,
+                    concat!($name, "_max"),
+                    mm.max().unwrap_or_default(),
+                    $unit
+                );
+            }
+        };
+    }
+
+    macro_rules! push_begin_end {
+        ($metrics:expr, $field:expr, $name:expr, $unit:expr) => {
+            if let Some(be) = $field {
+                push!($metrics, $name, be.diff(), $unit);
+            }
+        };
+    }
+
+    let mut metrics = Vec::new();
+
+    push_minmax!(metrics, memory.anon, "anon", BYTE_UNIT);
+    push_minmax!(metrics, memory.file, "file", BYTE_UNIT);
+    push_minmax!(metrics, memory.kernel, "kernel", BYTE_UNIT);
+    push_minmax!(metrics, memory.kernel_stack, "kernel_stack", BYTE_UNIT);
+    push_minmax!(metrics, memory.peak, "peak", BYTE_UNIT);
+    push_minmax!(metrics, memory.shmem, "shmem", BYTE_UNIT);
+    push_minmax!(metrics, memory.slab, "slab", BYTE_UNIT);
+    push_minmax!(metrics, memory.swap_current, "swap_current", BYTE_UNIT);
+
+    push!(
+        metrics,
+        "usage_usec",
+        cpu.usage_usec.diff(),
+        MICRO_SECOND_UNIT
+    );
+    push!(
+        metrics,
+        "user_usec",
+        cpu.user_usec.diff(),
+        MICRO_SECOND_UNIT
+    );
+    push!(
+        metrics,
+        "system_usec",
+        cpu.system_usec.diff(),
+        MICRO_SECOND_UNIT
+    );
+
+    push_begin_end!(metrics, cpu.nr_periods, "nr_periods", COUNT_UNIT);
+    push_begin_end!(metrics, cpu.nr_throttled, "nr_throttled", COUNT_UNIT);
+    push_begin_end!(
+        metrics,
+        cpu.throttled_usec,
+        "throttled_usec",
+        MICRO_SECOND_UNIT
+    );
+    push_begin_end!(metrics, cpu.nr_bursts, "nr_bursts", COUNT_UNIT);
+    push_begin_end!(metrics, cpu.burst_usec, "burst_usec", MICRO_SECOND_UNIT);
+
+    push_begin_end!(metrics, io.rbytes, "read_bytes", BYTE_UNIT);
+    push_begin_end!(metrics, io.wbytes, "write_bytes", BYTE_UNIT);
+
+    metrics
 }

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -1,13 +1,19 @@
-use std::fs;
-use std::path::PathBuf;
-use log::{debug, trace, warn};
+use crate::error::CgroupError;
+use crate::snapshot::Snapshot;
+use crate::util::{read_flat_keyed, read_io_stat, read_u64_opt};
+use futures::StreamExt;
 use joule_profiler_core::sensor::{Sensor, Sensors};
 use joule_profiler_core::source::MetricReader;
 use joule_profiler_core::types::{Metric, Metrics};
 use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
-use crate::error::CgroupError;
-use crate::snapshot::Snapshot;
-use crate::util::{read_flat_keyed, read_io_stat, read_u64_opt};
+use log::{debug, trace, warn};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_timerfd::Interval;
 
 mod error;
 mod snapshot;
@@ -30,11 +36,11 @@ const COUNT_UNIT: MetricUnit = MetricUnit {
     unit: Unit::Count,
 };
 
-
 #[derive(Debug, Clone)]
 pub struct CgroupConfig {
     pub cgroup_root: PathBuf,
     pub cgroup_name: String,
+    pub poll_interval: Option<Duration>,
 }
 
 impl Default for CgroupConfig {
@@ -42,6 +48,7 @@ impl Default for CgroupConfig {
         Self {
             cgroup_root: PathBuf::from("/sys/fs/cgroup"),
             cgroup_name: format!("joule-profiler-{}", std::process::id()),
+            poll_interval: None,
         }
     }
 }
@@ -49,7 +56,9 @@ impl Default for CgroupConfig {
 pub struct CgroupSource {
     config: CgroupConfig,
     cgroup_path: PathBuf,
-    last_snapshot: Snapshot,
+    shared_snapshot: Arc<Mutex<Snapshot>>,
+    handle: Option<JoinHandle<Result<(), CgroupError>>>,
+    last_ponctual: Snapshot,
 }
 
 impl CgroupSource {
@@ -63,7 +72,13 @@ impl CgroupSource {
 
         let cgroup_path = config.cgroup_root.join(&config.cgroup_name);
 
-        Ok(Self {config, cgroup_path,last_snapshot: Snapshot::default()})
+        Ok(Self {
+            config,
+            cgroup_path,
+            shared_snapshot: Arc::new(Mutex::new(Snapshot::default())),
+            handle: None,
+            last_ponctual: Snapshot::default(),
+        })
     }
 
     pub fn try_default() -> Result<Self, CgroupError> {
@@ -72,7 +87,7 @@ impl CgroupSource {
 
     fn create_and_enable_controllers(&self) -> Result<(), CgroupError> {
         if !self.cgroup_path.exists() {
-            fs::create_dir_all(&self.cgroup_path).map_err(|e| CgroupError::Io {
+            fs::create_dir_all(&self.cgroup_path).map_err(|e| CgroupError::IoPath {
                 path: self.cgroup_path.display().to_string(),
                 source: e,
             })?;
@@ -102,10 +117,10 @@ impl CgroupSource {
         Ok(())
     }
 
-
     fn attach_pid(&self, pid: i32) -> Result<(), CgroupError> {
         let procs_path = self.cgroup_path.join("cgroup.procs");
-        fs::write(&procs_path, pid.to_string()).map_err(|e| CgroupError::Attach { pid, source: e })?;
+        fs::write(&procs_path, pid.to_string())
+            .map_err(|e| CgroupError::Attach { pid, source: e })?;
         debug!(
             "Attached PID {pid} to cgroup {}",
             self.cgroup_path.display()
@@ -146,25 +161,39 @@ impl CgroupSource {
         }
     }
 
-    fn snapshot(&self) -> Snapshot {
+    fn read_memory_fields(cgroup_path: &Path) -> (u64, u64, u64, u64) {
+        let memory_current = read_u64_opt(&cgroup_path.join("memory.current"))
+            .ok()
+            .flatten()
+            .unwrap_or(0);
+
+        let memory_swap_current = read_u64_opt(&cgroup_path.join("memory.swap.current"))
+            .ok()
+            .flatten()
+            .unwrap_or(0);
+
+        let (memory_anon, memory_file) =
+            if let Ok(stat) = read_flat_keyed(&cgroup_path.join("memory.stat")) {
+                (
+                    stat.get("anon").copied().unwrap_or(0),
+                    stat.get("file").copied().unwrap_or(0),
+                )
+            } else {
+                (0, 0)
+            };
+
+        (
+            memory_current,
+            memory_anon,
+            memory_file,
+            memory_swap_current,
+        )
+    }
+
+    fn read_not_polled_fields(&self) -> Snapshot {
         let mut snap = Snapshot::default();
 
-        snap.memory_current = read_u64_opt(&self.cgroup_path.join("memory.current"))
-            .ok()
-            .flatten();
-
-        snap.memory_peak = read_u64_opt(&self.cgroup_path.join("memory.peak"))
-            .ok()
-            .flatten();
-
-        snap.memory_swap_current =
-            read_u64_opt(&self.cgroup_path.join("memory.swap.current"))
-                .ok()
-                .flatten();
-
         if let Ok(stat) = read_flat_keyed(&self.cgroup_path.join("memory.stat")) {
-            snap.memory_anon = stat.get("anon").copied();
-            snap.memory_file = stat.get("file").copied();
             snap.memory_kernel_stack = stat.get("kernel_stack").copied();
             snap.memory_slab = stat.get("slab").copied();
         }
@@ -182,6 +211,11 @@ impl CgroupSource {
             snap.io_rbytes = Some(rb);
             snap.io_wbytes = Some(wb);
         }
+
+        snap.memory_peak = read_u64_opt(&self.cgroup_path.join("memory.peak"))
+            .ok()
+            .flatten();
+
         snap
     }
 }
@@ -193,41 +227,118 @@ impl MetricReader for CgroupSource {
     async fn init(&mut self, pid: i32) -> Result<(), Self::Error> {
         self.create_and_enable_controllers()?;
         self.attach_pid(pid)?;
+
+        if let Some(interval) = self.config.poll_interval {
+            let shared = self.shared_snapshot.clone();
+            let cgroup_path = self.cgroup_path.clone();
+
+            let handle = tokio::spawn(async move {
+                debug!("Starting cgroup memory polling.");
+                let mut ticker = Interval::new_interval(interval)?;
+
+                loop {
+                    ticker.next().await;
+
+                    let (memory_current, memory_anon, memory_file, memory_swap_current) =
+                        CgroupSource::read_memory_fields(&cgroup_path);
+
+                    trace!(
+                        "cgroup poll — current:{memory_current} anon:{memory_anon} \
+                         file:{memory_file} swap:{memory_swap_current}"
+                    );
+
+                    let mut snap = shared.lock().await;
+                    snap.update(
+                        memory_current,
+                        memory_anon,
+                        memory_file,
+                        memory_swap_current,
+                    );
+                }
+            });
+
+            self.handle = Some(handle);
+        }
+
         debug!("CgroupSource initialised for PID {pid}");
         Ok(())
     }
 
     async fn join(&mut self) -> Result<(), Self::Error> {
+        if let Some(handle) = self.handle.take() {
+            if handle.is_finished() {
+                if let Ok(res) = handle.await {
+                    return res;
+                }
+            } else {
+                handle.abort();
+            }
+        }
         self.cleanup();
         Ok(())
     }
 
     async fn measure(&mut self) -> Result<(), Self::Error> {
-        self.last_snapshot = self.snapshot();
+        if self.config.poll_interval.is_none() {
+            let (memory_current, memory_anon, memory_file, memory_swap_current) =
+                CgroupSource::read_memory_fields(&self.cgroup_path);
+            let mut snap = self.shared_snapshot.lock().await;
+            snap.update(
+                memory_current,
+                memory_anon,
+                memory_file,
+                memory_swap_current,
+            );
+        }
+
+        self.last_ponctual = self.read_not_polled_fields();
         Ok(())
     }
 
     async fn retrieve(&mut self) -> Result<Self::Type, Self::Error> {
-        Ok(std::mem::take(&mut self.last_snapshot))
+        let mut shared = self.shared_snapshot.lock().await;
+        shared.remove_sentinel_values();
+
+        let mut snap = shared.clone();
+        shared.reset_phase();
+        drop(shared);
+
+        snap.memory_peak = self.last_ponctual.memory_peak;
+        snap.memory_kernel_stack = self.last_ponctual.memory_kernel_stack;
+        snap.memory_slab = self.last_ponctual.memory_slab;
+        snap.cpu_usage_usec = self.last_ponctual.cpu_usage_usec;
+        snap.cpu_user_usec = self.last_ponctual.cpu_user_usec;
+        snap.cpu_system_usec = self.last_ponctual.cpu_system_usec;
+        snap.cpu_nr_periods = self.last_ponctual.cpu_nr_periods;
+        snap.cpu_nr_throttled = self.last_ponctual.cpu_nr_throttled;
+        snap.cpu_throttled_usec = self.last_ponctual.cpu_throttled_usec;
+        snap.io_rbytes = self.last_ponctual.io_rbytes;
+        snap.io_wbytes = self.last_ponctual.io_wbytes;
+
+        Ok(snap)
     }
 
     fn get_sensors(&self) -> Result<Sensors, Self::Error> {
         let sensors = vec![
-            Sensor::new("memory_current",      BYTE_UNIT,         Self::get_name()),
-            Sensor::new("memory_peak",         BYTE_UNIT,         Self::get_name()),
-            Sensor::new("memory_anon",         BYTE_UNIT,         Self::get_name()),
-            Sensor::new("memory_file",         BYTE_UNIT,         Self::get_name()),
-            Sensor::new("memory_kernel_stack", BYTE_UNIT,         Self::get_name()),
-            Sensor::new("memory_slab",         BYTE_UNIT,         Self::get_name()),
-            Sensor::new("memory_swap_current", BYTE_UNIT,         Self::get_name()),
-            Sensor::new("cpu_usage_usec",      MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("cpu_user_usec",       MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("cpu_system_usec",     MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("cpu_nr_periods",      COUNT_UNIT,        Self::get_name()),
-            Sensor::new("cpu_nr_throttled",    COUNT_UNIT,        Self::get_name()),
-            Sensor::new("cpu_throttled_usec",  MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("io_rbytes",           BYTE_UNIT,         Self::get_name()),
-            Sensor::new("io_wbytes",           BYTE_UNIT,         Self::get_name()),
+            Sensor::new("memory_current_min", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_current_max", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_anon_min", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_anon_max", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_file_min", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_file_max", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_swap_current_min", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_swap_current_max", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_peak", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_kernel_stack", BYTE_UNIT, Self::get_name()),
+            Sensor::new("memory_slab", BYTE_UNIT, Self::get_name()),
+            Sensor::new("cpu_usage_usec", MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("cpu_user_usec", MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("cpu_system_usec", MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("cpu_nr_periods", COUNT_UNIT, Self::get_name()),
+            Sensor::new("cpu_nr_throttled", COUNT_UNIT, Self::get_name()),
+            Sensor::new("cpu_throttled_usec", MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("io_rbytes", BYTE_UNIT, Self::get_name()),
+            Sensor::new("io_wbytes", BYTE_UNIT, Self::get_name()),
         ];
         Ok(sensors)
     }
@@ -241,27 +352,37 @@ impl MetricReader for CgroupSource {
                     metrics.push(Metric::new($name, v, $unit, Self::get_name()));
                 }
             };
+            (direct $field:expr, $name:expr, $unit:expr) => {
+                metrics.push(Metric::new($name, $field, $unit, Self::get_name()));
+            };
         }
 
-        push!(snap.memory_current,      "memory_current",      BYTE_UNIT);
-        push!(snap.memory_peak,         "memory_peak",         BYTE_UNIT);
-        push!(snap.memory_anon,         "memory_anon",         BYTE_UNIT);
-        push!(snap.memory_file,         "memory_file",         BYTE_UNIT);
+        push!(direct snap.memory_current_min,      "memory_current_min",      BYTE_UNIT);
+        push!(direct snap.memory_current_max,      "memory_current_max",      BYTE_UNIT);
+        push!(direct snap.memory_anon_min,         "memory_anon_min",         BYTE_UNIT);
+        push!(direct snap.memory_anon_max,         "memory_anon_max",         BYTE_UNIT);
+        push!(direct snap.memory_file_min,         "memory_file_min",         BYTE_UNIT);
+        push!(direct snap.memory_file_max,         "memory_file_max",         BYTE_UNIT);
+        push!(direct snap.memory_swap_current_min, "memory_swap_current_min", BYTE_UNIT);
+        push!(direct snap.memory_swap_current_max, "memory_swap_current_max", BYTE_UNIT);
+        push!(snap.memory_peak, "memory_peak", BYTE_UNIT);
         push!(snap.memory_kernel_stack, "memory_kernel_stack", BYTE_UNIT);
-        push!(snap.memory_slab,         "memory_slab",         BYTE_UNIT);
-        push!(snap.memory_swap_current, "memory_swap_current", BYTE_UNIT);
-        push!(snap.cpu_usage_usec,      "cpu_usage_usec",      MICRO_SECOND_UNIT);
-        push!(snap.cpu_user_usec,       "cpu_user_usec",       MICRO_SECOND_UNIT);
-        push!(snap.cpu_system_usec,     "cpu_system_usec",     MICRO_SECOND_UNIT);
-        push!(snap.cpu_nr_periods,      "cpu_nr_periods",      COUNT_UNIT);
-        push!(snap.cpu_nr_throttled,    "cpu_nr_throttled",    COUNT_UNIT);
-        push!(snap.cpu_throttled_usec,  "cpu_throttled_usec",  MICRO_SECOND_UNIT);
-        push!(snap.io_rbytes,           "io_rbytes",           BYTE_UNIT);
-        push!(snap.io_wbytes,           "io_wbytes",           BYTE_UNIT);
+        push!(snap.memory_slab, "memory_slab", BYTE_UNIT);
+        push!(snap.cpu_usage_usec, "cpu_usage_usec", MICRO_SECOND_UNIT);
+        push!(snap.cpu_user_usec, "cpu_user_usec", MICRO_SECOND_UNIT);
+        push!(snap.cpu_system_usec, "cpu_system_usec", MICRO_SECOND_UNIT);
+        push!(snap.cpu_nr_periods, "cpu_nr_periods", COUNT_UNIT);
+        push!(snap.cpu_nr_throttled, "cpu_nr_throttled", COUNT_UNIT);
+        push!(
+            snap.cpu_throttled_usec,
+            "cpu_throttled_usec",
+            MICRO_SECOND_UNIT
+        );
+        push!(snap.io_rbytes, "io_rbytes", BYTE_UNIT);
+        push!(snap.io_wbytes, "io_wbytes", BYTE_UNIT);
 
         Ok(metrics)
     }
-
 
     fn get_name() -> &'static str {
         SOURCE_NAME

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 use tokio_util::sync::CancellationToken;
 
-use crate::cgroup::{Cgroup, RootCgroup, StatsReader};
+use crate::cgroup::{Cgroup, CgroupBackend, SysFsBackend};
 use crate::counters::{Counters, CpuCounters, IoCounters, MemoryCounters};
 use crate::error::CgroupError;
 
@@ -56,11 +56,14 @@ pub(crate) type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 ///
 /// Owns the process cgroup and root cgroup handles, and maintains
 /// internal counters for both process-level and system-wide metrics.
-pub struct CgroupSource {
+pub struct CgroupSource<B = SysFsBackend>
+where
+    B: CgroupBackend,
+{
     config: CgroupConfig,
     handle: Option<WorkerHandle>,
-    pub proc_cgroup: Arc<Cgroup>,
-    pub root_cgroup: Arc<RootCgroup>,
+    pub proc_cgroup: Arc<Cgroup<B>>,
+    pub root_cgroup: Arc<Cgroup<B>>,
     proc_memory_counters: Arc<Mutex<MemoryCounters>>,
     global_memory_counters: Arc<Mutex<MemoryCounters>>,
     proc_cpu_counters: CpuCounters,
@@ -76,14 +79,18 @@ impl CgroupSource {
     ///
     /// Initializes internal cgroup handles but does initialize and attach any PID yet.
     pub fn new(config: CgroupConfig) -> Result<Self> {
-        let root_cgroup = Arc::new(RootCgroup::new(config.cgroup_root.clone()));
-        let proc_cgroup = Arc::new(root_cgroup.child(&config.cgroup_name));
+        let root_cgroup = if let Some(cgroup_root) = &config.cgroup_root {
+            Cgroup::at(cgroup_root.clone())
+        } else {
+            Cgroup::root()
+        };
+        let proc_cgroup = root_cgroup.child(&config.cgroup_name);
 
         Ok(Self {
             config,
             handle: None,
-            root_cgroup,
-            proc_cgroup,
+            root_cgroup: Arc::new(root_cgroup),
+            proc_cgroup: Arc::new(proc_cgroup),
             proc_memory_counters: Arc::default(),
             global_memory_counters: Arc::default(),
             proc_cpu_counters: CpuCounters::default(),
@@ -94,14 +101,16 @@ impl CgroupSource {
             end_timestamp: 0,
         })
     }
+}
 
+impl<B: CgroupBackend> CgroupSource<B> {
     /// Creates a background worker that periodically samples memory usage.
     ///
     /// This worker updates process and global memory counters at a fixed interval.
     /// It can be cancelled using the returned `CancellationToken`.
     pub fn create_worker(
-        root_cgroup: Arc<RootCgroup>,
-        proc_cgroup: Arc<Cgroup>,
+        root_cgroup: Arc<Cgroup<B>>,
+        proc_cgroup: Arc<Cgroup<B>>,
         proc_memory_counters: Arc<Mutex<MemoryCounters>>,
         global_memory_counters: Arc<Mutex<MemoryCounters>>,
         poll_interval: Duration,
@@ -144,7 +153,7 @@ impl CgroupSource {
     }
 }
 
-impl MetricReader for CgroupSource {
+impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
     type Type = Counters;
     type Error = CgroupError;
 
@@ -155,12 +164,7 @@ impl MetricReader for CgroupSource {
     /// - attaches the target PID
     /// - optionally starts background polling worker
     async fn init(&mut self, pid: i32) -> Result<()> {
-        self.proc_cgroup.initialize()?;
-        for controller in &self.config.controllers {
-            self.root_cgroup.activate_controller(*controller)?;
-        }
-
-        self.proc_cgroup.attach_pid(pid)?;
+        self.proc_cgroup.initialize(pid, &self.config.controllers)?;
 
         if let Some(poll_interval) = self.config.poll_interval {
             self.handle = Some(Self::create_worker(
@@ -174,7 +178,7 @@ impl MetricReader for CgroupSource {
 
         self.begin_timestamp = get_timestamp_micros();
 
-        debug!("Cgroup source initialised for pid {pid}");
+        debug!("Cgroup source initialized for pid {pid}.");
         Ok(())
     }
 
@@ -182,6 +186,8 @@ impl MetricReader for CgroupSource {
     ///
     /// Updates internal CPU, memory, and I/O counters.
     async fn measure(&mut self) -> Result<()> {
+        debug!("Measure cgroup source.");
+
         self.end_timestamp = get_timestamp_micros();
         {
             let snapshot = self.proc_cgroup.stats().memory()?;
@@ -208,6 +214,8 @@ impl MetricReader for CgroupSource {
 
     /// Returns collected metrics and resets per-phase counters.
     async fn retrieve(&mut self) -> Result<Self::Type> {
+        debug!("Retriving cgroup counters.");
+
         let proc_memory = {
             let mut lock = self.proc_memory_counters.lock().await;
             let counters = *lock;
@@ -252,6 +260,7 @@ impl MetricReader for CgroupSource {
     /// Stops background worker and cleans up the cgroup.
     async fn join(&mut self) -> Result<()> {
         if let Some((cancellation_token, handle)) = self.handle.take() {
+            debug!("Joining cgroup source polling task.");
             cancellation_token.cancel();
             handle.await??;
         }
@@ -261,6 +270,7 @@ impl MetricReader for CgroupSource {
 
     /// Returns the list of exported sensors.
     fn get_sensors(&self) -> Result<Sensors> {
+        debug!("Retrieving cgroup source sensors.");
         Ok(vec![
             Sensor::new("usage_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
             Sensor::new("user_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
@@ -372,7 +382,7 @@ fn to_metrics(
                 format!("{prefix}_{}", $name),
                 $value,
                 $unit,
-                CgroupSource::get_name(),
+                CgroupSource::<SysFsBackend>::get_name(),
             ));
         };
     }
@@ -450,96 +460,162 @@ fn to_metrics(
 
     metrics
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf};
-    use tokio::time::Duration;
+    use crate::cgroup::Controller;
+    use crate::snapshot::{CpuSnapshot, IoSnapshot, MemorySnapshot};
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::time::{Duration, sleep};
 
-    fn temp_root(name: &str) -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!("cgroup_src_{name}"));
-        let _ = fs::create_dir_all(&p);
-        p
+    #[derive(Default, Clone)]
+    struct MockCgroupBackend {
+        memory: Arc<std::sync::Mutex<MemorySnapshot>>,
+        cpu: Arc<std::sync::Mutex<CpuSnapshot>>,
+        io: Arc<std::sync::Mutex<IoSnapshot>>,
     }
 
-    fn setup_source(name: &str) -> CgroupSource {
-        let mut cfg = CgroupConfig::default();
-        cfg.cgroup_root = temp_root(name);
-        cfg.cgroup_name = "test".to_string();
-        cfg.poll_interval = None;
-        CgroupSource::new(cfg).unwrap()
+    impl CgroupBackend for MockCgroupBackend {
+        fn memory(&self) -> Result<MemorySnapshot> {
+            Ok(self.memory.lock().unwrap().clone())
+        }
+
+        fn cpu(&self) -> Result<CpuSnapshot> {
+            Ok(self.cpu.lock().unwrap().clone())
+        }
+
+        fn io(&self) -> Result<IoSnapshot> {
+            Ok(self.io.lock().unwrap().clone())
+        }
+
+        fn cleanup(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn initialize(&self, _pid: i32, _controllers: &HashSet<Controller>) -> Result<()> {
+            Ok(())
+        }
     }
 
-    #[tokio::test]
-    async fn test_init_and_attach() {
-        let mut src = setup_source("init");
+    fn setup_source() -> (CgroupSource<MockCgroupBackend>, MockCgroupBackend) {
+        let backend = MockCgroupBackend::default();
 
-        src.init(42).await.unwrap();
+        let root = Arc::new(Cgroup::new(
+            PathBuf::from("/tmp/root"),
+            None,
+            backend.clone(),
+        ));
 
-        let procs = src.proc_cgroup.path.join("cgroup.procs");
-        let content = fs::read_to_string(procs).unwrap();
+        let proc = Arc::new(Cgroup::new(
+            PathBuf::from("/tmp/proc"),
+            Some(PathBuf::from("/tmp/root")),
+            backend.clone(),
+        ));
 
-        assert!(content.contains("42"));
+        let source = CgroupSource {
+            config: CgroupConfig::default(),
+            handle: None,
+            root_cgroup: root,
+            proc_cgroup: proc,
+            proc_memory_counters: Arc::default(),
+            global_memory_counters: Arc::default(),
+            proc_cpu_counters: Default::default(),
+            global_cpu_counters: Default::default(),
+            proc_io_counters: Default::default(),
+            global_io_counters: Default::default(),
+            begin_timestamp: 0,
+            end_timestamp: 0,
+        };
 
-        src.join().await.unwrap();
+        (source, backend)
     }
 
     #[tokio::test]
     async fn test_measure_updates_counters() {
-        let mut src = setup_source("measure");
-        let root = src.root_cgroup.path.clone();
-
-        src.init(1).await.unwrap();
-
-        fs::write(root.join("test/memory.stat"), "anon 200").unwrap();
+        let (mut src, backend) = setup_source();
 
         {
             let mem = src.proc_memory_counters.lock().await;
             assert!(mem.anon.is_none());
         }
 
-        src.measure().await.unwrap();
-
         {
-            let mem = src.proc_memory_counters.lock().await;
-            assert_eq!(mem.anon.unwrap().max().unwrap(), 200);
-            assert_eq!(mem.anon.unwrap().min().unwrap(), 200);
+            backend.memory.lock().unwrap().anon = Some(200);
         }
-
-        fs::write(root.join("test/memory.stat"), "anon 400").unwrap();
 
         src.measure().await.unwrap();
 
         {
             let mem = src.proc_memory_counters.lock().await;
-            assert_eq!(mem.anon.unwrap().max().unwrap(), 400);
-            assert_eq!(mem.anon.unwrap().min().unwrap(), 200);
+            let anon = mem.anon.unwrap();
+
+            assert_eq!(anon.min(), Some(200));
+            assert_eq!(anon.max(), Some(200));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_measure_tracks_min_max() {
+        let (mut src, backend) = setup_source();
+
+        {
+            let mut memory = backend.memory.lock().unwrap();
+            memory.anon = Some(200);
+            memory.current = Some(200);
+            memory.peak = Some(200);
         }
 
-        src.join().await.unwrap();
+        src.measure().await.unwrap();
+
+        {
+            let mut memory = backend.memory.lock().unwrap();
+            memory.anon = Some(400);
+            memory.current = Some(400);
+            memory.peak = Some(400);
+        }
+
+        src.measure().await.unwrap();
+
+        let mem = src.proc_memory_counters.lock().await;
+        let anon = mem.anon.unwrap();
+        let current = mem.current.unwrap();
+        let peak = mem.peak.unwrap();
+
+        assert_eq!(anon.min(), Some(200));
+        assert_eq!(anon.max(), Some(400));
+
+        assert_eq!(current.min(), Some(200));
+        assert_eq!(current.max(), Some(400));
+
+        assert_eq!(peak.min(), Some(200));
+        assert_eq!(peak.max(), Some(400));
     }
 
     #[tokio::test]
     async fn test_retrieve_compute_diffs() {
-        let mut src = setup_source("retrieve");
-        let root = src.root_cgroup.path.clone();
+        let (mut src, backend) = setup_source();
 
-        fs::write(
-            root.join("test/cpu.stat"),
-            "usage_usec 1000\nuser_usec 500\nsystem_usec 500\nnr_periods 2\n",
-        )
-        .unwrap();
+        {
+            let mut cpu = backend.cpu.lock().unwrap();
 
-        src.init(1).await.unwrap();
+            cpu.usage_usec = 1000;
+            cpu.user_usec = 500;
+            cpu.system_usec = 500;
+            cpu.nr_periods = Some(2);
+        }
+
         src.measure().await.unwrap();
 
-        fs::write(
-            root.join("test/cpu.stat"),
-            "usage_usec 2000\nuser_usec 1000\nsystem_usec 1000\nnr_periods 4\n",
-        )
-        .unwrap();
+        {
+            let mut cpu = backend.cpu.lock().unwrap();
+
+            cpu.usage_usec = 2000;
+            cpu.user_usec = 1000;
+            cpu.system_usec = 1000;
+            cpu.nr_periods = Some(4);
+        }
 
         src.measure().await.unwrap();
 
@@ -549,20 +625,51 @@ mod tests {
         assert_eq!(counters.proc_cpu.user_usec.diff(), 500);
         assert_eq!(counters.proc_cpu.system_usec.diff(), 500);
         assert_eq!(counters.proc_cpu.nr_periods.unwrap().diff(), 2);
-
-        src.join().await.unwrap();
     }
 
     #[tokio::test]
-    async fn test_join_stops_worker() {
-        let mut src = setup_source("worker");
+    async fn test_worker_updates_counters() {
+        let (src, backend) = setup_source();
 
-        src.config.poll_interval = Some(Duration::from_millis(10));
+        let (token, handle) = CgroupSource::create_worker(
+            src.root_cgroup.clone(),
+            src.proc_cgroup.clone(),
+            src.proc_memory_counters.clone(),
+            src.global_memory_counters.clone(),
+            Duration::from_millis(10),
+        )
+        .unwrap();
 
-        src.init(1).await.unwrap();
+        {
+            let mem = src.proc_memory_counters.lock().await;
+            assert!(mem.anon.is_none());
+        }
 
-        let res = src.join().await;
+        {
+            backend.memory.lock().unwrap().anon = Some(200);
+        }
 
-        assert!(res.is_ok());
+        sleep(Duration::from_millis(10)).await;
+
+        {
+            let mem = src.proc_memory_counters.lock().await;
+            assert_eq!(mem.anon.unwrap().max().unwrap(), 200);
+            assert_eq!(mem.anon.unwrap().min().unwrap(), 200);
+        }
+
+        {
+            backend.memory.lock().unwrap().anon = Some(100);
+        }
+
+        sleep(Duration::from_millis(10)).await;
+
+        {
+            let mem = src.proc_memory_counters.lock().await;
+            assert_eq!(mem.anon.unwrap().max().unwrap(), 200);
+            assert_eq!(mem.anon.unwrap().min().unwrap(), 100);
+        }
+
+        token.cancel();
+        handle.await.unwrap().unwrap();
     }
 }

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -8,7 +8,8 @@
 use futures::StreamExt;
 use joule_profiler_core::sensor::{Sensor, Sensors};
 use joule_profiler_core::source::MetricReader;
-use joule_profiler_core::types::{Metric, Metrics};
+use joule_profiler_core::time::get_timestamp_micros;
+use joule_profiler_core::types::{Metric, MetricValue, Metrics};
 use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
 use log::{debug, trace};
 use std::sync::Arc;
@@ -66,6 +67,8 @@ pub struct CgroupSource {
     global_cpu_counters: CpuCounters,
     proc_io_counters: IoCounters,
     global_io_counters: IoCounters,
+    begin_timestamp: u128,
+    end_timestamp: u128,
 }
 
 impl CgroupSource {
@@ -87,6 +90,8 @@ impl CgroupSource {
             global_cpu_counters: CpuCounters::default(),
             proc_io_counters: IoCounters::default(),
             global_io_counters: IoCounters::default(),
+            begin_timestamp: 0,
+            end_timestamp: 0,
         })
     }
 
@@ -167,6 +172,8 @@ impl MetricReader for CgroupSource {
             )?);
         }
 
+        self.begin_timestamp = get_timestamp_micros();
+
         debug!("Cgroup source initialised for pid {pid}");
         Ok(())
     }
@@ -175,6 +182,7 @@ impl MetricReader for CgroupSource {
     ///
     /// Updates internal CPU, memory, and I/O counters.
     async fn measure(&mut self) -> Result<()> {
+        self.end_timestamp = get_timestamp_micros();
         {
             let snapshot = self.proc_cgroup.stats().memory()?;
             let mut lock = self.proc_memory_counters.lock().await;
@@ -226,6 +234,9 @@ impl MetricReader for CgroupSource {
         let global_io = self.global_io_counters;
         self.global_io_counters.new_phase();
 
+        let begin_timestamp = self.begin_timestamp;
+        self.begin_timestamp = self.end_timestamp;
+
         Ok(Counters {
             proc_memory,
             proc_cpu,
@@ -233,6 +244,8 @@ impl MetricReader for CgroupSource {
             global_memory,
             global_cpu,
             global_io,
+            begin_timestamp,
+            end_timestamp: self.end_timestamp,
         })
     }
 
@@ -278,22 +291,68 @@ impl MetricReader for CgroupSource {
         ])
     }
 
+    #[allow(clippy::cast_precision_loss)]
     /// Converts counters into metrics.
     fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
-        Ok(to_metrics(
-            &counters.proc_memory,
-            &counters.proc_cpu,
-            &counters.proc_io,
-            "proc",
-        )
-        .into_iter()
-        .chain(to_metrics(
-            &counters.global_memory,
-            &counters.global_cpu,
-            &counters.global_io,
-            "global",
-        ))
-        .collect())
+        let phase_duration: u64 = counters
+            .end_timestamp
+            .saturating_sub(counters.begin_timestamp)
+            .try_into()
+            .unwrap_or_default();
+
+        let proc_cpu_usage_usec = counters.proc_cpu.usage_usec.diff();
+
+        let proc_usage_ratio = if phase_duration == 0 {
+            0.0
+        } else {
+            proc_cpu_usage_usec as f64 / phase_duration as f64 * 100.0
+        };
+
+        let proc_cpu_usage = Metric::new(
+            "proc_cpu_usage",
+            MetricValue::Float(proc_usage_ratio, Some(2)),
+            MetricUnit {
+                prefix: UnitPrefix::None,
+                unit: Unit::Percent,
+            },
+            Self::get_name(),
+        );
+
+        let global_cpu_usage_usec = counters.global_cpu.usage_usec.diff();
+
+        let global_usage_ratio = if phase_duration == 0 {
+            0.0
+        } else {
+            global_cpu_usage_usec as f64 / phase_duration as f64 * 100.0
+        };
+
+        let global_cpu_usage = Metric::new(
+            "global_cpu_usage",
+            MetricValue::Float(global_usage_ratio, Some(2)),
+            MetricUnit {
+                prefix: UnitPrefix::None,
+                unit: Unit::Percent,
+            },
+            Self::get_name(),
+        );
+
+        let metrics = vec![proc_cpu_usage, global_cpu_usage];
+
+        Ok(metrics
+            .into_iter()
+            .chain(to_metrics(
+                &counters.proc_memory,
+                &counters.proc_cpu,
+                &counters.proc_io,
+                "proc",
+            ))
+            .chain(to_metrics(
+                &counters.global_memory,
+                &counters.global_cpu,
+                &counters.global_io,
+                "global",
+            ))
+            .collect())
     }
 
     fn get_name() -> &'static str {

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -1,25 +1,29 @@
-use crate::error::CgroupError;
-use crate::snapshot::Snapshot;
-use crate::util::{read_flat_keyed, read_io_stat, read_u64_opt};
 use futures::StreamExt;
 use joule_profiler_core::sensor::{Sensor, Sensors};
 use joule_profiler_core::source::MetricReader;
 use joule_profiler_core::types::{Metric, Metrics};
 use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
-use log::{debug, trace, warn};
-use std::fs;
-use std::path::{Path, PathBuf};
+use log::{debug, trace};
+use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
+use tokio_util::sync::CancellationToken;
 
+use crate::cgroup::{Cgroup, Controller};
+use crate::counters::{Counters, CpuCounters, IoCounters, MemoryCounters};
+use crate::error::CgroupError;
+
+mod cgroup;
+mod counters;
 mod error;
 mod snapshot;
 mod util;
 
-const SOURCE_NAME: &str = "CGroup";
+const SOURCE_NAME: &str = "cgroup";
 
 const BYTE_UNIT: MetricUnit = MetricUnit {
     prefix: UnitPrefix::None,
@@ -36,11 +40,15 @@ const COUNT_UNIT: MetricUnit = MetricUnit {
     unit: Unit::Count,
 };
 
+pub(crate) type Result<T> = std::result::Result<T, CgroupError>;
+pub(crate) type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
+
 #[derive(Debug, Clone)]
 pub struct CgroupConfig {
     pub cgroup_root: PathBuf,
     pub cgroup_name: String,
     pub poll_interval: Option<Duration>,
+    pub controllers: HashSet<Controller>,
 }
 
 impl Default for CgroupConfig {
@@ -49,350 +57,258 @@ impl Default for CgroupConfig {
             cgroup_root: PathBuf::from("/sys/fs/cgroup"),
             cgroup_name: format!("joule-profiler-{}", std::process::id()),
             poll_interval: None,
+            controllers: vec![Controller::Io, Controller::Mem, Controller::Cpu]
+                .into_iter()
+                .collect(),
         }
     }
 }
 
 pub struct CgroupSource {
     config: CgroupConfig,
-    cgroup_path: PathBuf,
-    shared_snapshot: Arc<Mutex<Snapshot>>,
-    handle: Option<JoinHandle<Result<(), CgroupError>>>,
-    last_ponctual: Snapshot,
+    handle: Option<WorkerHandle>,
+    cgroup: Arc<Cgroup>,
+    shared_memory_counters: Arc<Mutex<MemoryCounters>>,
+    cpu_counters: CpuCounters,
+    io_counters: IoCounters,
 }
 
 impl CgroupSource {
-    pub fn new(config: CgroupConfig) -> Result<Self, CgroupError> {
-        let controllers = config.cgroup_root.join("cgroup.controllers");
-        if !controllers.exists() {
-            return Err(CgroupError::NotAvailable(
-                config.cgroup_root.display().to_string(),
-            ));
-        }
-
-        let cgroup_path = config.cgroup_root.join(&config.cgroup_name);
+    pub fn new(config: CgroupConfig) -> Result<Self> {
+        let cgroup = Arc::new(Cgroup::new(
+            config.cgroup_root.clone(),
+            &config.cgroup_name,
+        )?);
 
         Ok(Self {
             config,
-            cgroup_path,
-            shared_snapshot: Arc::new(Mutex::new(Snapshot::default())),
             handle: None,
-            last_ponctual: Snapshot::default(),
+            cgroup,
+            shared_memory_counters: Arc::default(),
+            cpu_counters: CpuCounters::default(),
+            io_counters: IoCounters::default(),
         })
     }
 
-    pub fn try_default() -> Result<Self, CgroupError> {
-        Self::new(CgroupConfig::default())
-    }
+    pub fn create_worker(
+        cgroup: Arc<Cgroup>,
+        shared_memory_counters: Arc<Mutex<MemoryCounters>>,
+        poll_interval: Duration,
+    ) -> Result<WorkerHandle> {
+        let mut ticker = Interval::new_interval(poll_interval)?;
 
-    fn create_and_enable_controllers(&self) -> Result<(), CgroupError> {
-        if !self.cgroup_path.exists() {
-            fs::create_dir_all(&self.cgroup_path).map_err(|e| CgroupError::IoPath {
-                path: self.cgroup_path.display().to_string(),
-                source: e,
-            })?;
-            debug!("Created cgroup at {}", self.cgroup_path.display());
-        }
+        let cancellation_token = CancellationToken::new();
+        let cancellation_token_clone = cancellation_token.clone();
 
-        let subtree_control = self.config.cgroup_root.join("cgroup.subtree_control");
-        for controller in ["memory", "cpu", "io"] {
-            let token = format!("+{controller}");
-            let controller_static: &'static str = match controller {
-                "memory" => "memory",
-                "cpu" => "cpu",
-                "io" => "io",
-                _ => unreachable!(),
-            };
-            fs::write(&subtree_control, &token).map_err(|e| CgroupError::EnableController {
-                controller: controller_static,
-                path: subtree_control.display().to_string(),
-                source: e,
-            })?;
-            trace!(
-                "Enabled controller `{controller}` in {}",
-                subtree_control.display()
-            );
-        }
+        let handle = tokio::spawn(async move {
+            debug!("Starting cgroup memory polling.");
 
-        Ok(())
-    }
+            loop {
+                tokio::select! {
+                    _ = ticker.next() => {
+                        trace!("Polled cgroup source.");
+                        let memory_snapshot = cgroup.read_memory()?;
+                        let mut lock = shared_memory_counters.lock().await;
+                        lock.update(&memory_snapshot);
+                    }
 
-    fn attach_pid(&self, pid: i32) -> Result<(), CgroupError> {
-        let procs_path = self.cgroup_path.join("cgroup.procs");
-        fs::write(&procs_path, pid.to_string())
-            .map_err(|e| CgroupError::Attach { pid, source: e })?;
-        debug!(
-            "Attached PID {pid} to cgroup {}",
-            self.cgroup_path.display()
-        );
-        Ok(())
-    }
-
-    fn live_pids(&self) -> Vec<i32> {
-        let path = self.cgroup_path.join("cgroup.procs");
-        match fs::read_to_string(&path) {
-            Ok(raw) => raw
-                .lines()
-                .filter_map(|l| l.trim().parse::<i32>().ok())
-                .collect(),
-            Err(e) => {
-                warn!("Could not read cgroup.procs ({}): {e}", path.display());
-                Vec::new()
+                    () = cancellation_token.cancelled() => {
+                        debug!("Cgroup worker stopped.");
+                        break;
+                    }
+                }
             }
-        }
-    }
 
-    fn cleanup(&self) {
-        let root_procs = self.config.cgroup_root.join("cgroup.procs");
-        for pid in self.live_pids() {
-            if let Err(e) = fs::write(&root_procs, pid.to_string()) {
-                warn!("Could not move PID {pid} back to root cgroup: {e}");
-            }
-        }
-        if self.cgroup_path.exists() {
-            if let Err(e) = fs::remove_dir(&self.cgroup_path) {
-                warn!(
-                    "Could not remove cgroup {} (may still have live tasks): {e}",
-                    self.cgroup_path.display()
-                );
-            } else {
-                debug!("Removed cgroup {}", self.cgroup_path.display());
-            }
-        }
-    }
+            Ok(())
+        });
 
-    fn read_memory_fields(cgroup_path: &Path) -> (u64, u64, u64, u64) {
-        let memory_current = read_u64_opt(&cgroup_path.join("memory.current"))
-            .ok()
-            .flatten()
-            .unwrap_or(0);
-
-        let memory_swap_current = read_u64_opt(&cgroup_path.join("memory.swap.current"))
-            .ok()
-            .flatten()
-            .unwrap_or(0);
-
-        let (memory_anon, memory_file) =
-            if let Ok(stat) = read_flat_keyed(&cgroup_path.join("memory.stat")) {
-                (
-                    stat.get("anon").copied().unwrap_or(0),
-                    stat.get("file").copied().unwrap_or(0),
-                )
-            } else {
-                (0, 0)
-            };
-
-        (
-            memory_current,
-            memory_anon,
-            memory_file,
-            memory_swap_current,
-        )
-    }
-
-    fn read_not_polled_fields(&self) -> Snapshot {
-        let mut snap = Snapshot::default();
-
-        if let Ok(stat) = read_flat_keyed(&self.cgroup_path.join("memory.stat")) {
-            snap.memory_kernel_stack = stat.get("kernel_stack").copied();
-            snap.memory_slab = stat.get("slab").copied();
-        }
-
-        if let Ok(stat) = read_flat_keyed(&self.cgroup_path.join("cpu.stat")) {
-            snap.cpu_usage_usec = stat.get("usage_usec").copied();
-            snap.cpu_user_usec = stat.get("user_usec").copied();
-            snap.cpu_system_usec = stat.get("system_usec").copied();
-            snap.cpu_nr_periods = stat.get("nr_periods").copied();
-            snap.cpu_nr_throttled = stat.get("nr_throttled").copied();
-            snap.cpu_throttled_usec = stat.get("throttled_usec").copied();
-        }
-
-        if let Ok((rb, wb)) = read_io_stat(&self.cgroup_path.join("io.stat")) {
-            snap.io_rbytes = Some(rb);
-            snap.io_wbytes = Some(wb);
-        }
-
-        snap.memory_peak = read_u64_opt(&self.cgroup_path.join("memory.peak"))
-            .ok()
-            .flatten();
-
-        snap
+        Ok((cancellation_token_clone, handle))
     }
 }
 
 impl MetricReader for CgroupSource {
-    type Type = Snapshot;
+    type Type = Counters;
     type Error = CgroupError;
 
-    async fn init(&mut self, pid: i32) -> Result<(), Self::Error> {
-        self.create_and_enable_controllers()?;
-        self.attach_pid(pid)?;
-
-        if let Some(interval) = self.config.poll_interval {
-            let shared = self.shared_snapshot.clone();
-            let cgroup_path = self.cgroup_path.clone();
-
-            let handle = tokio::spawn(async move {
-                debug!("Starting cgroup memory polling.");
-                let mut ticker = Interval::new_interval(interval)?;
-
-                loop {
-                    ticker.next().await;
-
-                    let (memory_current, memory_anon, memory_file, memory_swap_current) =
-                        CgroupSource::read_memory_fields(&cgroup_path);
-
-                    trace!(
-                        "cgroup poll — current:{memory_current} anon:{memory_anon} \
-                         file:{memory_file} swap:{memory_swap_current}"
-                    );
-
-                    let mut snap = shared.lock().await;
-                    snap.update(
-                        memory_current,
-                        memory_anon,
-                        memory_file,
-                        memory_swap_current,
-                    );
-                }
-            });
-
-            self.handle = Some(handle);
+    async fn init(&mut self, pid: i32) -> Result<()> {
+        self.cgroup.initialize_cgroup()?;
+        for controller in &self.config.controllers {
+            self.cgroup.activate_controller(*controller)?;
         }
 
-        debug!("CgroupSource initialised for PID {pid}");
+        self.cgroup.attach_pid(pid)?;
+
+        if let Some(poll_interval) = self.config.poll_interval {
+            self.handle = Some(Self::create_worker(
+                self.cgroup.clone(),
+                self.shared_memory_counters.clone(),
+                poll_interval,
+            )?);
+        }
+
+        debug!("Cgroup source initialised for pid {pid}");
         Ok(())
     }
 
-    async fn join(&mut self) -> Result<(), Self::Error> {
-        if let Some(handle) = self.handle.take() {
-            if handle.is_finished() {
-                if let Ok(res) = handle.await {
-                    return res;
-                }
-            } else {
-                handle.abort();
-            }
+    async fn measure(&mut self) -> Result<()> {
+        let memory_snapshot = self.cgroup.read_memory()?;
+        {
+            let mut lock = self.shared_memory_counters.lock().await;
+            lock.update(&memory_snapshot);
         }
-        self.cleanup();
+        let cpu_snapshot = self.cgroup.read_cpu()?;
+        self.cpu_counters.update(&cpu_snapshot);
+
+        let io_snapshot = self.cgroup.read_io()?;
+        self.io_counters.update(&io_snapshot);
+
         Ok(())
     }
 
-    async fn measure(&mut self) -> Result<(), Self::Error> {
-        if self.config.poll_interval.is_none() {
-            let (memory_current, memory_anon, memory_file, memory_swap_current) =
-                CgroupSource::read_memory_fields(&self.cgroup_path);
-            let mut snap = self.shared_snapshot.lock().await;
-            snap.update(
-                memory_current,
-                memory_anon,
-                memory_file,
-                memory_swap_current,
-            );
-        }
+    async fn retrieve(&mut self) -> Result<Self::Type> {
+        let memory = {
+            let mut lock = self.shared_memory_counters.lock().await;
+            let memory_counters = *lock;
+            lock.reset();
+            memory_counters
+        };
 
-        self.last_ponctual = self.read_not_polled_fields();
+        let cpu = self.cpu_counters;
+        self.cpu_counters.new_phase();
+
+        let io = self.io_counters;
+        self.io_counters.new_phase();
+
+        Ok(Counters { memory, cpu, io })
+    }
+
+    async fn join(&mut self) -> Result<()> {
+        if let Some((cancellation_token, handle)) = self.handle.take() {
+            cancellation_token.cancel();
+            handle.await??;
+        }
+        self.cgroup.cleanup()?;
         Ok(())
     }
 
-    async fn retrieve(&mut self) -> Result<Self::Type, Self::Error> {
-        let mut shared = self.shared_snapshot.lock().await;
-        shared.remove_sentinel_values();
-
-        let mut snap = shared.clone();
-        shared.reset_phase();
-        drop(shared);
-
-        snap.memory_peak = self.last_ponctual.memory_peak;
-        snap.memory_kernel_stack = self.last_ponctual.memory_kernel_stack;
-        snap.memory_slab = self.last_ponctual.memory_slab;
-        snap.cpu_usage_usec = self.last_ponctual.cpu_usage_usec;
-        snap.cpu_user_usec = self.last_ponctual.cpu_user_usec;
-        snap.cpu_system_usec = self.last_ponctual.cpu_system_usec;
-        snap.cpu_nr_periods = self.last_ponctual.cpu_nr_periods;
-        snap.cpu_nr_throttled = self.last_ponctual.cpu_nr_throttled;
-        snap.cpu_throttled_usec = self.last_ponctual.cpu_throttled_usec;
-        snap.io_rbytes = self.last_ponctual.io_rbytes;
-        snap.io_wbytes = self.last_ponctual.io_wbytes;
-
-        Ok(snap)
+    fn get_sensors(&self) -> Result<Sensors> {
+        Ok(vec![
+            Sensor::new("usage_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
+            Sensor::new("user_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
+            Sensor::new("system_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
+            Sensor::new("nr_periods", COUNT_UNIT, SOURCE_NAME),
+            Sensor::new("nr_throttled", COUNT_UNIT, SOURCE_NAME),
+            Sensor::new("throttled_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
+            Sensor::new("nr_bursts", COUNT_UNIT, SOURCE_NAME),
+            Sensor::new("burst_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
+            Sensor::new("anon_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("anon_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("file_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("file_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("kernel_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("kernel_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("kernel_stack_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("kernel_stack_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("peak_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("peak_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("shmem_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("shmem_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("slab_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("slab_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("swap_current_min", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("swap_current_max", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("read_bytes", BYTE_UNIT, SOURCE_NAME),
+            Sensor::new("write_bytes", BYTE_UNIT, SOURCE_NAME),
+        ])
     }
 
-    fn get_sensors(&self) -> Result<Sensors, Self::Error> {
-        let sensors = vec![
-            Sensor::new("memory_current_min", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_current_max", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_anon_min", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_anon_max", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_file_min", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_file_max", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_swap_current_min", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_swap_current_max", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_peak", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_kernel_stack", BYTE_UNIT, Self::get_name()),
-            Sensor::new("memory_slab", BYTE_UNIT, Self::get_name()),
-            Sensor::new("cpu_usage_usec", MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("cpu_user_usec", MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("cpu_system_usec", MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("cpu_nr_periods", COUNT_UNIT, Self::get_name()),
-            Sensor::new("cpu_nr_throttled", COUNT_UNIT, Self::get_name()),
-            Sensor::new("cpu_throttled_usec", MICRO_SECOND_UNIT, Self::get_name()),
-            Sensor::new("io_rbytes", BYTE_UNIT, Self::get_name()),
-            Sensor::new("io_wbytes", BYTE_UNIT, Self::get_name()),
-        ];
-        Ok(sensors)
-    }
-
-    fn to_metrics(&self, snap: Self::Type) -> Result<Metrics, Self::Error> {
-        let mut metrics = Vec::new();
-
+    fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
         macro_rules! push {
-            ($field:expr, $name:expr, $unit:expr) => {
-                if let Some(v) = $field {
-                    metrics.push(Metric::new($name, v, $unit, Self::get_name()));
-                }
-            };
-            (direct $field:expr, $name:expr, $unit:expr) => {
-                metrics.push(Metric::new($name, $field, $unit, Self::get_name()));
+            ($metrics:expr, $name:expr, $value:expr, $unit:expr) => {
+                $metrics.push(Metric::new($name, $value, $unit, Self::get_name()));
             };
         }
 
-        push!(direct snap.memory_current_min,      "memory_current_min",      BYTE_UNIT);
-        push!(direct snap.memory_current_max,      "memory_current_max",      BYTE_UNIT);
-        push!(direct snap.memory_anon_min,         "memory_anon_min",         BYTE_UNIT);
-        push!(direct snap.memory_anon_max,         "memory_anon_max",         BYTE_UNIT);
-        push!(direct snap.memory_file_min,         "memory_file_min",         BYTE_UNIT);
-        push!(direct snap.memory_file_max,         "memory_file_max",         BYTE_UNIT);
-        push!(direct snap.memory_swap_current_min, "memory_swap_current_min", BYTE_UNIT);
-        push!(direct snap.memory_swap_current_max, "memory_swap_current_max", BYTE_UNIT);
-        push!(snap.memory_peak, "memory_peak", BYTE_UNIT);
-        push!(snap.memory_kernel_stack, "memory_kernel_stack", BYTE_UNIT);
-        push!(snap.memory_slab, "memory_slab", BYTE_UNIT);
-        push!(snap.cpu_usage_usec, "cpu_usage_usec", MICRO_SECOND_UNIT);
-        push!(snap.cpu_user_usec, "cpu_user_usec", MICRO_SECOND_UNIT);
-        push!(snap.cpu_system_usec, "cpu_system_usec", MICRO_SECOND_UNIT);
-        push!(snap.cpu_nr_periods, "cpu_nr_periods", COUNT_UNIT);
-        push!(snap.cpu_nr_throttled, "cpu_nr_throttled", COUNT_UNIT);
+        macro_rules! push_minmax {
+            ($metrics:expr, $field:expr, $name:expr, $unit:expr) => {
+                if let Some(mm) = $field {
+                    push!(
+                        $metrics,
+                        concat!($name, "_min"),
+                        mm.min().unwrap_or_default(),
+                        $unit
+                    );
+                    push!(
+                        $metrics,
+                        concat!($name, "_max"),
+                        mm.max().unwrap_or_default(),
+                        $unit
+                    );
+                }
+            };
+        }
+
+        macro_rules! push_begin_end {
+            ($metrics:expr, $field:expr, $name:expr, $unit:expr) => {
+                if let Some(be) = $field {
+                    push!($metrics, $name, be.diff(), $unit);
+                }
+            };
+        }
+
+        let mut metrics = Vec::new();
+        let m = counters.memory;
+
+        push_minmax!(metrics, m.anon, "anon", BYTE_UNIT);
+        push_minmax!(metrics, m.file, "file", BYTE_UNIT);
+        push_minmax!(metrics, m.kernel, "kernel", BYTE_UNIT);
+        push_minmax!(metrics, m.kernel_stack, "kernel_stack", BYTE_UNIT);
+        push_minmax!(metrics, m.peak, "peak", BYTE_UNIT);
+        push_minmax!(metrics, m.shmem, "shmem", BYTE_UNIT);
+        push_minmax!(metrics, m.slab, "slab", BYTE_UNIT);
+        push_minmax!(metrics, m.swap_current, "swap_current", BYTE_UNIT);
+
+        let cpu = counters.cpu;
+
         push!(
-            snap.cpu_throttled_usec,
-            "cpu_throttled_usec",
+            metrics,
+            "usage_usec",
+            cpu.usage_usec.diff(),
             MICRO_SECOND_UNIT
         );
-        push!(snap.io_rbytes, "io_rbytes", BYTE_UNIT);
-        push!(snap.io_wbytes, "io_wbytes", BYTE_UNIT);
+        push!(
+            metrics,
+            "user_usec",
+            cpu.user_usec.diff(),
+            MICRO_SECOND_UNIT
+        );
+        push!(
+            metrics,
+            "system_usec",
+            cpu.system_usec.diff(),
+            MICRO_SECOND_UNIT
+        );
+
+        push_begin_end!(metrics, cpu.nr_periods, "nr_periods", COUNT_UNIT);
+        push_begin_end!(metrics, cpu.nr_throttled, "nr_throttled", COUNT_UNIT);
+        push_begin_end!(
+            metrics,
+            cpu.throttled_usec,
+            "throttled_usec",
+            MICRO_SECOND_UNIT
+        );
+        push_begin_end!(metrics, cpu.nr_bursts, "nr_bursts", COUNT_UNIT);
+        push_begin_end!(metrics, cpu.burst_usec, "burst_usec", MICRO_SECOND_UNIT);
+
+        let io = counters.io;
+
+        push_begin_end!(metrics, io.rbytes, "read_bytes", BYTE_UNIT);
+        push_begin_end!(metrics, io.wbytes, "write_bytes", BYTE_UNIT);
 
         Ok(metrics)
     }
 
     fn get_name() -> &'static str {
         SOURCE_NAME
-    }
-}
-
-impl Drop for CgroupSource {
-    fn drop(&mut self) {
-        if self.cgroup_path.exists() {
-            self.cleanup();
-        }
     }
 }

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -19,7 +19,7 @@ use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 use tokio_util::sync::CancellationToken;
 
-use crate::cgroup::{Cgroup, CgroupBackend, SysFsBackend};
+use crate::cgroup::{CgroupBackend, ChildCgroup, RootCgroup, SysFsBackend};
 use crate::counters::{Counters, CpuCounters, IoCounters, MemoryCounters};
 use crate::error::CgroupError;
 
@@ -62,8 +62,8 @@ where
 {
     config: CgroupConfig,
     handle: Option<WorkerHandle>,
-    pub proc_cgroup: Arc<Cgroup<B>>,
-    pub root_cgroup: Arc<Cgroup<B>>,
+    pub proc_cgroup: Arc<ChildCgroup<B>>,
+    pub root_cgroup: Arc<RootCgroup<B>>,
     proc_memory_counters: Arc<Mutex<MemoryCounters>>,
     global_memory_counters: Arc<Mutex<MemoryCounters>>,
     proc_cpu_counters: CpuCounters,
@@ -80,9 +80,9 @@ impl CgroupSource {
     /// Initializes internal cgroup handles but does initialize and attach any PID yet.
     pub fn new(config: CgroupConfig) -> Result<Self> {
         let root_cgroup = if let Some(cgroup_root) = &config.cgroup_root {
-            Cgroup::at(cgroup_root.clone())
+            RootCgroup::at(cgroup_root.clone())
         } else {
-            Cgroup::root()
+            RootCgroup::default()
         };
         let proc_cgroup = root_cgroup.child(&config.cgroup_name);
 
@@ -109,8 +109,8 @@ impl<B: CgroupBackend> CgroupSource<B> {
     /// This worker updates process and global memory counters at a fixed interval.
     /// It can be cancelled using the returned `CancellationToken`.
     pub fn create_worker(
-        root_cgroup: Arc<Cgroup<B>>,
-        proc_cgroup: Arc<Cgroup<B>>,
+        proc_cgroup: Arc<ChildCgroup<B>>,
+        root_cgroup: Arc<RootCgroup<B>>,
         proc_memory_counters: Arc<Mutex<MemoryCounters>>,
         global_memory_counters: Arc<Mutex<MemoryCounters>>,
         poll_interval: Duration,
@@ -128,12 +128,12 @@ impl<B: CgroupBackend> CgroupSource<B> {
                     _ = ticker.next() => {
                         trace!("Polled cgroup source.");
                         {
-                            let snapshot = proc_cgroup.stats().memory()?;
+                            let snapshot = proc_cgroup.memory()?;
                             let mut lock = proc_memory_counters.lock().await;
                             lock.update(&snapshot);
                         }
                         {
-                            let snapshot = root_cgroup.stats().memory()?;
+                            let snapshot = root_cgroup.memory()?;
                             let mut lock = global_memory_counters.lock().await;
                             lock.update(&snapshot);
                         }
@@ -168,8 +168,8 @@ impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
 
         if let Some(poll_interval) = self.config.poll_interval {
             self.handle = Some(Self::create_worker(
-                self.root_cgroup.clone(),
                 self.proc_cgroup.clone(),
+                self.root_cgroup.clone(),
                 self.proc_memory_counters.clone(),
                 self.global_memory_counters.clone(),
                 poll_interval,
@@ -190,24 +190,20 @@ impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
 
         self.end_timestamp = get_timestamp_micros();
         {
-            let snapshot = self.proc_cgroup.stats().memory()?;
+            let snapshot = self.proc_cgroup.memory()?;
             let mut lock = self.proc_memory_counters.lock().await;
             lock.update(&snapshot);
         }
-        self.proc_cpu_counters
-            .update(&self.proc_cgroup.stats().cpu()?);
-        self.proc_io_counters
-            .update(&self.proc_cgroup.stats().io()?);
+        self.proc_cpu_counters.update(&self.proc_cgroup.cpu()?);
+        self.proc_io_counters.update(&self.proc_cgroup.io()?);
 
         {
-            let snapshot = self.root_cgroup.stats().memory()?;
+            let snapshot = self.root_cgroup.memory()?;
             let mut lock = self.global_memory_counters.lock().await;
             lock.update(&snapshot);
         }
-        self.global_cpu_counters
-            .update(&self.root_cgroup.stats().cpu()?);
-        self.global_io_counters
-            .update(&self.root_cgroup.stats().io()?);
+        self.global_cpu_counters.update(&self.root_cgroup.cpu()?);
+        self.global_io_counters.update(&self.root_cgroup.io()?);
 
         Ok(())
     }
@@ -466,7 +462,7 @@ mod tests {
     use crate::cgroup::Controller;
     use crate::snapshot::{CpuSnapshot, IoSnapshot, MemorySnapshot};
     use std::collections::HashSet;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use tokio::time::{Duration, sleep};
 
@@ -478,23 +474,29 @@ mod tests {
     }
 
     impl CgroupBackend for MockCgroupBackend {
-        fn memory(&self) -> Result<MemorySnapshot> {
+        fn memory(&self, _path: &Path) -> Result<MemorySnapshot> {
             Ok(self.memory.lock().unwrap().clone())
         }
 
-        fn cpu(&self) -> Result<CpuSnapshot> {
+        fn cpu(&self, _path: &Path) -> Result<CpuSnapshot> {
             Ok(self.cpu.lock().unwrap().clone())
         }
 
-        fn io(&self) -> Result<IoSnapshot> {
+        fn io(&self, _path: &Path) -> Result<IoSnapshot> {
             Ok(self.io.lock().unwrap().clone())
         }
 
-        fn cleanup(&self) -> Result<()> {
+        fn cleanup(&self, _path: &Path, _root: &Path) -> Result<()> {
             Ok(())
         }
 
-        fn initialize(&self, _pid: i32, _controllers: &HashSet<Controller>) -> Result<()> {
+        fn initialize(
+            &self,
+            _path: &Path,
+            _root: &Path,
+            _pid: i32,
+            _controllers: &HashSet<Controller>,
+        ) -> Result<()> {
             Ok(())
         }
     }
@@ -502,15 +504,11 @@ mod tests {
     fn setup_source() -> (CgroupSource<MockCgroupBackend>, MockCgroupBackend) {
         let backend = MockCgroupBackend::default();
 
-        let root = Arc::new(Cgroup::new(
-            PathBuf::from("/tmp/root"),
-            None,
-            backend.clone(),
-        ));
+        let root = Arc::new(RootCgroup::new(PathBuf::from("/tmp/root"), backend.clone()));
 
-        let proc = Arc::new(Cgroup::new(
-            PathBuf::from("/tmp/proc"),
-            Some(PathBuf::from("/tmp/root")),
+        let proc = Arc::new(ChildCgroup::new(
+            PathBuf::from("/tmp/cgroup"),
+            PathBuf::from("/tmp/root"),
             backend.clone(),
         ));
 
@@ -632,8 +630,8 @@ mod tests {
         let (src, backend) = setup_source();
 
         let (token, handle) = CgroupSource::create_worker(
-            src.root_cgroup.clone(),
             src.proc_cgroup.clone(),
+            src.root_cgroup.clone(),
             src.proc_memory_counters.clone(),
             src.global_memory_counters.clone(),
             Duration::from_millis(10),

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -1,11 +1,16 @@
+//! cgroup metric source for Joule Profiler.
+//!
+//! This module implements a [`MetricReader`] and uses Linux cgroup v2 to
+//! collect per-process and global system metrics using kernel cgroup files.
+//!
+//! An asynchronous tokio task runs to poll non monotonic metrics.
+
 use futures::StreamExt;
 use joule_profiler_core::sensor::{Sensor, Sensors};
 use joule_profiler_core::source::MetricReader;
 use joule_profiler_core::types::{Metric, Metrics};
 use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
 use log::{debug, trace};
-use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -13,15 +18,18 @@ use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 use tokio_util::sync::CancellationToken;
 
-use crate::cgroup::{Cgroup, Controller, RootCgroup, StatsReader};
+use crate::cgroup::{Cgroup, RootCgroup, StatsReader};
 use crate::counters::{Counters, CpuCounters, IoCounters, MemoryCounters};
 use crate::error::CgroupError;
 
 mod cgroup;
+mod config;
 mod counters;
 mod error;
 mod snapshot;
 mod util;
+
+pub use config::CgroupConfig;
 
 const SOURCE_NAME: &str = "cgroup";
 
@@ -43,27 +51,10 @@ const COUNT_UNIT: MetricUnit = MetricUnit {
 pub(crate) type Result<T> = std::result::Result<T, CgroupError>;
 pub(crate) type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 
-#[derive(Debug, Clone)]
-pub struct CgroupConfig {
-    pub cgroup_root: PathBuf,
-    pub cgroup_name: String,
-    pub poll_interval: Option<Duration>,
-    pub controllers: HashSet<Controller>,
-}
-
-impl Default for CgroupConfig {
-    fn default() -> Self {
-        Self {
-            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
-            cgroup_name: format!("joule-profiler-{}", std::process::id()),
-            poll_interval: None,
-            controllers: vec![Controller::Io, Controller::Mem, Controller::Cpu]
-                .into_iter()
-                .collect(),
-        }
-    }
-}
-
+/// cgroup metrics source.
+///
+/// Owns the process cgroup and root cgroup handles, and maintains
+/// internal counters for both process-level and system-wide metrics.
 pub struct CgroupSource {
     config: CgroupConfig,
     handle: Option<WorkerHandle>,
@@ -78,6 +69,9 @@ pub struct CgroupSource {
 }
 
 impl CgroupSource {
+    /// Creates a new cgroup metric source.
+    ///
+    /// Initializes internal cgroup handles but does initialize and attach any PID yet.
     pub fn new(config: CgroupConfig) -> Result<Self> {
         let root_cgroup = Arc::new(RootCgroup::new(config.cgroup_root.clone()));
         let proc_cgroup = Arc::new(root_cgroup.child(&config.cgroup_name));
@@ -96,6 +90,10 @@ impl CgroupSource {
         })
     }
 
+    /// Creates a background worker that periodically samples memory usage.
+    ///
+    /// This worker updates process and global memory counters at a fixed interval.
+    /// It can be cancelled using the returned `CancellationToken`.
     pub fn create_worker(
         root_cgroup: Arc<RootCgroup>,
         proc_cgroup: Arc<Cgroup>,
@@ -145,6 +143,12 @@ impl MetricReader for CgroupSource {
     type Type = Counters;
     type Error = CgroupError;
 
+    /// Initializes the cgroup for the given process and enables controllers.
+    ///
+    /// - creates the process cgroup directory
+    /// - enables requested controllers on root cgroup
+    /// - attaches the target PID
+    /// - optionally starts background polling worker
     async fn init(&mut self, pid: i32) -> Result<()> {
         self.proc_cgroup.initialize()?;
         for controller in &self.config.controllers {
@@ -167,6 +171,9 @@ impl MetricReader for CgroupSource {
         Ok(())
     }
 
+    /// Performs a measurement of all available metrics.
+    ///
+    /// Updates internal CPU, memory, and I/O counters.
     async fn measure(&mut self) -> Result<()> {
         {
             let snapshot = self.proc_cgroup.stats().memory()?;
@@ -191,6 +198,7 @@ impl MetricReader for CgroupSource {
         Ok(())
     }
 
+    /// Returns collected metrics and resets per-phase counters.
     async fn retrieve(&mut self) -> Result<Self::Type> {
         let proc_memory = {
             let mut lock = self.proc_memory_counters.lock().await;
@@ -228,6 +236,7 @@ impl MetricReader for CgroupSource {
         })
     }
 
+    /// Stops background worker and cleans up the cgroup.
     async fn join(&mut self) -> Result<()> {
         if let Some((cancellation_token, handle)) = self.handle.take() {
             cancellation_token.cancel();
@@ -237,6 +246,7 @@ impl MetricReader for CgroupSource {
         Ok(())
     }
 
+    /// Returns the list of exported sensors.
     fn get_sensors(&self) -> Result<Sensors> {
         Ok(vec![
             Sensor::new("usage_usec", MICRO_SECOND_UNIT, SOURCE_NAME),
@@ -268,6 +278,7 @@ impl MetricReader for CgroupSource {
         ])
     }
 
+    /// Converts counters into metrics.
     fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
         Ok(to_metrics(
             &counters.proc_memory,

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -1,0 +1,277 @@
+use std::fs;
+use std::path::PathBuf;
+use log::{debug, trace, warn};
+use joule_profiler_core::sensor::{Sensor, Sensors};
+use joule_profiler_core::source::MetricReader;
+use joule_profiler_core::types::{Metric, Metrics};
+use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
+use crate::error::CgroupError;
+use crate::snapshot::Snapshot;
+use crate::util::{read_flat_keyed, read_io_stat, read_u64_opt};
+
+mod error;
+mod snapshot;
+mod util;
+
+const SOURCE_NAME: &str = "CGroup";
+
+const BYTE_UNIT: MetricUnit = MetricUnit {
+    prefix: UnitPrefix::None,
+    unit: Unit::Byte,
+};
+
+const MICRO_SECOND_UNIT: MetricUnit = MetricUnit {
+    prefix: UnitPrefix::Micro,
+    unit: Unit::Second,
+};
+
+const COUNT_UNIT: MetricUnit = MetricUnit {
+    prefix: UnitPrefix::None,
+    unit: Unit::Count,
+};
+
+
+#[derive(Debug, Clone)]
+pub struct CgroupConfig {
+    pub cgroup_root: PathBuf,
+    pub cgroup_name: String,
+}
+
+impl Default for CgroupConfig {
+    fn default() -> Self {
+        Self {
+            cgroup_root: PathBuf::from("/sys/fs/cgroup"),
+            cgroup_name: format!("joule-profiler-{}", std::process::id()),
+        }
+    }
+}
+
+pub struct CgroupSource {
+    config: CgroupConfig,
+    cgroup_path: PathBuf,
+    last_snapshot: Snapshot,
+}
+
+impl CgroupSource {
+    pub fn new(config: CgroupConfig) -> Result<Self, CgroupError> {
+        let controllers = config.cgroup_root.join("cgroup.controllers");
+        if !controllers.exists() {
+            return Err(CgroupError::NotAvailable(
+                config.cgroup_root.display().to_string(),
+            ));
+        }
+
+        let cgroup_path = config.cgroup_root.join(&config.cgroup_name);
+
+        Ok(Self {config, cgroup_path,last_snapshot: Snapshot::default()})
+    }
+
+    pub fn try_default() -> Result<Self, CgroupError> {
+        Self::new(CgroupConfig::default())
+    }
+
+    fn create_and_enable_controllers(&self) -> Result<(), CgroupError> {
+        if !self.cgroup_path.exists() {
+            fs::create_dir_all(&self.cgroup_path).map_err(|e| CgroupError::Io {
+                path: self.cgroup_path.display().to_string(),
+                source: e,
+            })?;
+            debug!("Created cgroup at {}", self.cgroup_path.display());
+        }
+
+        let subtree_control = self.config.cgroup_root.join("cgroup.subtree_control");
+        for controller in ["memory", "cpu", "io"] {
+            let token = format!("+{controller}");
+            let controller_static: &'static str = match controller {
+                "memory" => "memory",
+                "cpu" => "cpu",
+                "io" => "io",
+                _ => unreachable!(),
+            };
+            fs::write(&subtree_control, &token).map_err(|e| CgroupError::EnableController {
+                controller: controller_static,
+                path: subtree_control.display().to_string(),
+                source: e,
+            })?;
+            trace!(
+                "Enabled controller `{controller}` in {}",
+                subtree_control.display()
+            );
+        }
+
+        Ok(())
+    }
+
+
+    fn attach_pid(&self, pid: i32) -> Result<(), CgroupError> {
+        let procs_path = self.cgroup_path.join("cgroup.procs");
+        fs::write(&procs_path, pid.to_string()).map_err(|e| CgroupError::Attach { pid, source: e })?;
+        debug!(
+            "Attached PID {pid} to cgroup {}",
+            self.cgroup_path.display()
+        );
+        Ok(())
+    }
+
+    fn live_pids(&self) -> Vec<i32> {
+        let path = self.cgroup_path.join("cgroup.procs");
+        match fs::read_to_string(&path) {
+            Ok(raw) => raw
+                .lines()
+                .filter_map(|l| l.trim().parse::<i32>().ok())
+                .collect(),
+            Err(e) => {
+                warn!("Could not read cgroup.procs ({}): {e}", path.display());
+                Vec::new()
+            }
+        }
+    }
+
+    fn cleanup(&self) {
+        let root_procs = self.config.cgroup_root.join("cgroup.procs");
+        for pid in self.live_pids() {
+            if let Err(e) = fs::write(&root_procs, pid.to_string()) {
+                warn!("Could not move PID {pid} back to root cgroup: {e}");
+            }
+        }
+        if self.cgroup_path.exists() {
+            if let Err(e) = fs::remove_dir(&self.cgroup_path) {
+                warn!(
+                    "Could not remove cgroup {} (may still have live tasks): {e}",
+                    self.cgroup_path.display()
+                );
+            } else {
+                debug!("Removed cgroup {}", self.cgroup_path.display());
+            }
+        }
+    }
+
+    fn snapshot(&self) -> Snapshot {
+        let mut snap = Snapshot::default();
+
+        snap.memory_current = read_u64_opt(&self.cgroup_path.join("memory.current"))
+            .ok()
+            .flatten();
+
+        snap.memory_peak = read_u64_opt(&self.cgroup_path.join("memory.peak"))
+            .ok()
+            .flatten();
+
+        snap.memory_swap_current =
+            read_u64_opt(&self.cgroup_path.join("memory.swap.current"))
+                .ok()
+                .flatten();
+
+        if let Ok(stat) = read_flat_keyed(&self.cgroup_path.join("memory.stat")) {
+            snap.memory_anon = stat.get("anon").copied();
+            snap.memory_file = stat.get("file").copied();
+            snap.memory_kernel_stack = stat.get("kernel_stack").copied();
+            snap.memory_slab = stat.get("slab").copied();
+        }
+
+        if let Ok(stat) = read_flat_keyed(&self.cgroup_path.join("cpu.stat")) {
+            snap.cpu_usage_usec = stat.get("usage_usec").copied();
+            snap.cpu_user_usec = stat.get("user_usec").copied();
+            snap.cpu_system_usec = stat.get("system_usec").copied();
+            snap.cpu_nr_periods = stat.get("nr_periods").copied();
+            snap.cpu_nr_throttled = stat.get("nr_throttled").copied();
+            snap.cpu_throttled_usec = stat.get("throttled_usec").copied();
+        }
+
+        if let Ok((rb, wb)) = read_io_stat(&self.cgroup_path.join("io.stat")) {
+            snap.io_rbytes = Some(rb);
+            snap.io_wbytes = Some(wb);
+        }
+        snap
+    }
+}
+
+impl MetricReader for CgroupSource {
+    type Type = Snapshot;
+    type Error = CgroupError;
+
+    async fn init(&mut self, pid: i32) -> Result<(), Self::Error> {
+        self.create_and_enable_controllers()?;
+        self.attach_pid(pid)?;
+        debug!("CgroupSource initialised for PID {pid}");
+        Ok(())
+    }
+
+    async fn join(&mut self) -> Result<(), Self::Error> {
+        self.cleanup();
+        Ok(())
+    }
+
+    async fn measure(&mut self) -> Result<(), Self::Error> {
+        self.last_snapshot = self.snapshot();
+        Ok(())
+    }
+
+    async fn retrieve(&mut self) -> Result<Self::Type, Self::Error> {
+        Ok(std::mem::take(&mut self.last_snapshot))
+    }
+
+    fn get_sensors(&self) -> Result<Sensors, Self::Error> {
+        let sensors = vec![
+            Sensor::new("memory_current",      BYTE_UNIT,         Self::get_name()),
+            Sensor::new("memory_peak",         BYTE_UNIT,         Self::get_name()),
+            Sensor::new("memory_anon",         BYTE_UNIT,         Self::get_name()),
+            Sensor::new("memory_file",         BYTE_UNIT,         Self::get_name()),
+            Sensor::new("memory_kernel_stack", BYTE_UNIT,         Self::get_name()),
+            Sensor::new("memory_slab",         BYTE_UNIT,         Self::get_name()),
+            Sensor::new("memory_swap_current", BYTE_UNIT,         Self::get_name()),
+            Sensor::new("cpu_usage_usec",      MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("cpu_user_usec",       MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("cpu_system_usec",     MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("cpu_nr_periods",      COUNT_UNIT,        Self::get_name()),
+            Sensor::new("cpu_nr_throttled",    COUNT_UNIT,        Self::get_name()),
+            Sensor::new("cpu_throttled_usec",  MICRO_SECOND_UNIT, Self::get_name()),
+            Sensor::new("io_rbytes",           BYTE_UNIT,         Self::get_name()),
+            Sensor::new("io_wbytes",           BYTE_UNIT,         Self::get_name()),
+        ];
+        Ok(sensors)
+    }
+
+    fn to_metrics(&self, snap: Self::Type) -> Result<Metrics, Self::Error> {
+        let mut metrics = Vec::new();
+
+        macro_rules! push {
+            ($field:expr, $name:expr, $unit:expr) => {
+                if let Some(v) = $field {
+                    metrics.push(Metric::new($name, v, $unit, Self::get_name()));
+                }
+            };
+        }
+
+        push!(snap.memory_current,      "memory_current",      BYTE_UNIT);
+        push!(snap.memory_peak,         "memory_peak",         BYTE_UNIT);
+        push!(snap.memory_anon,         "memory_anon",         BYTE_UNIT);
+        push!(snap.memory_file,         "memory_file",         BYTE_UNIT);
+        push!(snap.memory_kernel_stack, "memory_kernel_stack", BYTE_UNIT);
+        push!(snap.memory_slab,         "memory_slab",         BYTE_UNIT);
+        push!(snap.memory_swap_current, "memory_swap_current", BYTE_UNIT);
+        push!(snap.cpu_usage_usec,      "cpu_usage_usec",      MICRO_SECOND_UNIT);
+        push!(snap.cpu_user_usec,       "cpu_user_usec",       MICRO_SECOND_UNIT);
+        push!(snap.cpu_system_usec,     "cpu_system_usec",     MICRO_SECOND_UNIT);
+        push!(snap.cpu_nr_periods,      "cpu_nr_periods",      COUNT_UNIT);
+        push!(snap.cpu_nr_throttled,    "cpu_nr_throttled",    COUNT_UNIT);
+        push!(snap.cpu_throttled_usec,  "cpu_throttled_usec",  MICRO_SECOND_UNIT);
+        push!(snap.io_rbytes,           "io_rbytes",           BYTE_UNIT);
+        push!(snap.io_wbytes,           "io_wbytes",           BYTE_UNIT);
+
+        Ok(metrics)
+    }
+
+
+    fn get_name() -> &'static str {
+        SOURCE_NAME
+    }
+}
+
+impl Drop for CgroupSource {
+    fn drop(&mut self) {
+        if self.cgroup_path.exists() {
+            self.cleanup();
+        }
+    }
+}

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -59,8 +59,8 @@ pub(crate) type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 pub struct CgroupSource {
     config: CgroupConfig,
     handle: Option<WorkerHandle>,
-    proc_cgroup: Arc<Cgroup>,
-    root_cgroup: Arc<RootCgroup>,
+    pub proc_cgroup: Arc<Cgroup>,
+    pub root_cgroup: Arc<RootCgroup>,
     proc_memory_counters: Arc<Mutex<MemoryCounters>>,
     global_memory_counters: Arc<Mutex<MemoryCounters>>,
     proc_cpu_counters: CpuCounters,
@@ -449,4 +449,120 @@ fn to_metrics(
     push_begin_end!(metrics, io.wbytes, "write_bytes", BYTE_UNIT);
 
     metrics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf};
+    use tokio::time::Duration;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("cgroup_src_{name}"));
+        let _ = fs::create_dir_all(&p);
+        p
+    }
+
+    fn setup_source(name: &str) -> CgroupSource {
+        let mut cfg = CgroupConfig::default();
+        cfg.cgroup_root = temp_root(name);
+        cfg.cgroup_name = "test".to_string();
+        cfg.poll_interval = None;
+        CgroupSource::new(cfg).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_init_and_attach() {
+        let mut src = setup_source("init");
+
+        src.init(42).await.unwrap();
+
+        let procs = src.proc_cgroup.path.join("cgroup.procs");
+        let content = fs::read_to_string(procs).unwrap();
+
+        assert!(content.contains("42"));
+
+        src.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_measure_updates_counters() {
+        let mut src = setup_source("measure");
+        let root = src.root_cgroup.path.clone();
+
+        src.init(1).await.unwrap();
+
+        fs::write(root.join("test/memory.stat"), "anon 200").unwrap();
+
+        {
+            let mem = src.proc_memory_counters.lock().await;
+            assert!(mem.anon.is_none());
+        }
+
+        src.measure().await.unwrap();
+
+        {
+            let mem = src.proc_memory_counters.lock().await;
+            assert_eq!(mem.anon.unwrap().max().unwrap(), 200);
+            assert_eq!(mem.anon.unwrap().min().unwrap(), 200);
+        }
+
+        fs::write(root.join("test/memory.stat"), "anon 400").unwrap();
+
+        src.measure().await.unwrap();
+
+        {
+            let mem = src.proc_memory_counters.lock().await;
+            assert_eq!(mem.anon.unwrap().max().unwrap(), 400);
+            assert_eq!(mem.anon.unwrap().min().unwrap(), 200);
+        }
+
+        src.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_compute_diffs() {
+        let mut src = setup_source("retrieve");
+        let root = src.root_cgroup.path.clone();
+
+        fs::write(
+            root.join("test/cpu.stat"),
+            "usage_usec 1000\nuser_usec 500\nsystem_usec 500\nnr_periods 2\n",
+        )
+        .unwrap();
+
+        src.init(1).await.unwrap();
+        src.measure().await.unwrap();
+
+        fs::write(
+            root.join("test/cpu.stat"),
+            "usage_usec 2000\nuser_usec 1000\nsystem_usec 1000\nnr_periods 4\n",
+        )
+        .unwrap();
+
+        src.measure().await.unwrap();
+
+        let counters = src.retrieve().await.unwrap();
+
+        assert_eq!(counters.proc_cpu.usage_usec.diff(), 1000);
+        assert_eq!(counters.proc_cpu.user_usec.diff(), 500);
+        assert_eq!(counters.proc_cpu.system_usec.diff(), 500);
+        assert_eq!(counters.proc_cpu.nr_periods.unwrap().diff(), 2);
+
+        src.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_join_stops_worker() {
+        let mut src = setup_source("worker");
+
+        src.config.poll_interval = Some(Duration::from_millis(10));
+
+        src.init(1).await.unwrap();
+
+        let res = src.join().await;
+
+        assert!(res.is_ok());
+    }
 }

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -161,8 +161,6 @@ impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
     async fn init(&mut self, pid: i32) -> Result<()> {
         if self.config.create_cgroup {
             self.proc_cgroup.create()?;
-            self.root_cgroup
-                .enable_controllers(&self.config.controllers)?;
         }
         if self.config.attach_pid {
             self.proc_cgroup.attach_pid(pid)?;
@@ -463,9 +461,7 @@ fn to_metrics(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroup::Controller;
     use crate::snapshot::{CpuSnapshot, IoSnapshot, MemorySnapshot};
-    use std::collections::HashSet;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use tokio::time::{Duration, sleep};
@@ -499,14 +495,6 @@ mod tests {
         }
 
         fn attach_pid(&self, _path: &Path, _pid: i32) -> Result<()> {
-            Ok(())
-        }
-
-        fn enable_controllers(
-            &self,
-            _root: &Path,
-            _controllers: &HashSet<Controller>,
-        ) -> Result<()> {
             Ok(())
         }
     }

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -157,14 +157,16 @@ impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
     type Type = Counters;
     type Error = CgroupError;
 
-    /// Initializes the cgroup for the given process and enables controllers.
-    ///
-    /// - creates the process cgroup directory
-    /// - enables requested controllers on root cgroup
-    /// - attaches the target PID
-    /// - optionally starts background polling worker
+    /// Initializes the cgroup source with the given pid.
     async fn init(&mut self, pid: i32) -> Result<()> {
-        self.proc_cgroup.initialize(pid, &self.config.controllers)?;
+        if self.config.create_cgroup {
+            self.proc_cgroup.create()?;
+            self.root_cgroup
+                .enable_controllers(&self.config.controllers)?;
+        }
+        if self.config.attach_pid {
+            self.proc_cgroup.attach_pid(pid)?;
+        }
 
         if let Some(poll_interval) = self.config.poll_interval {
             self.handle = Some(Self::create_worker(
@@ -210,7 +212,7 @@ impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
 
     /// Returns collected metrics and resets per-phase counters.
     async fn retrieve(&mut self) -> Result<Self::Type> {
-        debug!("Retriving cgroup counters.");
+        debug!("Retrieving cgroup counters.");
 
         let proc_memory = {
             let mut lock = self.proc_memory_counters.lock().await;
@@ -260,7 +262,9 @@ impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
             cancellation_token.cancel();
             handle.await??;
         }
-        self.proc_cgroup.cleanup()?;
+        if self.config.create_cgroup {
+            self.proc_cgroup.cleanup()?;
+        }
         Ok(())
     }
 
@@ -490,11 +494,17 @@ mod tests {
             Ok(())
         }
 
-        fn initialize(
+        fn create(&self, _path: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        fn attach_pid(&self, _path: &Path, _pid: i32) -> Result<()> {
+            Ok(())
+        }
+
+        fn enable_controllers(
             &self,
-            _path: &Path,
             _root: &Path,
-            _pid: i32,
             _controllers: &HashSet<Controller>,
         ) -> Result<()> {
             Ok(())

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -166,15 +166,13 @@ impl<B: CgroupBackend> MetricReader for CgroupSource<B> {
             self.proc_cgroup.attach_pid(pid)?;
         }
 
-        if let Some(poll_interval) = self.config.poll_interval {
-            self.handle = Some(Self::create_worker(
-                self.proc_cgroup.clone(),
-                self.root_cgroup.clone(),
-                self.proc_memory_counters.clone(),
-                self.global_memory_counters.clone(),
-                poll_interval,
-            )?);
-        }
+        self.handle = Some(Self::create_worker(
+            self.proc_cgroup.clone(),
+            self.root_cgroup.clone(),
+            self.proc_memory_counters.clone(),
+            self.global_memory_counters.clone(),
+            self.config.poll_interval,
+        )?);
 
         self.begin_timestamp = get_timestamp_micros();
 

--- a/sources/cgroup/src/snapshot.rs
+++ b/sources/cgroup/src/snapshot.rs
@@ -1,92 +1,31 @@
-#[derive(Debug, Clone)]
-pub struct Snapshot {
-    pub memory_current_min: u64,
-    pub memory_current_max: u64,
-    pub memory_anon_min: u64,
-    pub memory_anon_max: u64,
-    pub memory_file_min: u64,
-    pub memory_file_max: u64,
-    pub memory_swap_current_min: u64,
-    pub memory_swap_current_max: u64,
-
-    pub memory_peak: Option<u64>,
-    pub memory_kernel_stack: Option<u64>,
-    pub memory_slab: Option<u64>,
-    pub cpu_usage_usec: Option<u64>,
-    pub cpu_user_usec: Option<u64>,
-    pub cpu_system_usec: Option<u64>,
-    pub cpu_nr_periods: Option<u64>,
-    pub cpu_nr_throttled: Option<u64>,
-    pub cpu_throttled_usec: Option<u64>,
-    pub io_rbytes: Option<u64>,
-    pub io_wbytes: Option<u64>,
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemorySnapshot {
+    pub current: u64,
+    pub swap_current: Option<u64>,
+    pub anon: Option<u64>,
+    pub file: Option<u64>,
+    pub peak: Option<u64>,
+    pub shmem: Option<u64>,
+    pub kernel: Option<u64>,
+    pub kernel_stack: Option<u64>,
+    pub slab: Option<u64>,
 }
 
-impl Default for Snapshot {
-    fn default() -> Self {
-        Self {
-            memory_current_min: u64::MAX,
-            memory_current_max: 0,
-            memory_anon_min: u64::MAX,
-            memory_anon_max: 0,
-            memory_file_min: u64::MAX,
-            memory_file_max: 0,
-            memory_swap_current_min: u64::MAX,
-            memory_swap_current_max: 0,
-            memory_peak: None,
-            memory_kernel_stack: None,
-            memory_slab: None,
-            cpu_usage_usec: None,
-            cpu_user_usec: None,
-            cpu_system_usec: None,
-            cpu_nr_periods: None,
-            cpu_nr_throttled: None,
-            cpu_throttled_usec: None,
-            io_rbytes: None,
-            io_wbytes: None,
-        }
-    }
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CpuSnapshot {
+    pub usage_usec: u64,
+    pub user_usec: u64,
+    pub system_usec: u64,
+
+    pub nr_periods: Option<u64>,
+    pub nr_throttled: Option<u64>,
+    pub throttled_usec: Option<u64>,
+    pub nr_bursts: Option<u64>,
+    pub burst_usec: Option<u64>,
 }
 
-impl Snapshot {
-    pub fn update(
-        &mut self,
-        memory_current: u64,
-        memory_anon: u64,
-        memory_file: u64,
-        memory_swap_current: u64,
-    ) {
-        self.memory_current_min = self.memory_current_min.min(memory_current);
-        self.memory_current_max = self.memory_current_max.max(memory_current);
-        self.memory_anon_min = self.memory_anon_min.min(memory_anon);
-        self.memory_anon_max = self.memory_anon_max.max(memory_anon);
-        self.memory_file_min = self.memory_file_min.min(memory_file);
-        self.memory_file_max = self.memory_file_max.max(memory_file);
-        self.memory_swap_current_min = self.memory_swap_current_min.min(memory_swap_current);
-        self.memory_swap_current_max = self.memory_swap_current_max.max(memory_swap_current);
-    }
-
-    pub fn reset_phase(&mut self) {
-        self.memory_current_min = u64::MAX;
-        self.memory_current_max = 0;
-        self.memory_anon_min = u64::MAX;
-        self.memory_anon_max = 0;
-        self.memory_file_min = u64::MAX;
-        self.memory_file_max = 0;
-        self.memory_swap_current_min = u64::MAX;
-        self.memory_swap_current_max = 0;
-    }
-
-    pub fn remove_sentinel_values(&mut self) {
-        for v in [
-            &mut self.memory_current_min,
-            &mut self.memory_anon_min,
-            &mut self.memory_file_min,
-            &mut self.memory_swap_current_min,
-        ] {
-            if *v == u64::MAX {
-                *v = 0;
-            }
-        }
-    }
+#[derive(Debug, Default, Clone, Copy)]
+pub struct IoSnapshot {
+    pub rbytes: Option<u64>,
+    pub wbytes: Option<u64>,
 }

--- a/sources/cgroup/src/snapshot.rs
+++ b/sources/cgroup/src/snapshot.rs
@@ -1,36 +1,92 @@
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Snapshot {
-
-    // Memory (memory.current)
-    pub memory_current: Option<u64>,
+    pub memory_current_min: u64,
+    pub memory_current_max: u64,
+    pub memory_anon_min: u64,
+    pub memory_anon_max: u64,
+    pub memory_file_min: u64,
+    pub memory_file_max: u64,
+    pub memory_swap_current_min: u64,
+    pub memory_swap_current_max: u64,
 
     pub memory_peak: Option<u64>,
-
-    pub memory_anon: Option<u64>,
-
-    pub memory_file: Option<u64>,
-
     pub memory_kernel_stack: Option<u64>,
-
     pub memory_slab: Option<u64>,
-
-    pub memory_swap_current: Option<u64>,
-
-    // CPU (cpu.stat)
     pub cpu_usage_usec: Option<u64>,
-
     pub cpu_user_usec: Option<u64>,
-
     pub cpu_system_usec: Option<u64>,
-
     pub cpu_nr_periods: Option<u64>,
-
     pub cpu_nr_throttled: Option<u64>,
-
     pub cpu_throttled_usec: Option<u64>,
-
-    // I/O (io.stat)
     pub io_rbytes: Option<u64>,
-
     pub io_wbytes: Option<u64>,
+}
+
+impl Default for Snapshot {
+    fn default() -> Self {
+        Self {
+            memory_current_min: u64::MAX,
+            memory_current_max: 0,
+            memory_anon_min: u64::MAX,
+            memory_anon_max: 0,
+            memory_file_min: u64::MAX,
+            memory_file_max: 0,
+            memory_swap_current_min: u64::MAX,
+            memory_swap_current_max: 0,
+            memory_peak: None,
+            memory_kernel_stack: None,
+            memory_slab: None,
+            cpu_usage_usec: None,
+            cpu_user_usec: None,
+            cpu_system_usec: None,
+            cpu_nr_periods: None,
+            cpu_nr_throttled: None,
+            cpu_throttled_usec: None,
+            io_rbytes: None,
+            io_wbytes: None,
+        }
+    }
+}
+
+impl Snapshot {
+    pub fn update(
+        &mut self,
+        memory_current: u64,
+        memory_anon: u64,
+        memory_file: u64,
+        memory_swap_current: u64,
+    ) {
+        self.memory_current_min = self.memory_current_min.min(memory_current);
+        self.memory_current_max = self.memory_current_max.max(memory_current);
+        self.memory_anon_min = self.memory_anon_min.min(memory_anon);
+        self.memory_anon_max = self.memory_anon_max.max(memory_anon);
+        self.memory_file_min = self.memory_file_min.min(memory_file);
+        self.memory_file_max = self.memory_file_max.max(memory_file);
+        self.memory_swap_current_min = self.memory_swap_current_min.min(memory_swap_current);
+        self.memory_swap_current_max = self.memory_swap_current_max.max(memory_swap_current);
+    }
+
+    pub fn reset_phase(&mut self) {
+        self.memory_current_min = u64::MAX;
+        self.memory_current_max = 0;
+        self.memory_anon_min = u64::MAX;
+        self.memory_anon_max = 0;
+        self.memory_file_min = u64::MAX;
+        self.memory_file_max = 0;
+        self.memory_swap_current_min = u64::MAX;
+        self.memory_swap_current_max = 0;
+    }
+
+    pub fn remove_sentinel_values(&mut self) {
+        for v in [
+            &mut self.memory_current_min,
+            &mut self.memory_anon_min,
+            &mut self.memory_file_min,
+            &mut self.memory_swap_current_min,
+        ] {
+            if *v == u64::MAX {
+                *v = 0;
+            }
+        }
+    }
 }

--- a/sources/cgroup/src/snapshot.rs
+++ b/sources/cgroup/src/snapshot.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MemorySnapshot {
-    pub current: u64,
+    pub current: Option<u64>,
     pub swap_current: Option<u64>,
     pub anon: Option<u64>,
     pub file: Option<u64>,

--- a/sources/cgroup/src/snapshot.rs
+++ b/sources/cgroup/src/snapshot.rs
@@ -1,31 +1,79 @@
+/// Memory-related cgroup snapshot.
+///
+/// Represents a single read of `memory.stat` + memory pressure files.
+///
+/// All values are raw kernel counters in bytes.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MemorySnapshot {
+    /// Total current memory usage.
     pub current: Option<u64>,
+
+    /// Current swap usage.
     pub swap_current: Option<u64>,
+
+    /// Anonymous memory usage (heap, stack, anon mmap).
     pub anon: Option<u64>,
+
+    /// File-backed memory usage (page cache).
     pub file: Option<u64>,
+
+    /// Peak memory usage observed by cgroup.
     pub peak: Option<u64>,
+
+    /// Shared memory usage (tmpfs, /dev/shm).
     pub shmem: Option<u64>,
+
+    /// Kernel memory usage.
     pub kernel: Option<u64>,
+
+    /// Kernel stack memory usage.
     pub kernel_stack: Option<u64>,
+
+    /// Slab allocator usage.
     pub slab: Option<u64>,
 }
 
+/// CPU-related cgroup snapshot.
+///
+/// Represents raw values from `cpu.stat`.
+///
+/// `usage_usec`, `user_usec`, and `system_usec` are always present
+/// and represent cumulative CPU time in microseconds.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CpuSnapshot {
+    /// Total CPU time consumed (user + kernel).
     pub usage_usec: u64,
+
+    /// CPU time spent in user space.
     pub user_usec: u64,
+
+    /// CPU time spent in kernel space.
     pub system_usec: u64,
 
+    /// Number of scheduling periods.
     pub nr_periods: Option<u64>,
+
+    /// Number of throttled periods due to CPU quota limits.
     pub nr_throttled: Option<u64>,
+
+    /// Total time spent throttled.
     pub throttled_usec: Option<u64>,
+
+    /// Number of burst events (burstable cgroups).
     pub nr_bursts: Option<u64>,
+
+    /// Total burst time.
     pub burst_usec: Option<u64>,
 }
 
+/// I/O-related cgroup snapshot.
+///
+/// Represents raw values from `io.stat`.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct IoSnapshot {
+    /// Total bytes read by the cgroup.
     pub rbytes: Option<u64>,
+
+    /// Total bytes written by the cgroup.
     pub wbytes: Option<u64>,
 }

--- a/sources/cgroup/src/snapshot.rs
+++ b/sources/cgroup/src/snapshot.rs
@@ -1,0 +1,36 @@
+#[derive(Debug, Clone, Default)]
+pub struct Snapshot {
+
+    // Memory (memory.current)
+    pub memory_current: Option<u64>,
+
+    pub memory_peak: Option<u64>,
+
+    pub memory_anon: Option<u64>,
+
+    pub memory_file: Option<u64>,
+
+    pub memory_kernel_stack: Option<u64>,
+
+    pub memory_slab: Option<u64>,
+
+    pub memory_swap_current: Option<u64>,
+
+    // CPU (cpu.stat)
+    pub cpu_usage_usec: Option<u64>,
+
+    pub cpu_user_usec: Option<u64>,
+
+    pub cpu_system_usec: Option<u64>,
+
+    pub cpu_nr_periods: Option<u64>,
+
+    pub cpu_nr_throttled: Option<u64>,
+
+    pub cpu_throttled_usec: Option<u64>,
+
+    // I/O (io.stat)
+    pub io_rbytes: Option<u64>,
+
+    pub io_wbytes: Option<u64>,
+}

--- a/sources/cgroup/src/util.rs
+++ b/sources/cgroup/src/util.rs
@@ -98,3 +98,108 @@ pub fn read_io_stat(path: &Path) -> Result<(Option<u64>, Option<u64>)> {
         if has_w { Some(wbytes) } else { None },
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs::File, io::Write, path::PathBuf};
+
+    fn temp_file(name: &str, content: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(name);
+        let mut file = File::create(&path).unwrap();
+        write!(file, "{}", content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_read_u64_ok() {
+        let path = temp_file("valid_u64", "42");
+
+        let v = read_u64(&path).unwrap();
+        assert_eq!(v, 42);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_read_u64_invalid() {
+        let path = temp_file("invalid_u64", "NaN");
+
+        let err = read_u64(&path).unwrap_err();
+        assert!(matches!(err, CgroupError::Parse { .. }));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_read_u64_opt_missing() {
+        let mut path = std::env::temp_dir();
+        path.push("missing_file");
+
+        let v = read_u64_opt(&path).unwrap();
+        assert_eq!(v, None);
+    }
+
+    #[test]
+    fn test_read_u64_opt_present() {
+        let path = temp_file("present_u64", "100");
+
+        let v = read_u64_opt(&path).unwrap();
+        assert_eq!(v, Some(100));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_read_flat_keyed_file() {
+        let content = "\
+foo 10
+bar 20
+invalid_line
+baz not_a_number";
+
+        let path = temp_file("test_flat_keyed", content);
+
+        let map = read_flat_keyed_file(&path).unwrap();
+        println!("map {map:?}");
+        println!("{content}");
+
+        assert_eq!(map.get("foo"), Some(&10));
+        assert_eq!(map.get("bar"), Some(&20));
+        assert_eq!(map.get("baz"), None);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_read_io_stat() {
+        let content = "\
+8:0 rbytes=100 wbytes=50
+8:1 rbytes=20 wbytes=30";
+
+        let path = temp_file("test_io_stat", content);
+
+        let (r, w) = read_io_stat(&path).unwrap();
+
+        assert_eq!(r, Some(120));
+        assert_eq!(w, Some(80));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_read_io_stat_partial() {
+        let content = "\
+8:0 rbytes=10
+8:1 rbytes=5";
+
+        let path = temp_file("test_io_stat_partial", content);
+
+        let (r, w) = read_io_stat(&path).unwrap();
+
+        assert_eq!(r, Some(15));
+        assert_eq!(w, None);
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/sources/cgroup/src/util.rs
+++ b/sources/cgroup/src/util.rs
@@ -1,62 +1,79 @@
-//! Low-level helpers to read cgroup v2 pseudo-files.
+use std::{collections::HashMap, fs, path::Path};
 
-use std::collections::HashMap;
-use std::fs;
-use std::path::Path;
+use crate::{Result, error::CgroupError};
 
-use crate::error::CgroupError;
-pub fn read_u64_opt(path: &Path) -> Result<Option<u64>, CgroupError> {
+pub fn read_u64(path: &Path) -> Result<u64> {
     let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
-        path: path.display().to_string(),
+        path: path.to_path_buf(),
         source: e,
     })?;
     let trimmed = raw.trim();
-    if trimmed == "max" {
-        return Ok(None);
-    }
-    trimmed
-        .parse::<u64>()
-        .map(Some)
-        .map_err(|_| CgroupError::Parse {
-            path: path.display().to_string(),
-            expected: "u64 or \"max\"",
-            got: trimmed.to_string(),
-        })
+    trimmed.parse::<u64>().map_err(|err| CgroupError::Parse {
+        path: path.to_path_buf(),
+        source: err,
+    })
 }
 
-pub fn read_flat_keyed(path: &Path) -> Result<HashMap<String, u64>, CgroupError> {
-    let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
-        path: path.display().to_string(),
-        source: e,
+pub fn read_u64_opt(path: &Path) -> Result<Option<u64>> {
+    if fs::exists(path)? {
+        Ok(Some(read_u64(path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn read_flat_keyed_file(path: &Path) -> Result<HashMap<String, u64>> {
+    let raw = fs::read_to_string(path).map_err(|err| CgroupError::IoPath {
+        path: path.to_owned(),
+        source: err,
     })?;
 
-    let mut map = HashMap::new();
-    for line in raw.lines() {
-        let mut parts = line.splitn(2, ' ');
-        if let (Some(key), Some(val_str)) = (parts.next(), parts.next())
-            && let Ok(v) = val_str.trim().parse::<u64>()
-        {
-            map.insert(key.to_string(), v);
-        }
-    }
+    let map = raw
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, ' ');
+            if let (Some(key), Some(val_str)) = (parts.next(), parts.next())
+                && let Ok(v) = val_str.trim().parse::<u64>()
+            {
+                Some((key.to_string(), v))
+            } else {
+                None
+            }
+        })
+        .collect();
+
     Ok(map)
 }
 
-pub fn read_io_stat(path: &Path) -> Result<(u64, u64), CgroupError> {
+pub fn read_io_stat(path: &Path) -> Result<(Option<u64>, Option<u64>)> {
     let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
-        path: path.display().to_string(),
+        path: path.to_path_buf(),
         source: e,
     })?;
 
-    let (mut rbytes, mut wbytes) = (0u64, 0u64);
+    let mut rbytes = 0;
+    let mut wbytes = 0;
+    let mut has_r = false;
+    let mut has_w = false;
+
     for line in raw.lines() {
         for field in line.split_whitespace().skip(1) {
             if let Some(v) = field.strip_prefix("rbytes=") {
-                rbytes += v.parse::<u64>().unwrap_or(0);
-            } else if let Some(v) = field.strip_prefix("wbytes=") {
-                wbytes += v.parse::<u64>().unwrap_or(0);
+                if let Ok(val) = v.parse::<u64>() {
+                    rbytes += val;
+                    has_r = true;
+                }
+            } else if let Some(v) = field.strip_prefix("wbytes=")
+                && let Ok(val) = v.parse::<u64>()
+            {
+                wbytes += val;
+                has_w = true;
             }
         }
     }
-    Ok((rbytes, wbytes))
+
+    Ok((
+        if has_r { Some(rbytes) } else { None },
+        if has_w { Some(wbytes) } else { None },
+    ))
 }

--- a/sources/cgroup/src/util.rs
+++ b/sources/cgroup/src/util.rs
@@ -1,0 +1,62 @@
+//! Low-level helpers to read cgroup v2 pseudo-files.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use crate::error::CgroupError;
+pub fn read_u64_opt(path: &Path) -> Result<Option<u64>, CgroupError> {
+    let raw = fs::read_to_string(path).map_err(|e| CgroupError::Io {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    let trimmed = raw.trim();
+    if trimmed == "max" {
+        return Ok(None);
+    }
+    trimmed
+        .parse::<u64>()
+        .map(Some)
+        .map_err(|_| CgroupError::Parse {
+            path: path.display().to_string(),
+            expected: "u64 or \"max\"",
+            got: trimmed.to_string(),
+        })
+}
+
+pub fn read_flat_keyed(path: &Path) -> Result<HashMap<String, u64>, CgroupError> {
+    let raw = fs::read_to_string(path).map_err(|e| CgroupError::Io {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+
+    let mut map = HashMap::new();
+    for line in raw.lines() {
+        let mut parts = line.splitn(2, ' ');
+        if let (Some(key), Some(val_str)) = (parts.next(), parts.next()) {
+            if let Ok(v) = val_str.trim().parse::<u64>() {
+                map.insert(key.to_string(), v);
+            }
+        }
+    }
+    Ok(map)
+}
+
+pub fn read_io_stat(path: &Path) -> Result<(u64, u64), CgroupError> {
+    let raw = fs::read_to_string(path).map_err(|e| CgroupError::Io {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+
+    let (mut rbytes, mut wbytes) = (0u64, 0u64);
+    for line in raw.lines() {
+        for field in line.split_whitespace().skip(1) {
+            if let Some(v) = field.strip_prefix("rbytes=") {
+                rbytes += v.parse::<u64>().unwrap_or(0);
+            } else if let Some(v) = field.strip_prefix("wbytes=") {
+                wbytes += v.parse::<u64>().unwrap_or(0);
+            }
+        }
+    }
+    Ok((rbytes, wbytes))
+}

--- a/sources/cgroup/src/util.rs
+++ b/sources/cgroup/src/util.rs
@@ -2,7 +2,8 @@ use std::{collections::HashMap, fs, path::Path};
 
 use crate::{Result, error::CgroupError};
 
-pub fn read_u64(path: &Path) -> Result<u64> {
+/// Reads a `u64` value from a file, returns an error if unable to parse.
+fn read_u64(path: &Path) -> Result<u64> {
     let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
         path: path.to_path_buf(),
         source: e,
@@ -14,6 +15,9 @@ pub fn read_u64(path: &Path) -> Result<u64> {
     })
 }
 
+/// Reads an optional `u64` value from a file.
+///
+/// Return None if the file does not exist, else try to parse the file.
 pub fn read_u64_opt(path: &Path) -> Result<Option<u64>> {
     if fs::exists(path)? {
         Ok(Some(read_u64(path)?))
@@ -22,6 +26,16 @@ pub fn read_u64_opt(path: &Path) -> Result<Option<u64>> {
     }
 }
 
+/// Reads a flat key-value file.
+///
+/// Expected format:
+/// ```text
+/// key1 value1
+/// key2 value2
+/// ```
+///
+/// Returns a map of parsed metrics.
+/// Lines that fail to parse are ignored.
 pub fn read_flat_keyed_file(path: &Path) -> Result<HashMap<String, u64>> {
     let raw = fs::read_to_string(path).map_err(|err| CgroupError::IoPath {
         path: path.to_owned(),
@@ -45,6 +59,13 @@ pub fn read_flat_keyed_file(path: &Path) -> Result<HashMap<String, u64>> {
     Ok(map)
 }
 
+/// Reads I/O statistics from `io.stat`.
+///
+/// Parses per-device entries and sums:
+/// - `rbytes` (read bytes)
+/// - `wbytes` (written bytes)
+///
+/// Returns `(read_bytes, write_bytes)` if present.
 pub fn read_io_stat(path: &Path) -> Result<(Option<u64>, Option<u64>)> {
     let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
         path: path.to_path_buf(),

--- a/sources/cgroup/src/util.rs
+++ b/sources/cgroup/src/util.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use crate::error::CgroupError;
 pub fn read_u64_opt(path: &Path) -> Result<Option<u64>, CgroupError> {
-    let raw = fs::read_to_string(path).map_err(|e| CgroupError::Io {
+    let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
         path: path.display().to_string(),
         source: e,
     })?;
@@ -25,7 +25,7 @@ pub fn read_u64_opt(path: &Path) -> Result<Option<u64>, CgroupError> {
 }
 
 pub fn read_flat_keyed(path: &Path) -> Result<HashMap<String, u64>, CgroupError> {
-    let raw = fs::read_to_string(path).map_err(|e| CgroupError::Io {
+    let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
         path: path.display().to_string(),
         source: e,
     })?;
@@ -33,17 +33,17 @@ pub fn read_flat_keyed(path: &Path) -> Result<HashMap<String, u64>, CgroupError>
     let mut map = HashMap::new();
     for line in raw.lines() {
         let mut parts = line.splitn(2, ' ');
-        if let (Some(key), Some(val_str)) = (parts.next(), parts.next()) {
-            if let Ok(v) = val_str.trim().parse::<u64>() {
-                map.insert(key.to_string(), v);
-            }
+        if let (Some(key), Some(val_str)) = (parts.next(), parts.next())
+            && let Ok(v) = val_str.trim().parse::<u64>()
+        {
+            map.insert(key.to_string(), v);
         }
     }
     Ok(map)
 }
 
 pub fn read_io_stat(path: &Path) -> Result<(u64, u64), CgroupError> {
-    let raw = fs::read_to_string(path).map_err(|e| CgroupError::Io {
+    let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
         path: path.display().to_string(),
         source: e,
     })?;

--- a/sources/nvml/README.md
+++ b/sources/nvml/README.md
@@ -1,9 +1,8 @@
-# joule-profiler-source-nvml
-
+# NVML metric source
 
 NVIDIA GPU energy source for `joule-profiler` using the NVIDIA Management Library (NVML).
 
-This crate implements MetricSource from joule-profiler-core by querying NVIDIA GPU energy counters through the nvml-wrapper Rust crate,
+This crate implements the `MetricSource` trait from `joule-profiler-core` by querying NVIDIA GPU energy counters through the nvml-wrapper Rust crate,
 
 ## Overview
 

--- a/sources/nvml/README.md
+++ b/sources/nvml/README.md
@@ -9,8 +9,6 @@ This crate implements the `MetricSource` trait from `joule-profiler-core` by que
 NVML is the C-based API used internally by 'nvidia-smi'. It provides direct access to the NVIDIA GPU driver and exposes hardware energy counters, power draw, utilisation, clock speeds, memory usage, and more.
 `joule-profiler` uses NVML exclusively for energy measurement: it reads the cumulative energy counter (nvmlDeviceGetTotalEnergyConsumption) at each phase boundary and reports the delta in millijoules (mJ)
 
----
-
 ## Metrics collected
 
 | Metric | Unit | Description |
@@ -26,8 +24,3 @@ NVML is the C-based API used internally by 'nvidia-smi'. It provides direct acce
 | GPU | NVIDIA GPU |
 | Driver | NVIDIA driver with `libnvidia-ml.so` (included in standard driver packages) |
 | Permissions | Typically no extra permissions beyond driver access |
-
-
-## See also
-
-> Main project: [joule-profiler](https://github.com/joule-profiler/joule-profiler)

--- a/sources/perf_event/README.md
+++ b/sources/perf_event/README.md
@@ -1,7 +1,7 @@
-# joule-profiler-source-perf_event
+# perf_event metric source
 
 Performance counter source for `joule-profiler`. using the Linux perf_event subsystem.
-This crate implements MetricSource from `joule-profiler-core` and collects hardware and software performance counters (CPU cycles, instructions, cache misses, branch mispredictions…) via the perf_event_open(2) syscall, per phase.
+This crate implements `MetricSource` from `joule-profiler-core` and collects hardware and software performance counters (CPU cycles, instructions, cache misses, branch mispredictions…) via the perf_event_open(2) syscall, per phase.
 
 ## Overview
 

--- a/sources/perf_event/README.md
+++ b/sources/perf_event/README.md
@@ -7,8 +7,6 @@ This crate implements `MetricSource` from `joule-profiler-core` and collects har
 
 `perf_event` is the Linux kernel's performance monitoring API, available since kernel 2.6.31. It provides access to a wide range of hardware PMU counters, software counters, and kernel tracepoints. In the context of `joule-profiler`, these counters complement energy measurements by revealing the execution characteristics of each phase allowing you to correlate energy with IPC, cache efficiency, etc.
 
----
-
 ## Requirements
 
 | Requirement | Details |
@@ -30,14 +28,7 @@ sudo sysctl -w kernel.perf_event_paranoid=1
 echo 'kernel.perf_event_paranoid=1' | sudo tee /etc/sysctl.d/99-perf.conf
 sudo sysctl --system
 ```
----
 
 ## Scope
 
 At the moment, Joule Profiler attaches `perf_event` counters to the **monitored process** only (per-process mode).
-
----
-
-## See also
-
-> Main project: [joule-profiler](https://github.com/joule-profiler/joule-profiler)

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -185,6 +185,13 @@ impl<B: Backend> Procfs<B> {
                     pids_updated = true;
                     Ok(())
                 }
+                Err(ProcfsError::Procfs(procfs::ProcError::Incomplete(_))) => {
+                    trace!(
+                        "PID {pid} data incomplete (process exited during read), removing it from processes list."
+                    );
+                    pids_updated = true;
+                    Ok(())
+                }
                 r => r,
             }?;
         }

--- a/sources/rapl/README.md
+++ b/sources/rapl/README.md
@@ -20,7 +20,6 @@ RAPL (Running Average Power Limit) is an Intel processor feature available since
 
 > Available domains depend on the processor model. Both backends auto-discover domains at startup.
 
----
 ## Requirements
 
 | | powercap | perf_event |

--- a/sources/rapl/README.md
+++ b/sources/rapl/README.md
@@ -1,4 +1,4 @@
-# joule-profiler-source-rapl
+# RAPL metric source
 
 RAPL energy source for [joule-profiler](https://github.com/joule-profiler/joule-profiler).
 
@@ -29,6 +29,3 @@ RAPL (Running Average Power Limit) is an Intel processor feature available since
 | CPU | Intel Sandy Bridge+ | Intel Sandy Bridge+ |
 | Permissions | Root (kernel ≥ 5.10) | Root or `paranoid ≤ 0` |
 ---
-## See also
-
-> Main project: [joule-profiler](https://github.com/joule-profiler/joule-p


### PR DESCRIPTION
## Description

This pull request introduces a new metric source based on the Linux cgroup v2 interface. It enables the collection of CPU, I/O, and memory metrics both at the process level and at the system-wide level.

The implementation uses cgroup v2 statistics files exposed by the Linux kernel to provide accurate and low-overhead resource monitoring. It supports per-process isolation as well as global comparisons using the root cgroup, allowing to have more meaningful metrics.

Compared to the procfs source (in development), cgroups counters are updated on kernel space and allows to group all the processes together, while procfs requires to build the pid hierarchy and read the files of all pids, which adds a lot more overhead.

However, cgroups requires root privileges to be used while procfs doesn't need them.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Improvement
* [x] Documentation
* [ ] Other (please specify):

## Related Issues

The issue related is #23.

## Changes Made

* Implemented cgroup v2 metric source to retrieve CPU, IO and memory metrics of system and process.
* Documented the source and fixed other sources README.

## Checklist

* [x] My code follows the project style
* [x] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass