### PR TITLE
Feat/19 procfs source

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/bin/main.rs"
 joule-profiler-source-rapl = { path = "../sources/rapl", version = "1.0.2" }
 joule-profiler-source-nvml = { path = "../sources/nvml", version = "1.0.2" }
 joule-profiler-source-perf_event = { path = "../sources/perf_event", version = "1.0.2" }
+joule-profiler-source-procfs = { path = "../sources/procfs", version = "0.1.0" }
 
 joule-profiler-core.workspace = true
 log.workspace = true

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::Result;
 use joule_profiler_cli::{
     CliArgs, ProfilerCommand, RaplBackend, Source, init_logging, output_format_to_displayer,
@@ -72,11 +70,7 @@ async fn main() -> Result<()> {
 
     if cli.sources.contains(&Source::Procfs) {
         trace!("Initializing procfs source");
-        let config = ProcfsConfig {
-            poll_interval: Some(Duration::from_millis(1)),
-            ..Default::default()
-        };
-        let procfs = Procfs::new(config)?;
+        let procfs = Procfs::new(ProcfsConfig::default())?;
         profiler.add_source(procfs);
     }
 

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use joule_profiler_cli::{
     CliArgs, ProfilerCommand, RaplBackend, Source, init_logging, output_format_to_displayer,
@@ -69,7 +71,7 @@ async fn main() -> Result<()> {
 
     if cli.sources.contains(&Source::Procfs) {
         trace!("Initializing procfs source");
-        let procfs = Procfs::default();
+        let procfs = Procfs::new(Some(Duration::from_millis(1)))?;
         profiler.add_source(procfs);
     }
 

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -10,6 +10,7 @@ use joule_profiler_core::config::{Command, Config};
 use joule_profiler_source_nvml::Nvml;
 use joule_profiler_source_perf_event::PerfEvent;
 use joule_profiler_source_procfs::Procfs;
+use joule_profiler_source_procfs::config::ProcfsConfig;
 use joule_profiler_source_rapl::{perf, powercap};
 use log::{trace, warn};
 
@@ -71,7 +72,11 @@ async fn main() -> Result<()> {
 
     if cli.sources.contains(&Source::Procfs) {
         trace!("Initializing procfs source");
-        let procfs = Procfs::new(Some(Duration::from_millis(1)))?;
+        let config = ProcfsConfig {
+            poll_interval: Some(Duration::from_millis(1)),
+            ..Default::default()
+        };
+        let procfs = Procfs::new(&config)?;
         profiler.add_source(procfs);
     }
 

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -7,6 +7,7 @@ use joule_profiler_core::JouleProfiler;
 use joule_profiler_core::config::{Command, Config};
 use joule_profiler_source_nvml::Nvml;
 use joule_profiler_source_perf_event::PerfEvent;
+use joule_profiler_source_procfs::Procfs;
 use joule_profiler_source_rapl::{perf, powercap};
 use log::{trace, warn};
 
@@ -64,6 +65,12 @@ async fn main() -> Result<()> {
         trace!("Initializing perf_event source");
         let perf_event = PerfEvent::new()?;
         profiler.add_source(perf_event);
+    }
+
+    if cli.sources.contains(&Source::Procfs) {
+        trace!("Initializing procfs source");
+        let procfs = Procfs::default();
+        profiler.add_source(procfs);
     }
 
     let config = Config::try_from(cli)?;

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
             poll_interval: Some(Duration::from_millis(1)),
             ..Default::default()
         };
-        let procfs = Procfs::new(&config)?;
+        let procfs = Procfs::new(config)?;
         profiler.add_source(procfs);
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -122,6 +122,7 @@ pub enum Source {
     Nvml,
     #[value(alias = "perf_event")]
     Perf,
+    Procfs,
 }
 
 impl std::fmt::Display for Source {
@@ -130,6 +131,7 @@ impl std::fmt::Display for Source {
             Source::Rapl => "rapl",
             Source::Nvml => "nvml",
             Source::Perf => "perf | perf_event",
+            Source::Procfs => "procfs",
         };
         write!(f, "{s}")
     }

--- a/core/src/aggregate/metric.rs
+++ b/core/src/aggregate/metric.rs
@@ -55,7 +55,7 @@ pub type Metrics = Vec<Metric>;
 pub enum MetricValue {
     UnsignedInteger(u64),
     SignedInteger(i64),
-    Float(f64),
+    Float(f64, Option<u8>),
 }
 
 impl From<u64> for MetricValue {
@@ -70,7 +70,13 @@ impl From<i64> for MetricValue {
 }
 impl From<f64> for MetricValue {
     fn from(v: f64) -> Self {
-        Self::Float(v)
+        Self::Float(v, None)
+    }
+}
+
+impl From<(f64, u8)> for MetricValue {
+    fn from((v, dec): (f64, u8)) -> Self {
+        Self::Float(v, Some(dec))
     }
 }
 
@@ -79,7 +85,8 @@ impl Display for MetricValue {
         match self {
             Self::UnsignedInteger(v) => v.fmt(f),
             Self::SignedInteger(v) => v.fmt(f),
-            Self::Float(v) => v.fmt(f),
+            Self::Float(v, None) => v.fmt(f),
+            Self::Float(v, Some(decimal)) => write!(f, "{:.prec$}", v, prec = *decimal as usize),
         }
     }
 }
@@ -92,7 +99,11 @@ impl Serialize for MetricValue {
         match self {
             MetricValue::UnsignedInteger(v) => serializer.serialize_u64(*v),
             MetricValue::SignedInteger(v) => serializer.serialize_i64(*v),
-            MetricValue::Float(v) => serializer.serialize_f64(*v),
+            MetricValue::Float(v, None) => serializer.serialize_f64(*v),
+            MetricValue::Float(v, Some(dec)) => {
+                let factor = 10f64.powi(*dec as i32);
+                serializer.serialize_f64((v * factor).round() / factor)
+            }
         }
     }
 }

--- a/core/src/aggregate/metric.rs
+++ b/core/src/aggregate/metric.rs
@@ -101,7 +101,7 @@ impl Serialize for MetricValue {
             MetricValue::SignedInteger(v) => serializer.serialize_i64(*v),
             MetricValue::Float(v, None) => serializer.serialize_f64(*v),
             MetricValue::Float(v, Some(dec)) => {
-                let factor = 10f64.powi(*dec as i32);
+                let factor = 10f64.powi(i32::from(*dec));
                 serializer.serialize_f64((v * factor).round() / factor)
             }
         }

--- a/core/src/source/types.rs
+++ b/core/src/source/types.rs
@@ -9,9 +9,9 @@ use std::fmt::Debug;
 /// Any type implementing this trait represents the result of a metric measurement.
 /// It must implement `Debug` for logging and debugging, `Send` to be safely
 /// transferred across threads, and `Default` for easy initialization.
-pub trait MetricReaderTypeBound: Debug + Send + Default {}
+pub trait MetricReaderTypeBound: Send {}
 
-impl<T> MetricReaderTypeBound for T where T: Debug + Default + Send {}
+impl<T> MetricReaderTypeBound for T where T: Send {}
 
 /// Trait for errors produced by a [`MetricReader`](`super::MetricReader`).
 ///

--- a/sources/procfs/Cargo.toml
+++ b/sources/procfs/Cargo.toml
@@ -17,6 +17,7 @@ futures.workspace = true
 
 procfs = "0.18.0"
 tokio-timerfd = "0.2.0"
+tokio-util = "0.7.18"
 
 [dev-dependencies]
 mockall.workspace = true

--- a/sources/procfs/Cargo.toml
+++ b/sources/procfs/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "joule-profiler-source-procfs"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "procfs source for joule-profiler"
+keywords = ["procfs"]
+
+[dependencies]
+joule-profiler-core.workspace = true
+log.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+futures.workspace = true
+
+procfs = "0.18.0"
+tokio-timerfd = "0.2.0"
+
+[dev-dependencies]
+mockall.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/sources/procfs/Cargo.toml
+++ b/sources/procfs/Cargo.toml
@@ -6,7 +6,8 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "procfs source for joule-profiler"
-keywords = ["procfs", "Linux", "io", "memory"]
+keywords = ["procfs", "linux", "io", "memory"]
+readme = "README.md"
 
 [dependencies]
 joule-profiler-core.workspace = true

--- a/sources/procfs/Cargo.toml
+++ b/sources/procfs/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "procfs source for joule-profiler"
-keywords = ["procfs"]
+keywords = ["procfs", "Linux", "io", "memory"]
 
 [dependencies]
 joule-profiler-core.workspace = true
@@ -22,7 +22,6 @@ tokio-util = "0.7.18"
 [dev-dependencies]
 mockall.workspace = true
 tokio.workspace = true
-tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/sources/procfs/Cargo.toml
+++ b/sources/procfs/Cargo.toml
@@ -22,6 +22,7 @@ tokio-util = "0.7.18"
 [dev-dependencies]
 mockall.workspace = true
 tokio.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/sources/procfs/README.md
+++ b/sources/procfs/README.md
@@ -1,0 +1,88 @@
+# Procfs metric source
+
+Procfs metric source for [joule-profiler](https://github.com/joule-profiler/joule-profiler).
+
+This crate implements the `MetricReader` trait from `joule-profiler-core` and collects **process-level** and **system-wide** metrics using Linux **procfs** interface.
+
+The implementation relies on `/proc` filesystem to read runtime information about memory and I/O activity at process and system level.
+
+To do so, it uses two Tokio asynchronous background tasks:
+* one continuously polls and aggregates performance metrics.
+* the other continuously polls and rebuilds the process hierarchy.
+
+This separation allows efficient metric sampling while maintaining the overhead introduce at the lowest and rebuilding the process hierarchy efficiently.
+
+## Architecture
+
+### Asynchronous polling
+
+* **Metrics polling task:**
+  * Periodically reads the procfs
+  * Aggregates memory and I/O metrics
+  * Maintains snapshots per process and for the whole system
+
+* **Process hierarchy task:**
+  * Periodically scans `/proc`
+  * Builds a process tree from the profiled program PID.
+
+## Implemented metrics
+
+All metrics are reported for both:
+- individual processes
+- system-wide
+
+Metrics are prefixed with `proc` or `global`.
+
+### Memory (process-level)
+
+| Metric | Description |
+| - | - |
+| `proc_vm_size_min` | Minimum virtual memory size observed |
+| `proc_vm_size_max` | Maximum virtual memory size observed |
+| `proc_rss_min` | Minimum resident set size |
+| `proc_rss_max` | Maximum resident set size |
+| `proc_pss_min` | Minimum proportional set size |
+| `proc_pss_max` | Maximum proportional set size |
+| `proc_shared_min` | Minimum shared memory usage |
+| `proc_shared_max` | Maximum shared memory usage |
+| `proc_anon_min` | Minimum anonymous memory usage |
+| `proc_anon_max` | Maximum anonymous memory usage |
+
+### Memory (system-wide)
+
+| Metric | Description |
+| - | - |
+| `global_mem_used_min` | Minimum system memory usage observed |
+| `global_mem_used_max` | Maximum system memory usage observed |
+| `global_cached_min` | Minimum page cache usage |
+| `global_cached_max` | Maximum page cache usage |
+| `global_anon_min` | Minimum anonymous memory usage (system-wide) |
+| `global_anon_max` | Maximum anonymous memory usage (system-wide) |
+| `global_swap_free_min` | Minimum available swap observed |
+| `global_swap_free_max` | Maximum available swap observed |
+
+### I/O (process-level)
+
+| Metric | Description |
+| - | - |
+| `proc_io_read_bytes` | Total bytes read by the process |
+| `proc_io_write_bytes` | Total bytes written by the process |
+
+### Design notes
+
+* Memory metrics are tracked as time-series extrema (min/max) rather than instantaneous snapshots
+* System-wide metrics are derived from `/proc/meminfo` and aggregated process data
+* I/O metrics come from `/proc/[pid]/io`
+* Process hierarchy is rebuilt continuously to detect the most accurate bounds for each metrics
+
+## Requirements
+
+| Requirement | Version |
+| - | - |
+| Linux kernel | Procfs support (all modern Linux kernels) |
+| Permissions | Read access to `/proc` (typically available to all users, some fields may require elevated privileges) |
+
+## Notes
+
+> [!NOTE]
+> Some metrics may be unavailable depending on kernel configuration or permissions

--- a/sources/procfs/src/backend.rs
+++ b/sources/procfs/src/backend.rs
@@ -12,9 +12,16 @@ use crate::{
 /// Trait abstracting procfs for testing efficiently.
 #[cfg_attr(test, mockall::automock)]
 pub trait Backend: Send + Sync + 'static {
+    // Reads memory and I/O stats for a single pid and adds them into `snapshot`.
     fn read_proc(&self, pid: i32, snapshot: &mut ProcSnapshot) -> Result<()>;
+
+    /// Reads the current global system memory.
     fn measure_global(&self) -> Result<GlobalSnapshot>;
+
+    /// Collects the root pid and all its descendant recursively.
     fn collect_children(&self, pid: i32) -> HashSet<i32>;
+
+    /// Retrieve the total memory of the hardware.
     fn mem_total(&self) -> Result<u64>;
 }
 
@@ -88,7 +95,6 @@ impl Backend for ProcfsBackend {
         pids
     }
 
-    /// Retrieve the total memory of the hardware.
     fn mem_total(&self) -> Result<u64> {
         trace!("Retrieving Meminfo from {}.", Meminfo::PATH);
         Ok(Meminfo::from_file(Meminfo::PATH)?.mem_total)

--- a/sources/procfs/src/backend.rs
+++ b/sources/procfs/src/backend.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 /// Trait abstracting procfs for testing efficiently.
+#[cfg_attr(test, mockall::automock)]
 pub trait Backend: Send + Sync + 'static {
     fn read_proc(&self, pid: i32, snapshot: &mut ProcSnapshot) -> Result<()>;
     fn measure_global(&self) -> Result<GlobalSnapshot>;

--- a/sources/procfs/src/backend.rs
+++ b/sources/procfs/src/backend.rs
@@ -1,0 +1,94 @@
+use std::collections::{HashSet, VecDeque};
+
+use log::trace;
+use procfs::{Current, FromRead, Meminfo, process::Process};
+
+use crate::{
+    Result,
+    snapshot::{GlobalSnapshot, ProcSnapshot},
+    utils::read_child_processes,
+};
+
+/// Trait abstracting procfs for testing efficiently.
+pub trait Backend: Send + Sync + 'static {
+    fn read_proc(&self, pid: i32, snapshot: &mut ProcSnapshot) -> Result<()>;
+    fn measure_global(&self) -> Result<GlobalSnapshot>;
+    fn collect_children(&self, pid: i32) -> HashSet<i32>;
+    fn mem_total(&self) -> Result<u64>;
+}
+
+#[derive(Clone, Copy)]
+pub struct ProcfsBackend;
+
+impl Backend for ProcfsBackend {
+    /// Reads memory and I/O stats for a single pid and adds them into `snapshot`.
+    ///
+    /// Silently ignores `PermissionDenied` on I/O reads, which can happen
+    /// if the process exits between the smaps and io reads.
+    fn read_proc(&self, pid: i32, snapshot: &mut ProcSnapshot) -> Result<()> {
+        let process = Process::new(pid)?;
+
+        trace!("Querying process {} stat.", process.pid);
+        snapshot.vm_size += process.stat()?.vsize;
+
+        trace!("Querying process {} smaps_rollup.", process.pid);
+        let smaps = process.smaps_rollup()?;
+        if let Some(entry) = smaps.memory_map_rollup.0.first() {
+            let map = &entry.extension.map;
+            snapshot.rss += map.get("Rss").copied().unwrap_or(0);
+            snapshot.pss += map.get("Pss").copied().unwrap_or(0);
+            snapshot.anon += map.get("Anonymous").copied().unwrap_or(0);
+            snapshot.shared += map.get("Shared_Clean").copied().unwrap_or(0)
+                + map.get("Shared_Dirty").copied().unwrap_or(0);
+        }
+
+        trace!("Querying process {} io.", process.pid);
+        match process.io() {
+            Ok(io) => {
+                snapshot.read_bytes += io.rchar;
+                snapshot.write_bytes += io.wchar;
+            }
+            Err(procfs::ProcError::PermissionDenied(_)) => {}
+            Err(err) => return Err(err.into()),
+        }
+
+        Ok(())
+    }
+
+    /// Reads system-wide memory statistics from `/proc/meminfo`.
+    fn measure_global(&self) -> Result<GlobalSnapshot> {
+        let meminfo = Meminfo::from_file(Meminfo::PATH)?;
+        trace!("Querying global meminfo from {}", procfs::Meminfo::PATH);
+
+        Ok(GlobalSnapshot {
+            mem_available: meminfo.mem_available,
+            mem_free: meminfo.mem_free,
+            cached: meminfo.cached,
+            anon: meminfo.anon_pages,
+            swap_free: meminfo.swap_free,
+        })
+    }
+
+    /// Collects `root_pid` and all its descendant recursively.
+    /// Threads are excluded, only process leaders are returned.
+    fn collect_children(&self, pid: i32) -> HashSet<i32> {
+        let mut pids: HashSet<i32> = HashSet::new();
+        pids.insert(pid);
+        let mut queue: VecDeque<i32> = VecDeque::from([pid]);
+
+        while let Some(pid) = queue.pop_front() {
+            for child_pid in read_child_processes(pid) {
+                if !pids.contains(&child_pid) {
+                    pids.insert(child_pid);
+                    queue.push_back(child_pid);
+                }
+            }
+        }
+        pids
+    }
+
+    /// Retrieve the total memory of the hardware.
+    fn mem_total(&self) -> Result<u64> {
+        Ok(Meminfo::from_file(Meminfo::PATH)?.mem_total)
+    }
+}

--- a/sources/procfs/src/backend.rs
+++ b/sources/procfs/src/backend.rs
@@ -59,7 +59,7 @@ impl Backend for ProcfsBackend {
     /// Reads system-wide memory statistics from `/proc/meminfo`.
     fn measure_global(&self) -> Result<GlobalSnapshot> {
         let meminfo = Meminfo::from_file(Meminfo::PATH)?;
-        trace!("Querying global meminfo from {}", procfs::Meminfo::PATH);
+        trace!("Querying global meminfo from {}.", procfs::Meminfo::PATH);
 
         Ok(GlobalSnapshot {
             mem_available: meminfo.mem_available,
@@ -90,6 +90,7 @@ impl Backend for ProcfsBackend {
 
     /// Retrieve the total memory of the hardware.
     fn mem_total(&self) -> Result<u64> {
+        trace!("Retrieving Meminfo from {}.", Meminfo::PATH);
         Ok(Meminfo::from_file(Meminfo::PATH)?.mem_total)
     }
 }

--- a/sources/procfs/src/config.rs
+++ b/sources/procfs/src/config.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use crate::utils::MemoryUnit;
+
+/// Configuration for the `Procfs` metric source.
+#[derive(Debug, Clone)]
+pub struct ProcfsConfig {
+    /// Polling interval. If `None`, metrics are only captured on phase boundaries.
+    pub poll_interval: Option<Duration>,
+
+    /// Memory unit for process metrics (default: `Mega`).
+    pub proc_memory_unit: MemoryUnit,
+
+    /// Memory unit for global metrics (default: `Giga`).
+    pub global_memory_unit: MemoryUnit,
+}
+
+impl Default for ProcfsConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: None,
+            proc_memory_unit: MemoryUnit::Mega,
+            global_memory_unit: MemoryUnit::Giga,
+        }
+    }
+}

--- a/sources/procfs/src/config.rs
+++ b/sources/procfs/src/config.rs
@@ -8,6 +8,7 @@ pub struct ProcfsConfig {
     /// Polling interval. If `None`, metrics are only captured on phase boundaries.
     pub poll_interval: Option<Duration>,
 
+    /// Interval at which the process hierarchy is built from the profiled process PID.
     pub process_detection_poll_interval: Option<Duration>,
 
     /// Memory unit for process metrics (default: `Mega`).

--- a/sources/procfs/src/config.rs
+++ b/sources/procfs/src/config.rs
@@ -8,6 +8,8 @@ pub struct ProcfsConfig {
     /// Polling interval. If `None`, metrics are only captured on phase boundaries.
     pub poll_interval: Option<Duration>,
 
+    pub process_detection_poll_interval: Option<Duration>,
+
     /// Memory unit for process metrics (default: `Mega`).
     pub proc_memory_unit: MemoryUnit,
 
@@ -19,6 +21,7 @@ impl Default for ProcfsConfig {
     fn default() -> Self {
         Self {
             poll_interval: None,
+            process_detection_poll_interval: None,
             proc_memory_unit: MemoryUnit::Mega,
             global_memory_unit: MemoryUnit::Giga,
         }

--- a/sources/procfs/src/config.rs
+++ b/sources/procfs/src/config.rs
@@ -20,8 +20,8 @@ pub struct ProcfsConfig {
 impl Default for ProcfsConfig {
     fn default() -> Self {
         Self {
-            poll_interval: None,
-            process_detection_poll_interval: None,
+            poll_interval: Some(Duration::from_millis(10)),
+            process_detection_poll_interval: Some(Duration::from_secs(1)),
             proc_memory_unit: MemoryUnit::Mega,
             global_memory_unit: MemoryUnit::Giga,
         }

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -42,7 +42,22 @@ impl MemoryCounters {
     }
 
     pub fn delta(current: u64, start: u64) -> i64 {
-        current as i64 - start as i64
+        current.cast_signed() - start.cast_signed()
+    }
+
+    pub fn remove_sentinel_values(&mut self) {
+        let values = [
+            &mut self.min_vm_size,
+            &mut self.min_rss,
+            &mut self.min_pss,
+            &mut self.min_shared,
+            &mut self.min_anon,
+        ];
+        for v in values {
+            if *v == u64::MAX {
+                *v = 0;
+            }
+        }
     }
 }
 

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -1,223 +1,154 @@
-#[derive(Debug, Default, Clone, Copy)]
-pub struct MemoryCounters {
-    pub proc: ProcMemoryCounters,
-    pub global: GlobalMemoryCounters,
-}
+use crate::snapshot::{GlobalSnapshot, ProcSnapshot};
 
-#[derive(Debug, Default, Clone, Copy)]
-pub struct ProcMemoryCounters {
-    pub min_vm_size: u64,
-    pub max_vm_size: u64,
+#[derive(Debug, Clone, Copy)]
+pub struct MinMax(pub u64, pub u64);
 
-    pub min_rss: u64,
-    pub max_rss: u64,
-
-    pub min_pss: u64,
-    pub max_pss: u64,
-
-    pub min_shared: u64,
-    pub max_shared: u64,
-
-    pub min_anon: u64,
-    pub max_anon: u64,
-}
-
-impl ProcMemoryCounters {
-    pub fn update(&mut self, vm_size: u64, rss: u64, pss: u64, shared: u64, anon: u64) {
-        self.min_vm_size = self.min_vm_size.min(vm_size);
-        self.max_vm_size = self.max_vm_size.max(vm_size);
-
-        self.min_rss = self.min_rss.min(rss);
-        self.max_rss = self.max_rss.max(rss);
-
-        self.min_pss = self.min_pss.min(pss);
-        self.max_pss = self.max_pss.max(pss);
-
-        self.min_shared = self.min_shared.min(shared);
-        self.max_shared = self.max_shared.max(shared);
-
-        self.min_anon = self.min_anon.min(anon);
-        self.max_anon = self.max_anon.max(anon);
+impl MinMax {
+    pub fn update(&mut self, value: u64) {
+        self.0 = self.0.min(value);
+        self.1 = self.1.max(value);
     }
 
-    pub fn reset_phase(&mut self) {
-        self.min_vm_size = u64::MAX;
-        self.max_vm_size = 0;
-
-        self.min_rss = u64::MAX;
-        self.max_rss = 0;
-
-        self.min_pss = u64::MAX;
-        self.max_pss = 0;
-
-        self.min_shared = u64::MAX;
-        self.max_shared = 0;
-
-        self.min_anon = u64::MAX;
-        self.max_anon = 0;
+    pub fn reset(&mut self) {
+        self.0 = u64::MAX;
+        self.1 = 0;
     }
 
-    pub fn remove_sentinel_values(&mut self) {
-        let values = [
-            &mut self.min_vm_size,
-            &mut self.min_rss,
-            &mut self.min_pss,
-            &mut self.min_shared,
-            &mut self.min_anon,
-        ];
-        for v in values {
-            if *v == u64::MAX {
-                *v = 0;
-            }
+    pub fn remove_sentinel(&mut self) {
+        if self.0 == u64::MAX {
+            self.0 = 0;
         }
+    }
+
+    pub fn min(&self) -> u64 {
+        self.0
+    }
+
+    pub fn max(&self) -> u64 {
+        self.1
+    }
+}
+
+impl Default for MinMax {
+    fn default() -> Self {
+        Self(u64::MAX, 0)
     }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct GlobalMemoryCounters {
-    pub min_mem_available: Option<u64>,
-    pub max_mem_available: Option<u64>,
+pub struct ProcCounters {
+    pub vm_size: MinMax,
+    pub rss: MinMax,
+    pub pss: MinMax,
+    pub shared: MinMax,
+    pub anon: MinMax,
 
-    pub min_mem_free: u64,
-    pub max_mem_free: u64,
-
-    pub min_cached: u64,
-    pub max_cached: u64,
-
-    pub min_anon: Option<u64>,
-    pub max_anon: Option<u64>,
-
-    pub min_swap_free: u64,
-    pub max_swap_free: u64,
-}
-
-impl GlobalMemoryCounters {
-    pub fn update(
-        &mut self,
-        mem_available: Option<u64>,
-        mem_free: u64,
-        cached: u64,
-        anon: Option<u64>,
-        swap_free: u64,
-    ) {
-        if let Some(mem_available) = mem_available {
-            self.min_mem_available =
-                Some(if let Some(min_mem_available) = self.min_mem_available {
-                    min_mem_available.min(mem_available)
-                } else {
-                    mem_available
-                });
-
-            self.max_mem_available =
-                Some(if let Some(max_mem_available) = self.max_mem_available {
-                    max_mem_available.max(mem_available)
-                } else {
-                    mem_available
-                });
-        }
-
-        self.min_mem_free = self.min_mem_free.min(mem_free);
-        self.max_mem_free = self.max_mem_free.max(mem_free);
-
-        self.min_cached = self.min_cached.min(cached);
-        self.max_cached = self.max_cached.max(cached);
-
-        if let Some(anon) = anon {
-            self.min_anon = Some(if let Some(min_anon) = self.min_anon {
-                min_anon.min(anon)
-            } else {
-                anon
-            });
-
-            self.max_anon = Some(if let Some(max_anon) = self.max_anon {
-                max_anon.max(anon)
-            } else {
-                anon
-            });
-        }
-
-        self.min_anon = self.min_anon.min(anon);
-        self.max_anon = self.max_anon.max(anon);
-
-        self.min_swap_free = self.min_swap_free.min(swap_free);
-        self.max_swap_free = self.max_swap_free.max(swap_free);
-    }
-
-    pub fn reset_phase(&mut self) {
-        self.min_mem_available = self.min_mem_available.map(|_| u64::MAX);
-        self.max_mem_available = self.max_mem_available.map(|_| 0);
-
-        self.min_mem_free = u64::MAX;
-        self.max_mem_free = 0;
-
-        self.min_cached = u64::MAX;
-        self.max_cached = 0;
-
-        self.min_anon = self.min_anon.map(|_| u64::MAX);
-        self.max_anon = self.max_anon.map(|_| 0);
-
-        self.min_swap_free = u64::MAX;
-        self.max_swap_free = 0;
-    }
-
-    pub fn remove_sentinel_values(&mut self) {
-        self.min_mem_available = self
-            .min_mem_available
-            .map(|v| if v == u64::MAX { 0 } else { v });
-
-        self.min_anon = self.min_anon.map(|v| if v == u64::MAX { 0 } else { v });
-
-        let values = [
-            &mut self.min_mem_free,
-            &mut self.min_cached,
-            &mut self.min_swap_free,
-        ];
-        for v in values {
-            if *v == u64::MAX {
-                *v = 0;
-            }
-        }
-    }
-}
-
-impl MemoryCounters {
-    pub fn update_proc(&mut self, vm_size: u64, rss: u64, pss: u64, shared: u64, anon: u64) {
-        self.proc.update(vm_size, rss, pss, shared, anon);
-    }
-
-    pub fn update_global(
-        &mut self,
-        mem_available: Option<u64>,
-        mem_free: u64,
-        cached: u64,
-        anon: Option<u64>,
-        swap_free: u64,
-    ) {
-        self.global
-            .update(mem_available, mem_free, cached, anon, swap_free);
-    }
-
-    pub fn reset_phase(&mut self) {
-        self.proc.reset_phase();
-        self.global.reset_phase();
-    }
-
-    pub fn remove_sentinel_values(&mut self) {
-        self.proc.remove_sentinel_values();
-        self.global.remove_sentinel_values();
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-pub struct IoCounters {
     pub begin_read_bytes: u64,
     pub begin_write_bytes: u64,
     pub end_read_bytes: u64,
     pub end_write_bytes: u64,
 }
 
+impl ProcCounters {
+    pub fn update(&mut self, snapshot: &ProcSnapshot) {
+        self.vm_size.update(snapshot.vm_size);
+        self.rss.update(snapshot.rss);
+        self.pss.update(snapshot.pss);
+        self.shared.update(snapshot.shared);
+        self.anon.update(snapshot.anon);
+
+        self.end_read_bytes = snapshot.read_bytes;
+        self.end_write_bytes = snapshot.write_bytes;
+    }
+
+    pub fn reset(&mut self) {
+        self.vm_size.reset();
+        self.rss.reset();
+        self.pss.reset();
+        self.shared.reset();
+        self.anon.reset();
+
+        self.begin_read_bytes = self.end_read_bytes;
+        self.begin_write_bytes = self.end_write_bytes;
+    }
+
+    pub fn remove_sentinels(&mut self) {
+        self.vm_size.remove_sentinel();
+        self.rss.remove_sentinel();
+        self.pss.remove_sentinel();
+        self.shared.remove_sentinel();
+        self.anon.remove_sentinel();
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GlobalCounters {
+    pub mem_available: Option<MinMax>,
+    pub mem_free: MinMax,
+    pub cached: MinMax,
+    pub anon: Option<MinMax>,
+    pub swap_free: MinMax,
+}
+
+impl GlobalCounters {
+    pub fn update(&mut self, snapshot: &GlobalSnapshot) {
+        if let Some(value) = snapshot.mem_available {
+            self.mem_available.get_or_insert_default().update(value);
+        }
+
+        if let Some(value) = snapshot.anon {
+            self.anon.get_or_insert_default().update(value);
+        }
+
+        self.mem_free.update(snapshot.mem_free);
+        self.cached.update(snapshot.cached);
+        self.swap_free.update(snapshot.swap_free);
+    }
+
+    pub fn reset(&mut self) {
+        if let Some(mem_available) = &mut self.mem_available {
+            mem_available.reset();
+        }
+        if let Some(anon) = &mut self.anon {
+            anon.reset();
+        }
+        self.mem_free.reset();
+        self.cached.reset();
+        self.swap_free.reset();
+    }
+
+    pub fn remove_sentinels(&mut self) {
+        if let Some(mem_available) = &mut self.mem_available {
+            mem_available.remove_sentinel();
+        }
+        if let Some(anon) = &mut self.anon {
+            anon.remove_sentinel();
+        }
+        self.mem_free.remove_sentinel();
+        self.cached.remove_sentinel();
+        self.swap_free.remove_sentinel();
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Counters {
-    pub memory_counters: MemoryCounters,
-    pub io_counters: IoCounters,
+    pub proc: ProcCounters,
+    pub global: GlobalCounters,
+}
+
+impl Counters {
+    pub fn update(&mut self, proc: &ProcSnapshot, global: &GlobalSnapshot) {
+        self.proc.update(proc);
+        self.global.update(global);
+    }
+
+    pub fn reset(&mut self) {
+        self.proc.reset();
+        self.global.reset();
+    }
+
+    pub fn remove_sentinels(&mut self) {
+        self.proc.remove_sentinels();
+        self.global.remove_sentinels();
+    }
 }

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -1,48 +1,60 @@
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct MemoryCounters {
-    pub min_vm_size: u64,
-    pub min_rss: u64,
-    pub min_pss: u64,
-    pub min_shared: u64,
-    pub min_anon: u64,
+    pub proc: ProcMemoryCounters,
+    pub global: GlobalMemoryCounters,
+}
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ProcMemoryCounters {
+    pub min_vm_size: u64,
     pub max_vm_size: u64,
+
+    pub min_rss: u64,
     pub max_rss: u64,
+
+    pub min_pss: u64,
     pub max_pss: u64,
+
+    pub min_shared: u64,
     pub max_shared: u64,
+
+    pub min_anon: u64,
     pub max_anon: u64,
 }
 
-impl MemoryCounters {
+impl ProcMemoryCounters {
     pub fn update(&mut self, vm_size: u64, rss: u64, pss: u64, shared: u64, anon: u64) {
         self.min_vm_size = self.min_vm_size.min(vm_size);
         self.max_vm_size = self.max_vm_size.max(vm_size);
+
         self.min_rss = self.min_rss.min(rss);
         self.max_rss = self.max_rss.max(rss);
+
         self.min_pss = self.min_pss.min(pss);
         self.max_pss = self.max_pss.max(pss);
+
         self.min_shared = self.min_shared.min(shared);
         self.max_shared = self.max_shared.max(shared);
+
         self.min_anon = self.min_anon.min(anon);
         self.max_anon = self.max_anon.max(anon);
     }
 
     pub fn reset_phase(&mut self) {
-        self.max_vm_size = 0;
-        self.max_rss = 0;
-        self.max_pss = 0;
-        self.max_shared = 0;
-        self.max_anon = 0;
-
         self.min_vm_size = u64::MAX;
-        self.min_rss = u64::MAX;
-        self.min_pss = u64::MAX;
-        self.min_shared = u64::MAX;
-        self.min_anon = u64::MAX;
-    }
+        self.max_vm_size = 0;
 
-    pub fn delta(current: u64, start: u64) -> i64 {
-        current.cast_signed() - start.cast_signed()
+        self.min_rss = u64::MAX;
+        self.max_rss = 0;
+
+        self.min_pss = u64::MAX;
+        self.max_pss = 0;
+
+        self.min_shared = u64::MAX;
+        self.max_shared = 0;
+
+        self.min_anon = u64::MAX;
+        self.max_anon = 0;
     }
 
     pub fn remove_sentinel_values(&mut self) {
@@ -62,6 +74,141 @@ impl MemoryCounters {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
+pub struct GlobalMemoryCounters {
+    pub min_mem_available: Option<u64>,
+    pub max_mem_available: Option<u64>,
+
+    pub min_mem_free: u64,
+    pub max_mem_free: u64,
+
+    pub min_cached: u64,
+    pub max_cached: u64,
+
+    pub min_anon: Option<u64>,
+    pub max_anon: Option<u64>,
+
+    pub min_swap_free: u64,
+    pub max_swap_free: u64,
+}
+
+impl GlobalMemoryCounters {
+    pub fn update(
+        &mut self,
+        mem_available: Option<u64>,
+        mem_free: u64,
+        cached: u64,
+        anon: Option<u64>,
+        swap_free: u64,
+    ) {
+        if let Some(mem_available) = mem_available {
+            self.min_mem_available =
+                Some(if let Some(min_mem_available) = self.min_mem_available {
+                    min_mem_available.min(mem_available)
+                } else {
+                    mem_available
+                });
+
+            self.max_mem_available =
+                Some(if let Some(max_mem_available) = self.max_mem_available {
+                    max_mem_available.max(mem_available)
+                } else {
+                    mem_available
+                });
+        }
+
+        self.min_mem_free = self.min_mem_free.min(mem_free);
+        self.max_mem_free = self.max_mem_free.max(mem_free);
+
+        self.min_cached = self.min_cached.min(cached);
+        self.max_cached = self.max_cached.max(cached);
+
+        if let Some(anon) = anon {
+            self.min_anon = Some(if let Some(min_anon) = self.min_anon {
+                min_anon.min(anon)
+            } else {
+                anon
+            });
+
+            self.max_anon = Some(if let Some(max_anon) = self.max_anon {
+                max_anon.max(anon)
+            } else {
+                anon
+            });
+        }
+
+        self.min_anon = self.min_anon.min(anon);
+        self.max_anon = self.max_anon.max(anon);
+
+        self.min_swap_free = self.min_swap_free.min(swap_free);
+        self.max_swap_free = self.max_swap_free.max(swap_free);
+    }
+
+    pub fn reset_phase(&mut self) {
+        self.min_mem_available = self.min_mem_available.map(|_| u64::MAX);
+        self.max_mem_available = self.max_mem_available.map(|_| 0);
+
+        self.min_mem_free = u64::MAX;
+        self.max_mem_free = 0;
+
+        self.min_cached = u64::MAX;
+        self.max_cached = 0;
+
+        self.min_anon = self.min_anon.map(|_| u64::MAX);
+        self.max_anon = self.max_anon.map(|_| 0);
+
+        self.min_swap_free = u64::MAX;
+        self.max_swap_free = 0;
+    }
+
+    pub fn remove_sentinel_values(&mut self) {
+        self.min_mem_available = self
+            .min_mem_available
+            .map(|v| if v == u64::MAX { 0 } else { v });
+
+        self.min_anon = self.min_anon.map(|v| if v == u64::MAX { 0 } else { v });
+
+        let values = [
+            &mut self.min_mem_free,
+            &mut self.min_cached,
+            &mut self.min_swap_free,
+        ];
+        for v in values {
+            if *v == u64::MAX {
+                *v = 0;
+            }
+        }
+    }
+}
+
+impl MemoryCounters {
+    pub fn update_proc(&mut self, vm_size: u64, rss: u64, pss: u64, shared: u64, anon: u64) {
+        self.proc.update(vm_size, rss, pss, shared, anon);
+    }
+
+    pub fn update_global(
+        &mut self,
+        mem_available: Option<u64>,
+        mem_free: u64,
+        cached: u64,
+        anon: Option<u64>,
+        swap_free: u64,
+    ) {
+        self.global
+            .update(mem_available, mem_free, cached, anon, swap_free);
+    }
+
+    pub fn reset_phase(&mut self) {
+        self.proc.reset_phase();
+        self.global.reset_phase();
+    }
+
+    pub fn remove_sentinel_values(&mut self) {
+        self.proc.remove_sentinel_values();
+        self.global.remove_sentinel_values();
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
 pub struct IoCounters {
     pub begin_read_bytes: u64,
     pub begin_write_bytes: u64,
@@ -69,6 +216,7 @@ pub struct IoCounters {
     pub end_write_bytes: u64,
 }
 
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Counters {
     pub memory_counters: MemoryCounters,
     pub io_counters: IoCounters,

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -33,7 +33,7 @@ impl MemoryCounters {
         self.max_pss = 0;
         self.max_shared = 0;
         self.max_anon = 0;
-        
+
         self.min_vm_size = u64::MAX;
         self.min_rss = u64::MAX;
         self.min_pss = u64::MAX;

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -1,19 +1,27 @@
 use crate::snapshot::{GlobalSnapshot, ProcSnapshot};
 
+/// A min/max accumulator for a single metric.
+///
+/// Initialized with `min = u64::MAX` and `max = 0` as sentinels,
+/// so the first [`update`](MinMax::update) call sets both bounds correctly.
+/// Call [`remove_sentinel`](MinMax::remove_sentinel) before reading min.
 #[derive(Debug, Clone, Copy)]
 pub struct MinMax(pub u64, pub u64);
 
 impl MinMax {
+    /// Updates the min/max bounds with the provided value.
     pub fn update(&mut self, value: u64) {
         self.0 = self.0.min(value);
         self.1 = self.1.max(value);
     }
 
+    /// Resets to sentinel state (`min = u64::MAX`, `max = 0`).
     pub fn reset(&mut self) {
         self.0 = u64::MAX;
         self.1 = 0;
     }
 
+    /// Replaces the `u64::MAX` sentinel with `0` if no update was received.
     pub fn remove_sentinel(&mut self) {
         if self.0 == u64::MAX {
             self.0 = 0;
@@ -35,21 +43,46 @@ impl Default for MinMax {
     }
 }
 
+/// Accumulated memory and I/O counters for a process hierarchy over a phase.
+///
+/// Memory fields track min/max over all snapshots in the phase.
+/// I/O fields track cumulative byte counts: begin is set at phase start.
+/// All metrics are in bytes.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ProcCounters {
+    /// Virtual memory size.
     pub vm_size: MinMax,
+
+    /// Resident set size.
     pub rss: MinMax,
+
+    /// Proportional set size.
     pub pss: MinMax,
+
+    /// Shared memory, clean + dirty.
     pub shared: MinMax,
+
+    /// Anonymous memory.
     pub anon: MinMax,
 
+    /// Cumulative bytes read at the beginning of a phase.
     pub begin_read_bytes: u64,
+
+    /// Cumulative bytes written at the beginning of a phase.
     pub begin_write_bytes: u64,
+
+    /// Highest cumulative bytes read observed during this phase.
     pub end_read_bytes: u64,
+
+    /// Highest cumulative bytes written observed during this phase.
     pub end_write_bytes: u64,
 }
 
 impl ProcCounters {
+    /// Merges a [`ProcSnapshot`] into the counters.
+    ///
+    /// I/O fields take the max of the current end and the snapshot value,
+    /// since `/proc/{pid}/io` counters are monotonically increasing.
     pub fn update(&mut self, snapshot: &ProcSnapshot) {
         self.vm_size.update(snapshot.vm_size);
         self.rss.update(snapshot.rss);
@@ -61,6 +94,7 @@ impl ProcCounters {
         self.end_write_bytes = self.end_write_bytes.max(snapshot.write_bytes);
     }
 
+    /// Resets memory min/max for the next phase and carries I/O end values forward as the new begin.
     pub fn reset(&mut self) {
         self.vm_size.reset();
         self.rss.reset();
@@ -72,6 +106,7 @@ impl ProcCounters {
         self.begin_write_bytes = self.end_write_bytes;
     }
 
+    /// Replaces `u64::MAX` sentinels with `0` on all memory fields before reading.
     pub fn remove_sentinels(&mut self) {
         self.vm_size.remove_sentinel();
         self.rss.remove_sentinel();
@@ -81,16 +116,31 @@ impl ProcCounters {
     }
 }
 
+/// Accumulated system-wide memory counters over a phase.
+///
+/// `mem_available` and `anon` are `Option` because they may not be present
+/// in `/proc/meminfo` on all kernel configurations. They are initialized
+/// lazily on the first snapshot that contains them.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct GlobalCounters {
+    /// Available memory (`MemAvailable`). None if not exposed by the kernel.
     pub mem_available: Option<MinMax>,
+
+    /// Free memory (`MemFree`).
     pub mem_free: MinMax,
+
+    /// Page cache (`Cached`).
     pub cached: MinMax,
+
+    /// Anonymous pages (`AnonPages`). None if not exposed by the kernel.
     pub anon: Option<MinMax>,
+
+    /// Free swap (`SwapFree`).
     pub swap_free: MinMax,
 }
 
 impl GlobalCounters {
+    /// Merges a [`GlobalSnapshot`] into the counters.
     pub fn update(&mut self, snapshot: &GlobalSnapshot) {
         if let Some(value) = snapshot.mem_available {
             self.mem_available.get_or_insert_default().update(value);
@@ -105,6 +155,7 @@ impl GlobalCounters {
         self.swap_free.update(snapshot.swap_free);
     }
 
+    /// Resets all counters for the next phase.
     pub fn reset(&mut self) {
         if let Some(mem_available) = &mut self.mem_available {
             mem_available.reset();
@@ -117,6 +168,7 @@ impl GlobalCounters {
         self.swap_free.reset();
     }
 
+    /// Replaces `u64::MAX` sentinels with `0` on all fields before reading.
     pub fn remove_sentinels(&mut self) {
         if let Some(mem_available) = &mut self.mem_available {
             mem_available.remove_sentinel();

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -1,45 +1,27 @@
 use crate::snapshot::{GlobalSnapshot, ProcSnapshot};
 
 /// A min/max accumulator for a single metric.
-///
-/// Initialized with `min = u64::MAX` and `max = 0` as sentinels,
-/// so the first [`update`](MinMax::update) call sets both bounds correctly.
-/// Call [`remove_sentinel`](MinMax::remove_sentinel) before reading min.
-#[derive(Debug, Clone, Copy)]
-pub struct MinMax(pub u64, pub u64);
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MinMax(pub Option<u64>, Option<u64>);
 
 impl MinMax {
     /// Updates the min/max bounds with the provided value.
     pub fn update(&mut self, value: u64) {
-        self.0 = self.0.min(value);
-        self.1 = self.1.max(value);
+        self.0 = Some(self.0.map_or(value, |m| m.min(value)));
+        self.1 = Some(self.1.map_or(value, |m| m.max(value)));
     }
 
-    /// Resets to sentinel state (`min = u64::MAX`, `max = 0`).
     pub fn reset(&mut self) {
-        self.0 = u64::MAX;
-        self.1 = 0;
+        self.0 = None;
+        self.1 = None;
     }
 
-    /// Replaces the `u64::MAX` sentinel with `0` if no update was received.
-    pub fn remove_sentinel(&mut self) {
-        if self.0 == u64::MAX {
-            self.0 = 0;
-        }
-    }
-
-    pub fn min(&self) -> u64 {
+    pub fn min(&self) -> Option<u64> {
         self.0
     }
 
-    pub fn max(&self) -> u64 {
+    pub fn max(&self) -> Option<u64> {
         self.1
-    }
-}
-
-impl Default for MinMax {
-    fn default() -> Self {
-        Self(u64::MAX, 0)
     }
 }
 
@@ -89,7 +71,6 @@ impl ProcCounters {
         self.pss.update(snapshot.pss);
         self.shared.update(snapshot.shared);
         self.anon.update(snapshot.anon);
-
         self.end_read_bytes = self.end_read_bytes.max(snapshot.read_bytes);
         self.end_write_bytes = self.end_write_bytes.max(snapshot.write_bytes);
     }
@@ -101,18 +82,39 @@ impl ProcCounters {
         self.pss.reset();
         self.shared.reset();
         self.anon.reset();
-
         self.begin_read_bytes = self.end_read_bytes;
         self.begin_write_bytes = self.end_write_bytes;
     }
+}
 
-    /// Replaces `u64::MAX` sentinels with `0` on all memory fields before reading.
-    pub fn remove_sentinels(&mut self) {
-        self.vm_size.remove_sentinel();
-        self.rss.remove_sentinel();
-        self.pss.remove_sentinel();
-        self.shared.remove_sentinel();
-        self.anon.remove_sentinel();
+/// Computes used memory as `MemTotal - MemAvailable`.
+///
+/// If `MemAvailable` is present in `/proc/meminfo`, it is used directly (preferred).
+/// Otherwise, falls back to `MemTotal - (MemFree + Cached)`, which is less accurate
+/// but universally available.
+///
+/// Note: min/max are inverted relative to `available` since higher availability
+/// means lower usage.
+pub fn compute_mem_used(
+    mem_total: u64,
+    mem_available: Option<MinMax>,
+    mem_free: MinMax,
+    cached: MinMax,
+) -> MinMax {
+    if let Some(available) = mem_available {
+        MinMax(
+            Some(mem_total.saturating_sub(available.max().unwrap_or_default())),
+            Some(mem_total.saturating_sub(available.min().unwrap_or_default())),
+        )
+    } else {
+        MinMax(
+            Some(mem_total.saturating_sub(
+                mem_free.max().unwrap_or_default() + cached.max().unwrap_or_default(),
+            )),
+            Some(mem_total.saturating_sub(
+                mem_free.min().unwrap_or_default() + cached.min().unwrap_or_default(),
+            )),
+        )
     }
 }
 
@@ -142,43 +144,28 @@ pub struct GlobalCounters {
 impl GlobalCounters {
     /// Merges a [`GlobalSnapshot`] into the counters.
     pub fn update(&mut self, snapshot: &GlobalSnapshot) {
-        if let Some(value) = snapshot.mem_available {
-            self.mem_available.get_or_insert_default().update(value);
-        }
-
-        if let Some(value) = snapshot.anon {
-            self.anon.get_or_insert_default().update(value);
-        }
-
         self.mem_free.update(snapshot.mem_free);
         self.cached.update(snapshot.cached);
         self.swap_free.update(snapshot.swap_free);
+        if let Some(v) = snapshot.mem_available {
+            self.mem_available.get_or_insert_default().update(v);
+        }
+        if let Some(v) = snapshot.anon {
+            self.anon.get_or_insert_default().update(v);
+        }
     }
 
     /// Resets all counters for the next phase.
     pub fn reset(&mut self) {
-        if let Some(mem_available) = &mut self.mem_available {
-            mem_available.reset();
-        }
-        if let Some(anon) = &mut self.anon {
-            anon.reset();
-        }
         self.mem_free.reset();
         self.cached.reset();
         self.swap_free.reset();
-    }
-
-    /// Replaces `u64::MAX` sentinels with `0` on all fields before reading.
-    pub fn remove_sentinels(&mut self) {
-        if let Some(mem_available) = &mut self.mem_available {
-            mem_available.remove_sentinel();
+        if let Some(v) = &mut self.mem_available {
+            v.reset();
         }
-        if let Some(anon) = &mut self.anon {
-            anon.remove_sentinel();
+        if let Some(v) = &mut self.anon {
+            v.reset();
         }
-        self.mem_free.remove_sentinel();
-        self.cached.remove_sentinel();
-        self.swap_free.remove_sentinel();
     }
 }
 
@@ -197,10 +184,5 @@ impl Counters {
     pub fn reset(&mut self) {
         self.proc.reset();
         self.global.reset();
-    }
-
-    pub fn remove_sentinels(&mut self) {
-        self.proc.remove_sentinels();
-        self.global.remove_sentinels();
     }
 }

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -57,8 +57,8 @@ impl ProcCounters {
         self.shared.update(snapshot.shared);
         self.anon.update(snapshot.anon);
 
-        self.end_read_bytes = snapshot.read_bytes;
-        self.end_write_bytes = snapshot.write_bytes;
+        self.end_read_bytes = self.end_read_bytes.max(snapshot.read_bytes);
+        self.end_write_bytes = self.end_write_bytes.max(snapshot.write_bytes);
     }
 
     pub fn reset(&mut self) {

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -1,50 +1,44 @@
 #[derive(Debug, Default, Clone)]
 pub struct MemoryCounters {
-    pub vm_size: u64,
-    pub rss: u64,
-    pub pss: u64,
-    pub shared: u64,
-    pub anon: u64,
+    pub min_vm_size: u64,
+    pub min_rss: u64,
+    pub min_pss: u64,
+    pub min_shared: u64,
+    pub min_anon: u64,
 
     pub max_vm_size: u64,
     pub max_rss: u64,
     pub max_pss: u64,
     pub max_shared: u64,
     pub max_anon: u64,
-
-    pub phase_start_vm_size: u64,
-    pub phase_start_rss: u64,
-    pub phase_start_pss: u64,
-    pub phase_start_shared: u64,
-    pub phase_start_anon: u64,
 }
 
 impl MemoryCounters {
     pub fn update(&mut self, vm_size: u64, rss: u64, pss: u64, shared: u64, anon: u64) {
-        self.vm_size = vm_size;
+        self.min_vm_size = self.min_vm_size.min(vm_size);
         self.max_vm_size = self.max_vm_size.max(vm_size);
-        self.rss = rss;
+        self.min_rss = self.min_rss.min(rss);
         self.max_rss = self.max_rss.max(rss);
-        self.pss = pss;
+        self.min_pss = self.min_pss.min(pss);
         self.max_pss = self.max_pss.max(pss);
-        self.shared = shared;
+        self.min_shared = self.min_shared.min(shared);
         self.max_shared = self.max_shared.max(shared);
-        self.anon = anon;
+        self.min_anon = self.min_anon.min(anon);
         self.max_anon = self.max_anon.max(anon);
     }
 
     pub fn reset_phase(&mut self) {
-        self.phase_start_vm_size = self.vm_size;
-        self.phase_start_rss = self.rss;
-        self.phase_start_pss = self.pss;
-        self.phase_start_shared = self.shared;
-        self.phase_start_anon = self.anon;
-
-        self.max_vm_size = self.vm_size;
-        self.max_rss = self.rss;
-        self.max_pss = self.pss;
-        self.max_shared = self.shared;
-        self.max_anon = self.anon;
+        self.max_vm_size = 0;
+        self.max_rss = 0;
+        self.max_pss = 0;
+        self.max_shared = 0;
+        self.max_anon = 0;
+        
+        self.min_vm_size = u64::MAX;
+        self.min_rss = u64::MAX;
+        self.min_pss = u64::MAX;
+        self.min_shared = u64::MAX;
+        self.min_anon = u64::MAX;
     }
 
     pub fn delta(current: u64, start: u64) -> i64 {
@@ -62,5 +56,5 @@ pub struct IoCounters {
 
 pub struct Counters {
     pub memory_counters: MemoryCounters,
-    pub io_counters: IoCounters
+    pub io_counters: IoCounters,
 }

--- a/sources/procfs/src/counters.rs
+++ b/sources/procfs/src/counters.rs
@@ -1,0 +1,66 @@
+#[derive(Debug, Default, Clone)]
+pub struct MemoryCounters {
+    pub vm_size: u64,
+    pub rss: u64,
+    pub pss: u64,
+    pub shared: u64,
+    pub anon: u64,
+
+    pub max_vm_size: u64,
+    pub max_rss: u64,
+    pub max_pss: u64,
+    pub max_shared: u64,
+    pub max_anon: u64,
+
+    pub phase_start_vm_size: u64,
+    pub phase_start_rss: u64,
+    pub phase_start_pss: u64,
+    pub phase_start_shared: u64,
+    pub phase_start_anon: u64,
+}
+
+impl MemoryCounters {
+    pub fn update(&mut self, vm_size: u64, rss: u64, pss: u64, shared: u64, anon: u64) {
+        self.vm_size = vm_size;
+        self.max_vm_size = self.max_vm_size.max(vm_size);
+        self.rss = rss;
+        self.max_rss = self.max_rss.max(rss);
+        self.pss = pss;
+        self.max_pss = self.max_pss.max(pss);
+        self.shared = shared;
+        self.max_shared = self.max_shared.max(shared);
+        self.anon = anon;
+        self.max_anon = self.max_anon.max(anon);
+    }
+
+    pub fn reset_phase(&mut self) {
+        self.phase_start_vm_size = self.vm_size;
+        self.phase_start_rss = self.rss;
+        self.phase_start_pss = self.pss;
+        self.phase_start_shared = self.shared;
+        self.phase_start_anon = self.anon;
+
+        self.max_vm_size = self.vm_size;
+        self.max_rss = self.rss;
+        self.max_pss = self.pss;
+        self.max_shared = self.shared;
+        self.max_anon = self.anon;
+    }
+
+    pub fn delta(current: u64, start: u64) -> i64 {
+        current as i64 - start as i64
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct IoCounters {
+    pub begin_read_bytes: u64,
+    pub begin_write_bytes: u64,
+    pub end_read_bytes: u64,
+    pub end_write_bytes: u64,
+}
+
+pub struct Counters {
+    pub memory_counters: MemoryCounters,
+    pub io_counters: IoCounters
+}

--- a/sources/procfs/src/error.rs
+++ b/sources/procfs/src/error.rs
@@ -1,6 +1,7 @@
 //! Error types for the procfs metric source.
 
 use thiserror::Error;
+use tokio::task::JoinError;
 
 /// Errors that can occur while reading metrics from `/proc`.
 #[derive(Error, Debug)]
@@ -16,4 +17,12 @@ pub enum ProcfsError {
     /// An I/O error reading from `/proc` directly (e.g., `/proc/{pid}/task/{tid}/children`).
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    /// An error occured while joining the polling task.
+    #[error("Failed to join tokio task: {0}")]
+    JoinError(
+        #[from]
+        #[source]
+        JoinError,
+    ),
 }

--- a/sources/procfs/src/error.rs
+++ b/sources/procfs/src/error.rs
@@ -1,11 +1,19 @@
+//! Error types for the procfs metric source.
+
 use thiserror::Error;
 
+/// Errors that can occur while reading metrics from `/proc`.
 #[derive(Error, Debug)]
 pub enum ProcfsError {
+    /// The source was used before [`crate::Procfs::init`] was called.
     #[error("Procfs not initialized, call init first")]
     NotInitialized,
+
+    /// An error from the `procfs` crate (e.g., process not found, parse failure).
     #[error(transparent)]
     Procfs(#[from] procfs::ProcError),
+
+    /// An I/O error reading from `/proc` directly (e.g., `/proc/{pid}/task/{tid}/children`).
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }

--- a/sources/procfs/src/error.rs
+++ b/sources/procfs/src/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ProcfsError {
+    #[error("Procfs not initialized, call init first")]
+    NotInitialized,
+    #[error(transparent)]
+    Procfs(#[from] procfs::ProcError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -5,18 +5,24 @@ use joule_profiler_core::{
     types::{Metric, MetricValue, Metrics},
     unit::{MetricUnit, Unit, UnitPrefix},
 };
-use log::{debug, trace, warn};
-use procfs::{Current, FromRead, process::Process};
+use log::{debug, trace};
+use procfs::{Current, FromRead, Meminfo};
 use std::sync::Arc;
 use std::time::Duration;
-use thiserror::Error;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 
-use crate::{counters::Counters, utils::collect_all_children};
+use crate::{
+    counters::{Counters, MinMax},
+    error::ProcfsError,
+    snapshot::{GlobalSnapshot, ProcSnapshot, read_global, read_proc},
+    utils::{MemoryUnit, collect_all_children},
+};
 
 pub mod counters;
+pub mod error;
+mod snapshot;
 mod utils;
 
 const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {
@@ -24,156 +30,33 @@ const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {
     unit: Unit::Byte,
 };
 
-#[derive(Error, Debug)]
-pub enum ProcfsError {
-    #[error("Procfs not initialized, call init first")]
-    NotInitialized,
-    #[error(transparent)]
-    Procfs(#[from] procfs::ProcError),
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum MemoryUnit {
-    Bytes,
-    Kilo,
-    #[default]
-    Mega,
-    Giga,
-}
-
-impl From<MemoryUnit> for MetricUnit {
-    fn from(unit: MemoryUnit) -> Self {
-        match unit {
-            MemoryUnit::Bytes => MetricUnit {
-                prefix: UnitPrefix::None,
-                unit: Unit::Byte,
-            },
-            MemoryUnit::Kilo => MetricUnit {
-                prefix: UnitPrefix::Kilo,
-                unit: Unit::Byte,
-            },
-            MemoryUnit::Mega => MetricUnit {
-                prefix: UnitPrefix::Mega,
-                unit: Unit::Byte,
-            },
-            MemoryUnit::Giga => MetricUnit {
-                prefix: UnitPrefix::Giga,
-                unit: Unit::Byte,
-            },
-        }
-    }
-}
-
 type Result<T> = std::result::Result<T, ProcfsError>;
-
-pub struct MemorySnapshot {
-    proc_vm_size: u64,
-    proc_rss: u64,
-    proc_pss: u64,
-    proc_shared: u64,
-    proc_anon: u64,
-
-    global_mem_available: Option<u64>,
-    global_mem_free: u64,
-    global_cached: u64,
-    global_anon: Option<u64>,
-    global_swap_free: u64,
-}
 
 #[derive(Debug, Default)]
 pub struct Procfs {
     pid: i32,
+
     poll_interval: Option<Duration>,
     counters: Arc<Mutex<Counters>>,
     handle: Option<JoinHandle<Result<()>>>,
+
     proc_memory_unit: MemoryUnit,
     global_memory_unit: MemoryUnit,
-}
 
-fn read_proc_memory(process: &Process) -> Result<(u64, u64, u64, u64, u64)> {
-    let vm_size = process.stat()?.vsize;
-    trace!("Querying process {} smaps_rollup.", process.pid);
-    let smaps = process.smaps_rollup()?;
-
-    let (rss, pss, anon, shared) = smaps
-        .memory_map_rollup
-        .iter()
-        .next()
-        .map(|entry| {
-            let m = &entry.extension.map;
-            let rss = m.get("Rss").copied().unwrap_or(0);
-            let pss = m.get("Pss").copied().unwrap_or(0);
-            let anon = m.get("Anonymous").copied().unwrap_or(0);
-            let shared = m.get("Shared_Clean").copied().unwrap_or(0)
-                + m.get("Shared_Dirty").copied().unwrap_or(0);
-            (rss, pss, anon, shared)
-        })
-        .unwrap_or_default();
-
-    Ok((vm_size, rss, pss, shared, anon))
-}
-
-fn read_global_memory() -> Result<(Option<u64>, u64, u64, Option<u64>, u64)> {
-    let meminfo = procfs::Meminfo::from_file(procfs::Meminfo::PATH)?;
-    trace!("Querying global meminfo from {}", procfs::Meminfo::PATH);
-
-    Ok((
-        meminfo.mem_available,
-        meminfo.mem_free,
-        meminfo.cached,
-        meminfo.anon_pages,
-        meminfo.swap_free,
-    ))
-}
-
-fn read_io(process: &Process) -> Result<(u64, u64)> {
-    trace!("Querying process {} io.", process.pid);
-    let io = process.io()?;
-    Ok((io.rchar, io.wchar))
+    mem_total: u64,
 }
 
 impl Procfs {
-    pub fn new(poll_interval: Option<Duration>) -> Self {
-        Self {
+    pub fn new(poll_interval: Option<Duration>) -> Result<Self> {
+        let mem_total = Meminfo::from_file(Meminfo::PATH)?.mem_total;
+        Ok(Self {
+            pid: -1,
+            mem_total,
             poll_interval,
             global_memory_unit: MemoryUnit::Giga,
             ..Default::default()
-        }
+        })
     }
-}
-
-fn read_memory_counters(pids: &[i32]) -> Result<MemorySnapshot> {
-    let (proc_vm_size, proc_rss, proc_pss, proc_shared, proc_anon) = pids
-        .iter()
-        .filter_map(|p| Process::new(*p).ok())
-        .filter_map(|p| read_proc_memory(&p).ok())
-        .fold((0, 0, 0, 0, 0), |acc, (vm, r, ps, sh, an)| {
-            (acc.0 + vm, acc.1 + r, acc.2 + ps, acc.3 + sh, acc.4 + an)
-        });
-    trace!(
-        "vm_size: {proc_vm_size}, rss: {proc_rss}, pss: {proc_pss}, shared: {proc_shared}, anon: {proc_anon}."
-    );
-
-    let (global_mem_available, global_mem_free, global_cached, global_anon, global_swap_free) =
-        read_global_memory()?;
-    trace!(
-        "mem_available: {global_mem_available:?}, mem_free: {global_mem_free}, cached: {global_cached}, anon: {global_anon:?}, swap_free: {global_swap_free}."
-    );
-
-    Ok(MemorySnapshot {
-        proc_vm_size,
-        proc_rss,
-        proc_pss,
-        proc_shared,
-        proc_anon,
-        global_mem_available,
-        global_mem_free,
-        global_cached,
-        global_anon,
-        global_swap_free,
-    })
 }
 
 impl MetricReader for Procfs {
@@ -187,7 +70,7 @@ impl MetricReader for Procfs {
             return Ok(());
         };
 
-        let current_counters = self.counters.clone();
+        let counters = self.counters.clone();
 
         let handle = tokio::spawn(async move {
             debug!("Starting procfs polling.");
@@ -195,39 +78,19 @@ impl MetricReader for Procfs {
 
             loop {
                 ticker.next().await;
+                trace!("procfs source poll.");
 
-                let pids = collect_all_children(pid);
-                trace!("Found pids {pids:?}.");
+                let proc = match measure_proc(pid) {
+                    Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => {
+                        Ok(ProcSnapshot::default())
+                    }
+                    r => r,
+                }?;
 
-                let snapshot = read_memory_counters(&pids)?;
+                let global = measure_global()?;
 
-                let (read_bytes, write_bytes) = pids
-                    .into_iter()
-                    .filter_map(|p| Process::new(p).ok())
-                    .filter_map(|p| read_io(&p).ok())
-                    .fold((0, 0), |acc, (r, w)| (acc.0 + r, acc.1 + w));
-
-                let mut counters = current_counters.lock().await;
-
-                counters.memory_counters.update_proc(
-                    snapshot.proc_vm_size,
-                    snapshot.proc_rss,
-                    snapshot.proc_pss,
-                    snapshot.proc_shared,
-                    snapshot.proc_anon,
-                );
-                counters.memory_counters.update_global(
-                    snapshot.global_mem_available,
-                    snapshot.global_mem_free,
-                    snapshot.global_cached,
-                    snapshot.global_anon,
-                    snapshot.global_swap_free,
-                );
-
-                counters.io_counters.end_read_bytes =
-                    counters.io_counters.end_read_bytes.max(read_bytes);
-                counters.io_counters.end_write_bytes =
-                    counters.io_counters.end_write_bytes.max(write_bytes);
+                let mut counters = counters.lock().await;
+                counters.update(&proc, &global);
             }
         });
 
@@ -249,36 +112,15 @@ impl MetricReader for Procfs {
     }
 
     async fn measure(&mut self) -> Result<()> {
-        let pids = collect_all_children(self.pid);
+        let proc = match measure_proc(self.pid) {
+            Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => Ok(ProcSnapshot::default()),
+            r => r,
+        }?;
 
-        let snapshot = read_memory_counters(&pids)?;
+        let global = measure_global()?;
+
         let mut counters = self.counters.lock().await;
-        counters.memory_counters.update_proc(
-            snapshot.proc_vm_size,
-            snapshot.proc_rss,
-            snapshot.proc_pss,
-            snapshot.proc_shared,
-            snapshot.proc_anon,
-        );
-        counters.memory_counters.update_global(
-            snapshot.global_mem_available,
-            snapshot.global_mem_free,
-            snapshot.global_cached,
-            snapshot.global_anon,
-            snapshot.global_swap_free,
-        );
-
-        let (read_bytes, write_bytes) = pids
-            .into_iter()
-            .filter_map(|p| Process::new(p).ok())
-            .filter_map(|p| read_io(&p).ok())
-            .fold((0, 0), |acc, (r, w)| (acc.0 + r, acc.1 + w));
-
-        counters.io_counters.end_read_bytes = counters.io_counters.end_read_bytes.max(read_bytes);
-        counters.io_counters.end_write_bytes =
-            counters.io_counters.end_write_bytes.max(write_bytes);
-
-        warn!("{read_bytes} {write_bytes}");
+        counters.update(&proc, &global);
 
         Ok(())
     }
@@ -286,17 +128,13 @@ impl MetricReader for Procfs {
     async fn retrieve(&mut self) -> Result<Self::Type> {
         let mut lock = self.counters.lock().await;
         let counters = *lock;
-        lock.memory_counters.reset_phase();
-
-        lock.io_counters.begin_read_bytes = counters.io_counters.end_read_bytes;
-        lock.io_counters.begin_write_bytes = counters.io_counters.end_write_bytes;
-
+        lock.reset();
         Ok(counters)
     }
 
     fn get_sensors(&self) -> Result<Sensors> {
-        let proc_unit: MetricUnit = self.proc_memory_unit.into();
-        let global_unit: MetricUnit = self.global_memory_unit.into();
+        let proc_memory_unit: MetricUnit = self.proc_memory_unit.into();
+        let global_memory_unit: MetricUnit = self.global_memory_unit.into();
 
         let proc_sensors = [
             "proc_vm_size_min",
@@ -311,7 +149,7 @@ impl MetricReader for Procfs {
             "proc_anon_max",
         ]
         .into_iter()
-        .map(|name| Sensor::new(name, proc_unit, Self::get_name()));
+        .map(|name| Sensor::new(name, proc_memory_unit, Self::get_name()));
 
         let io_sensors = vec![
             Sensor::new(
@@ -337,7 +175,7 @@ impl MetricReader for Procfs {
             "global_swap_free_max",
         ]
         .into_iter()
-        .map(|name| Sensor::new(name, global_unit, Self::get_name()));
+        .map(|name| Sensor::new(name, global_memory_unit, Self::get_name()));
 
         Ok(proc_sensors
             .chain(global_sensors)
@@ -345,71 +183,80 @@ impl MetricReader for Procfs {
             .collect())
     }
 
-    fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
+    fn to_metrics(&self, mut counters: Self::Type) -> Result<Metrics> {
         let proc_unit: MetricUnit = self.proc_memory_unit.into();
         let global_unit: MetricUnit = self.global_memory_unit.into();
         let proc_conv = make_conv(self.proc_memory_unit);
         let global_conv = make_conv(self.global_memory_unit);
 
-        let mut memory_counters = counters.memory_counters;
-        memory_counters.remove_sentinel_values();
+        counters.remove_sentinels();
+        let proc = counters.proc;
 
-        let proc = &memory_counters.proc;
         let proc_memory_metrics: Metrics = [
-            ("proc_vm_size_min", proc_conv(proc.min_vm_size)),
-            ("proc_vm_size_max", proc_conv(proc.max_vm_size)),
-            ("proc_rss_min", proc_conv(proc.min_rss)),
-            ("proc_rss_max", proc_conv(proc.max_rss)),
-            ("proc_pss_min", proc_conv(proc.min_pss)),
-            ("proc_pss_max", proc_conv(proc.max_pss)),
-            ("proc_shared_min", proc_conv(proc.min_shared)),
-            ("proc_shared_max", proc_conv(proc.max_shared)),
-            ("proc_anon_min", proc_conv(proc.min_anon)),
-            ("proc_anon_max", proc_conv(proc.max_anon)),
+            ("proc_vm_size_min", proc_conv(proc.vm_size.min())),
+            ("proc_vm_size_max", proc_conv(proc.vm_size.max())),
+            ("proc_rss_min", proc_conv(proc.rss.min())),
+            ("proc_rss_max", proc_conv(proc.rss.max())),
+            ("proc_pss_min", proc_conv(proc.pss.min())),
+            ("proc_pss_max", proc_conv(proc.pss.max())),
+            ("proc_shared_min", proc_conv(proc.shared.min())),
+            ("proc_shared_max", proc_conv(proc.shared.max())),
+            ("proc_anon_min", proc_conv(proc.anon.min())),
+            ("proc_anon_max", proc_conv(proc.anon.max())),
         ]
         .into_iter()
         .map(|(name, value)| Metric::new(name, value, proc_unit, Self::get_name()))
         .collect();
 
-        let global = &memory_counters.global;
-        let mem_total = procfs::Meminfo::from_file(procfs::Meminfo::PATH)?.mem_total;
+        let io_metrics: Metrics = [
+            (
+                "proc_io_read_bytes",
+                proc.end_read_bytes.saturating_sub(proc.begin_read_bytes),
+            ),
+            (
+                "proc_io_write_bytes",
+                proc.end_write_bytes.saturating_sub(proc.begin_write_bytes),
+            ),
+        ]
+        .into_iter()
+        .map(|(name, value)| Metric::new(name, value, IO_COUNTERS_METRIC_UNIT, Self::get_name()))
+        .collect();
 
-        let mem_used = |mem_available: Option<u64>, mem_free: u64, cached: u64| -> u64 {
-            if let Some(available) = mem_available {
-                mem_total - available
-            } else {
-                mem_total.saturating_sub(mem_free + cached)
-            }
-        };
+        let global = counters.global;
 
-        let max_mem_used = mem_used(
-            global.min_mem_available,
-            global.min_mem_free,
-            global.min_cached,
-        );
-        let min_mem_used = mem_used(
-            global.max_mem_available,
-            global.max_mem_free,
-            global.max_cached,
-        );
+        let mem_used =
+            |mem_available: Option<MinMax>, mem_free: MinMax, cached: MinMax| -> MinMax {
+                if let Some(available) = mem_available {
+                    MinMax(
+                        self.mem_total.saturating_sub(available.max()),
+                        self.mem_total.saturating_sub(available.min()),
+                    )
+                } else {
+                    MinMax(
+                        self.mem_total.saturating_sub(mem_free.min() + cached.min()),
+                        self.mem_total.saturating_sub(mem_free.max() + cached.max()),
+                    )
+                }
+            };
+
+        let mem_used = mem_used(global.mem_available, global.mem_free, global.cached);
 
         let mut global_memory_metrics: Metrics = [
-            ("global_mem_used_min", global_conv(min_mem_used)),
-            ("global_mem_used_max", global_conv(max_mem_used)),
-            ("global_cached_min", global_conv(global.min_cached)),
-            ("global_cached_max", global_conv(global.max_cached)),
-            ("global_swap_free_min", global_conv(global.min_swap_free)),
-            ("global_swap_free_max", global_conv(global.max_swap_free)),
+            ("global_mem_used_min", global_conv(mem_used.min())),
+            ("global_mem_used_max", global_conv(mem_used.max())),
+            ("global_cached_min", global_conv(global.cached.min())),
+            ("global_cached_max", global_conv(global.cached.max())),
+            ("global_swap_free_min", global_conv(global.swap_free.min())),
+            ("global_swap_free_max", global_conv(global.swap_free.max())),
         ]
         .into_iter()
         .map(|(name, value)| Metric::new(name, value, global_unit, Self::get_name()))
         .collect();
 
-        if let Some(max_anon) = global.max_anon
-            && let Some(min_anon) = global.min_anon
-        {
-            let max_anon = global_conv(max_anon);
-            let min_anon = global_conv(min_anon);
+        if let Some(anon) = global.anon {
+            let min_anon = global_conv(anon.min());
+            let max_anon = global_conv(anon.max());
+
             global_memory_metrics.push(Metric::new(
                 "global_anon_max",
                 max_anon,
@@ -423,22 +270,6 @@ impl MetricReader for Procfs {
                 Self::get_name(),
             ));
         }
-
-        let io = counters.io_counters;
-        println!("{io:?}");
-        let io_metrics: Metrics = [
-            (
-                "proc_io_read_bytes",
-                io.end_read_bytes.saturating_sub(io.begin_read_bytes),
-            ),
-            (
-                "proc_io_write_bytes",
-                io.end_write_bytes.saturating_sub(io.begin_write_bytes),
-            ),
-        ]
-        .into_iter()
-        .map(|(name, value)| Metric::new(name, value, IO_COUNTERS_METRIC_UNIT, Self::get_name()))
-        .collect();
 
         Ok(proc_memory_metrics
             .into_iter()
@@ -460,4 +291,16 @@ fn make_conv(unit: MemoryUnit) -> fn(u64) -> MetricValue {
         MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / 1_048_576.0, Some(2)),
         MemoryUnit::Giga => |b| MetricValue::Float(b as f64 / 1_073_741_824.0, Some(2)),
     }
+}
+
+fn measure_proc(pid: i32) -> Result<ProcSnapshot> {
+    trace!("Retrieving process hierarchy from pid {pid}.");
+    let pids = collect_all_children(pid);
+    trace!("Found pids {pids:?}. Reading process procfs counters.");
+    read_proc(&pids)
+}
+
+fn measure_global() -> Result<GlobalSnapshot> {
+    trace!("Reading global procfs counters.");
+    read_global()
 }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -13,9 +13,13 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 
-use crate::counters::{Counters, IoCounters, MemoryCounters};
+use crate::{
+    counters::{Counters, IoCounters, MemoryCounters},
+    utils::collect_all_children,
+};
 
 pub mod counters;
+mod utils;
 
 const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {
     prefix: UnitPrefix::None,
@@ -68,7 +72,7 @@ type Result<T> = std::result::Result<T, ProcfsError>;
 
 #[derive(Debug, Default)]
 pub struct Procfs {
-    process: Option<Process>,
+    pid: i32,
     poll_interval: Option<Duration>,
     memory_counters: Arc<Mutex<MemoryCounters>>,
     io_counters: IoCounters,
@@ -117,7 +121,7 @@ impl MetricReader for Procfs {
     type Error = ProcfsError;
 
     async fn init(&mut self, pid: i32) -> Result<()> {
-        self.process = Some(Process::new(pid)?);
+        self.pid = pid;
 
         let Some(interval) = self.poll_interval else {
             return Ok(());
@@ -126,15 +130,23 @@ impl MetricReader for Procfs {
         let current_counters = self.memory_counters.clone();
 
         let handle = tokio::spawn(async move {
-            let process = Process::new(pid)?;
             let mut ticker = Interval::new_interval(interval)?;
 
             loop {
                 ticker.next().await;
 
-                let Ok((vm_size, rss, pss, shared, anon)) = read_memory(&process) else {
-                    continue;
+                let pids = match collect_all_children(pid) {
+                    Ok(c) => c,
+                    Err(_) => continue,
                 };
+
+                let (vm_size, rss, pss, shared, anon) = pids
+                    .into_iter()
+                    .filter_map(|p| Process::new(p).ok())
+                    .filter_map(|p| read_memory(&p).ok())
+                    .fold((0, 0, 0, 0, 0), |acc, (vm, r, ps, sh, an)| {
+                        (acc.0 + vm, acc.1 + r, acc.2 + ps, acc.3 + sh, acc.4 + an)
+                    });
 
                 let mut counters = current_counters.lock().await;
                 counters.update(vm_size, rss, pss, shared, anon);
@@ -159,25 +171,16 @@ impl MetricReader for Procfs {
     }
 
     async fn measure(&mut self) -> Result<()> {
-        let process = self.process.as_ref().ok_or(ProcfsError::NotInitialized)?;
+        let pids = collect_all_children(self.pid)?;
 
-        match read_io(process) {
-            Ok((read_bytes, write_bytes)) => {
-                self.io_counters.end_read_bytes = read_bytes;
-                self.io_counters.end_write_bytes = write_bytes;
-            }
-            Err(ProcfsError::Procfs(_)) => {}
-            Err(e) => return Err(e),
-        }
+        let (read_bytes, write_bytes) = pids
+            .into_iter()
+            .filter_map(|p| Process::new(p).ok())
+            .filter_map(|p| read_io(&p).ok())
+            .fold((0, 0), |acc, (r, w)| (acc.0 + r, acc.1 + w));
 
-        match read_memory(process) {
-            Ok((vm_size, rss, pss, shared, anon)) => {
-                let mut counters = self.memory_counters.lock().await;
-                counters.update(vm_size, rss, pss, shared, anon);
-            }
-            Err(ProcfsError::Procfs(_)) => {}
-            Err(e) => return Err(e),
-        }
+        self.io_counters.end_read_bytes = read_bytes;
+        self.io_counters.end_write_bytes = write_bytes;
 
         Ok(())
     }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -19,7 +19,7 @@ use tokio_timerfd::Interval;
 
 use crate::{
     config::ProcfsConfig,
-    counters::{Counters, MinMax},
+    counters::{Counters, compute_mem_used},
     error::ProcfsError,
     snapshot::{ProcSnapshot, measure_global, measure_proc},
     utils::make_conversion,
@@ -222,24 +222,23 @@ impl MetricReader for Procfs {
             .collect())
     }
 
-    fn to_metrics(&self, mut counters: Self::Type) -> Result<Metrics> {
+    fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
         let proc_unit: MetricUnit = self.config.proc_memory_unit.into();
         let global_unit: MetricUnit = self.config.global_memory_unit.into();
 
-        counters.remove_sentinels();
         let proc = counters.proc;
 
         let proc_memory_metrics: Metrics = [
-            ("proc_vm_size_min", proc.vm_size.min()),
-            ("proc_vm_size_max", proc.vm_size.max()),
-            ("proc_rss_min", proc.rss.min()),
-            ("proc_rss_max", proc.rss.max()),
-            ("proc_pss_min", proc.pss.min()),
-            ("proc_pss_max", proc.pss.max()),
-            ("proc_shared_min", proc.shared.min()),
-            ("proc_shared_max", proc.shared.max()),
-            ("proc_anon_min", proc.anon.min()),
-            ("proc_anon_max", proc.anon.max()),
+            ("proc_vm_size_min", proc.vm_size.min().unwrap_or_default()),
+            ("proc_vm_size_max", proc.vm_size.max().unwrap_or_default()),
+            ("proc_rss_min", proc.rss.min().unwrap_or_default()),
+            ("proc_rss_max", proc.rss.max().unwrap_or_default()),
+            ("proc_pss_min", proc.pss.min().unwrap_or_default()),
+            ("proc_pss_max", proc.pss.max().unwrap_or_default()),
+            ("proc_shared_min", proc.shared.min().unwrap_or_default()),
+            ("proc_shared_max", proc.shared.max().unwrap_or_default()),
+            ("proc_anon_min", proc.anon.min().unwrap_or_default()),
+            ("proc_anon_max", proc.anon.max().unwrap_or_default()),
         ]
         .into_iter()
         .map(|(name, value)| {
@@ -263,6 +262,7 @@ impl MetricReader for Procfs {
         .collect();
 
         let global = counters.global;
+        let global_memory_unit = self.config.global_memory_unit;
         let mem_used = compute_mem_used(
             self.mem_total,
             global.mem_available,
@@ -270,32 +270,36 @@ impl MetricReader for Procfs {
             global.cached,
         );
 
-        let global_memory_unit = self.config.global_memory_unit;
-
         let mut global_memory_metrics: Metrics = [
             (
                 "global_mem_used_min",
-                make_conversion(global_memory_unit, mem_used.min()),
+                make_conversion(global_memory_unit, mem_used.min().unwrap_or_default()),
             ),
             (
                 "global_mem_used_max",
-                make_conversion(global_memory_unit, mem_used.max()),
+                make_conversion(global_memory_unit, mem_used.max().unwrap_or_default()),
             ),
             (
                 "global_cached_min",
-                make_conversion(global_memory_unit, global.cached.min()),
+                make_conversion(global_memory_unit, global.cached.min().unwrap_or_default()),
             ),
             (
                 "global_cached_max",
-                make_conversion(global_memory_unit, global.cached.max()),
+                make_conversion(global_memory_unit, global.cached.max().unwrap_or_default()),
             ),
             (
                 "global_swap_free_min",
-                make_conversion(global_memory_unit, global.swap_free.min()),
+                make_conversion(
+                    global_memory_unit,
+                    global.swap_free.min().unwrap_or_default(),
+                ),
             ),
             (
                 "global_swap_free_max",
-                make_conversion(global_memory_unit, global.swap_free.max()),
+                make_conversion(
+                    global_memory_unit,
+                    global.swap_free.max().unwrap_or_default(),
+                ),
             ),
         ]
         .into_iter()
@@ -303,13 +307,20 @@ impl MetricReader for Procfs {
         .collect();
 
         if let Some(anon) = global.anon {
-            let anon: Vec<_> = [("global_anon_max", anon.0), ("global_anon_min", anon.1)]
-                .into_iter()
-                .map(|(name, value)| {
-                    let value = make_conversion(global_memory_unit, value);
-                    Metric::new(name, value, global_unit, Self::get_name())
-                })
-                .collect();
+            let anon: Vec<_> = [
+                ("global_anon_min", anon.min().unwrap_or_default()),
+                ("global_anon_max", anon.max().unwrap_or_default()),
+            ]
+            .into_iter()
+            .map(|(name, value)| {
+                Metric::new(
+                    name,
+                    make_conversion(global_memory_unit, value),
+                    global_unit,
+                    Self::get_name(),
+                )
+            })
+            .collect();
             global_memory_metrics.extend(anon);
         }
 
@@ -322,32 +333,5 @@ impl MetricReader for Procfs {
 
     fn get_name() -> &'static str {
         "procfs"
-    }
-}
-
-/// Computes used memory as `MemTotal - MemAvailable`.
-///
-/// If `MemAvailable` is present in `/proc/meminfo`, it is used directly (preferred).
-/// Otherwise, falls back to `MemTotal - (MemFree + Cached)`, which is less accurate
-/// but universally available.
-///
-/// Note: min/max are inverted relative to `available` since higher availability
-/// means lower usage.
-fn compute_mem_used(
-    mem_total: u64,
-    mem_available: Option<MinMax>,
-    mem_free: MinMax,
-    cached: MinMax,
-) -> MinMax {
-    if let Some(available) = mem_available {
-        MinMax(
-            mem_total.saturating_sub(available.max()),
-            mem_total.saturating_sub(available.min()),
-        )
-    } else {
-        MinMax(
-            mem_total.saturating_sub(mem_free.max() + cached.max()),
-            mem_total.saturating_sub(mem_free.min() + cached.min()),
-        )
     }
 }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -5,6 +5,7 @@ use joule_profiler_core::{
     types::{Metric, MetricValue, Metrics},
     unit::{MetricUnit, Unit, UnitPrefix},
 };
+use log::{debug, trace};
 use procfs::process::Process;
 use std::sync::Arc;
 use std::time::Duration;
@@ -82,6 +83,7 @@ pub struct Procfs {
 
 fn read_memory(process: &Process) -> Result<(u64, u64, u64, u64, u64)> {
     let vm_size = process.stat()?.vsize;
+    trace!("Querying process {} smaps_rollup.", process.pid);
     let smaps = process.smaps_rollup()?;
 
     let (rss, pss, anon, shared) = smaps
@@ -103,6 +105,7 @@ fn read_memory(process: &Process) -> Result<(u64, u64, u64, u64, u64)> {
 }
 
 fn read_io(process: &Process) -> Result<(u64, u64)> {
+    trace!("Querying process {} io.", process.pid);
     let io = process.io()?;
     Ok((io.rchar, io.wchar))
 }
@@ -130,6 +133,7 @@ impl MetricReader for Procfs {
         let current_counters = self.memory_counters.clone();
 
         let handle = tokio::spawn(async move {
+            debug!("Starting procfs polling.");
             let mut ticker = Interval::new_interval(interval)?;
 
             loop {
@@ -139,6 +143,7 @@ impl MetricReader for Procfs {
                     Ok(c) => c,
                     Err(_) => continue,
                 };
+                trace!("Found pids {pids:?}.");
 
                 let (vm_size, rss, pss, shared, anon) = pids
                     .into_iter()
@@ -147,6 +152,7 @@ impl MetricReader for Procfs {
                     .fold((0, 0, 0, 0, 0), |acc, (vm, r, ps, sh, an)| {
                         (acc.0 + vm, acc.1 + r, acc.2 + ps, acc.3 + sh, acc.4 + an)
                     });
+                trace!("vm_size: {vm_size}, rss: {rss}, pss: {pss}, shared: {shared}, anon: {anon}.");
 
                 let mut counters = current_counters.lock().await;
                 counters.update(vm_size, rss, pss, shared, anon);

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -1,0 +1,302 @@
+use futures::StreamExt;
+use joule_profiler_core::{
+    sensor::{Sensor, Sensors},
+    source::MetricReader,
+    types::{Metric, MetricValue, Metrics},
+    unit::{MetricUnit, Unit, UnitPrefix},
+};
+use procfs::process::Process;
+use std::sync::Arc;
+use std::time::Duration;
+use thiserror::Error;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_timerfd::Interval;
+
+use crate::counters::{Counters, IoCounters, MemoryCounters};
+
+pub mod counters;
+
+const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {prefix: UnitPrefix::None, unit: Unit::Byte};
+
+#[derive(Error, Debug)]
+pub enum ProcfsError {
+    #[error("Procfs not initialized, call init first")]
+    NotInitialized,
+    #[error(transparent)]
+    Procfs(#[from] procfs::ProcError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryUnit {
+    Bytes,
+    Kilo,
+    #[default]
+    Mega,
+    Giga,
+}
+
+impl From<MemoryUnit> for MetricUnit {
+    fn from(unit: MemoryUnit) -> Self {
+        match unit {
+            MemoryUnit::Bytes => MetricUnit {
+                prefix: UnitPrefix::None,
+                unit: Unit::Byte,
+            },
+            MemoryUnit::Kilo => MetricUnit {
+                prefix: UnitPrefix::Kilo,
+                unit: Unit::Byte,
+            },
+            MemoryUnit::Mega => MetricUnit {
+                prefix: UnitPrefix::Mega,
+                unit: Unit::Byte,
+            },
+            MemoryUnit::Giga => MetricUnit {
+                prefix: UnitPrefix::Giga,
+                unit: Unit::Byte,
+            },
+        }
+    }
+}
+
+type Result<T> = std::result::Result<T, ProcfsError>;
+
+#[derive(Debug, Default)]
+pub struct Procfs {
+    process: Option<Process>,
+    poll_interval: Option<Duration>,
+    memory_counters: Arc<Mutex<MemoryCounters>>,
+    io_counters: IoCounters,
+    handle: Option<JoinHandle<Result<()>>>,
+    memory_unit: MemoryUnit,
+}
+
+fn read_memory(process: &Process) -> Result<(u64, u64, u64, u64, u64)> {
+    let vm_size = process.stat()?.vsize;
+    let smaps = process.smaps_rollup()?;
+
+    let (rss, pss, anon, shared) = smaps
+        .memory_map_rollup
+        .iter()
+        .next()
+        .map(|entry| {
+            let m = &entry.extension.map;
+            let rss = m.get("Rss").copied().unwrap_or(0);
+            let pss = m.get("Pss").copied().unwrap_or(0);
+            let anon = m.get("Anonymous").copied().unwrap_or(0);
+            let shared = m.get("Shared_Clean").copied().unwrap_or(0)
+                + m.get("Shared_Dirty").copied().unwrap_or(0);
+            (rss, pss, anon, shared)
+        })
+        .unwrap_or_default();
+
+    Ok((vm_size, rss, pss, shared, anon))
+}
+
+fn read_io(process: &Process) -> Result<(u64, u64)> {
+    let io = process.io()?;
+    Ok((io.rchar, io.wchar))
+}
+
+impl Procfs {
+    pub fn new(poll_interval: Option<Duration>) -> Self {
+        Self {
+            poll_interval,
+            ..Default::default()
+        }
+    }
+}
+
+impl MetricReader for Procfs {
+    type Type = Counters;
+    type Error = ProcfsError;
+
+    async fn init(&mut self, pid: i32) -> Result<()> {
+        self.process = Some(Process::new(pid)?);
+
+        let Some(interval) = self.poll_interval else {
+            return Ok(());
+        };
+
+        let current_counters = self.memory_counters.clone();
+
+        let handle = tokio::spawn(async move {
+            let process = Process::new(pid)?;
+            let mut ticker = Interval::new_interval(interval)?;
+
+            loop {
+                ticker.next().await;
+
+                let Ok((vm_size, rss, pss, shared, anon)) = read_memory(&process) else {
+                    continue;
+                };
+
+                let mut counters = current_counters.lock().await;
+                counters.update(vm_size, rss, pss, shared, anon);
+            }
+        });
+
+        self.handle = Some(handle);
+        Ok(())
+    }
+
+    async fn join(&mut self) -> Result<()> {
+        if let Some(handle) = self.handle.take() {
+            if handle.is_finished() {
+                if let Ok(res) = handle.await {
+                    return res;
+                }
+            } else {
+                handle.abort();
+            }
+        }
+        Ok(())
+    }
+
+    async fn measure(&mut self) -> Result<()> {
+        let process = self.process.as_ref().ok_or(ProcfsError::NotInitialized)?;
+        
+        match read_io(process) {
+            Ok((read_bytes, write_bytes)) => {
+                self.io_counters.end_read_bytes = read_bytes;
+                self.io_counters.end_write_bytes = write_bytes;
+            }
+            Err(ProcfsError::Procfs(_)) => {}
+            Err(e) => return Err(e),
+        }
+
+        match read_memory(process) {
+            Ok((vm_size, rss, pss, shared, anon)) => {
+                let mut counters = self.memory_counters.lock().await;
+                counters.update(vm_size, rss, pss, shared, anon);
+            }
+            Err(ProcfsError::Procfs(_)) => {}
+            Err(e) => return Err(e),
+        }
+
+        Ok(())
+    }
+
+    async fn retrieve(&mut self) -> Result<Self::Type> {
+        let mut lock = self.memory_counters.lock().await;
+        let memory_counters = lock.clone();
+        lock.reset_phase();
+
+        let counters = Counters { memory_counters, io_counters: self.io_counters };
+
+        self.io_counters.begin_read_bytes = self.io_counters.end_read_bytes;
+        self.io_counters.begin_write_bytes = self.io_counters.end_write_bytes;
+
+        Ok(counters)
+    }
+
+    fn get_sensors(&self) -> Result<Sensors> {
+        Ok([
+            "vm_size",
+            "vm_size_max",
+            "rss",
+            "rss_max",
+            "pss",
+            "pss_max",
+            "shared",
+            "shared_max",
+            "anon",
+            "anon_max",
+        ]
+        .into_iter()
+        .map(|name| Sensor::new(name, self.memory_unit.into(), Self::get_name()))
+        .collect())
+    }
+
+    fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
+        let memory_unit = self.memory_unit.into();
+
+        let memory_counters = counters.memory_counters;
+
+        let (conv, conv_delta): (fn(u64) -> MetricValue, fn(i64) -> MetricValue) =
+            match self.memory_unit {
+                MemoryUnit::Bytes => (
+                    |b| MetricValue::UnsignedInteger(b),
+                    |s| MetricValue::SignedInteger(s),
+                ),
+                MemoryUnit::Kilo => (
+                    |b| MetricValue::UnsignedInteger(b / 1024),
+                    |s| MetricValue::SignedInteger(s / 1024),
+                ),
+                MemoryUnit::Mega => (
+                    |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0), Some(2)),
+                    |s| MetricValue::Float(s as f64 / (1024.0 * 1024.0), Some(2)),
+                ),
+                MemoryUnit::Giga => (
+                    |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0 * 1024.0), Some(2)),
+                    |s| MetricValue::Float(s as f64 / (1024.0 * 1024.0 * 1024.0), Some(2)),
+                ),
+            };
+
+        let memory_metrics: Metrics = [
+            ("vm_size", conv(memory_counters.vm_size)),
+            ("vm_size_max", conv(memory_counters.max_vm_size)),
+            ("rss", conv(memory_counters.rss)),
+            ("rss_max", conv(memory_counters.max_rss)),
+            ("pss", conv(memory_counters.pss)),
+            ("pss_max", conv(memory_counters.max_pss)),
+            ("shared", conv(memory_counters.shared)),
+            ("shared_max", conv(memory_counters.max_shared)),
+            ("anon", conv(memory_counters.anon)),
+            ("anon_max", conv(memory_counters.max_anon)),
+        ]
+        .into_iter()
+        .map(|(name, value)| Metric::new(name, value, memory_unit, Self::get_name()))
+        .collect();
+
+        let memory_deltas: Metrics = [
+            (
+                "vm_size_delta",
+                conv_delta(MemoryCounters::delta(memory_counters.vm_size, memory_counters.phase_start_vm_size)),
+            ),
+            (
+                "rss_delta",
+                conv_delta(MemoryCounters::delta(memory_counters.rss, memory_counters.phase_start_rss)),
+            ),
+            (
+                "pss_delta",
+                conv_delta(MemoryCounters::delta(memory_counters.pss, memory_counters.phase_start_pss)),
+            ),
+            (
+                "shared_delta",
+                conv_delta(MemoryCounters::delta(memory_counters.shared, memory_counters.phase_start_shared)),
+            ),
+            (
+                "anon_delta",
+                conv_delta(MemoryCounters::delta(memory_counters.anon, memory_counters.phase_start_anon)),
+            ),
+        ]
+        .into_iter()
+        .map(|(name, value)| Metric::new(name, value, memory_unit, Self::get_name()))
+        .collect();
+
+        let io_counters = counters.io_counters;
+        let read_bytes =
+    io_counters
+        .end_read_bytes
+        .saturating_sub(io_counters.begin_read_bytes);
+
+        let write_bytes =
+    io_counters
+        .end_write_bytes
+        .saturating_sub(io_counters.begin_write_bytes);
+
+        let io_metrics = vec![
+            Metric::new("read_bytes", read_bytes, IO_COUNTERS_METRIC_UNIT, Self::get_name()),
+            Metric::new("write_bytes", write_bytes, IO_COUNTERS_METRIC_UNIT, Self::get_name()),
+        ];
+
+        Ok(memory_metrics.into_iter().chain(memory_deltas).chain(io_metrics).collect())
+    }
+
+    fn get_name() -> &'static str {
+        "procfs"
+    }
+}

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -2,7 +2,7 @@ use futures::StreamExt;
 use joule_profiler_core::{
     sensor::{Sensor, Sensors},
     source::MetricReader,
-    types::{Metric, MetricValue, Metrics},
+    types::{Metric, Metrics},
     unit::{MetricUnit, Unit, UnitPrefix},
 };
 use log::{debug, trace};
@@ -17,7 +17,7 @@ use crate::{
     counters::{Counters, MinMax},
     error::ProcfsError,
     snapshot::{GlobalSnapshot, ProcSnapshot, read_global, read_proc},
-    utils::{MemoryUnit, collect_all_children},
+    utils::{MemoryUnit, collect_all_children, make_conversion},
 };
 
 pub mod counters;
@@ -186,26 +186,27 @@ impl MetricReader for Procfs {
     fn to_metrics(&self, mut counters: Self::Type) -> Result<Metrics> {
         let proc_unit: MetricUnit = self.proc_memory_unit.into();
         let global_unit: MetricUnit = self.global_memory_unit.into();
-        let proc_conv = make_conv(self.proc_memory_unit);
-        let global_conv = make_conv(self.global_memory_unit);
 
         counters.remove_sentinels();
         let proc = counters.proc;
 
         let proc_memory_metrics: Metrics = [
-            ("proc_vm_size_min", proc_conv(proc.vm_size.min())),
-            ("proc_vm_size_max", proc_conv(proc.vm_size.max())),
-            ("proc_rss_min", proc_conv(proc.rss.min())),
-            ("proc_rss_max", proc_conv(proc.rss.max())),
-            ("proc_pss_min", proc_conv(proc.pss.min())),
-            ("proc_pss_max", proc_conv(proc.pss.max())),
-            ("proc_shared_min", proc_conv(proc.shared.min())),
-            ("proc_shared_max", proc_conv(proc.shared.max())),
-            ("proc_anon_min", proc_conv(proc.anon.min())),
-            ("proc_anon_max", proc_conv(proc.anon.max())),
+            ("proc_vm_size_min", proc.vm_size.min()),
+            ("proc_vm_size_max", proc.vm_size.max()),
+            ("proc_rss_min", proc.rss.min()),
+            ("proc_rss_max", proc.rss.max()),
+            ("proc_pss_min", proc.pss.min()),
+            ("proc_pss_max", proc.pss.max()),
+            ("proc_shared_min", proc.shared.min()),
+            ("proc_shared_max", proc.shared.max()),
+            ("proc_anon_min", proc.anon.min()),
+            ("proc_anon_max", proc.anon.max()),
         ]
         .into_iter()
-        .map(|(name, value)| Metric::new(name, value, proc_unit, Self::get_name()))
+        .map(|(name, value)| {
+            let value = make_conversion(self.proc_memory_unit, value);
+            Metric::new(name, value, proc_unit, Self::get_name())
+        })
         .collect();
 
         let io_metrics: Metrics = [
@@ -242,33 +243,44 @@ impl MetricReader for Procfs {
         let mem_used = mem_used(global.mem_available, global.mem_free, global.cached);
 
         let mut global_memory_metrics: Metrics = [
-            ("global_mem_used_min", global_conv(mem_used.min())),
-            ("global_mem_used_max", global_conv(mem_used.max())),
-            ("global_cached_min", global_conv(global.cached.min())),
-            ("global_cached_max", global_conv(global.cached.max())),
-            ("global_swap_free_min", global_conv(global.swap_free.min())),
-            ("global_swap_free_max", global_conv(global.swap_free.max())),
+            (
+                "global_mem_used_min",
+                make_conversion(self.global_memory_unit, mem_used.min()),
+            ),
+            (
+                "global_mem_used_max",
+                make_conversion(self.global_memory_unit, mem_used.max()),
+            ),
+            (
+                "global_cached_min",
+                make_conversion(self.global_memory_unit, global.cached.min()),
+            ),
+            (
+                "global_cached_max",
+                make_conversion(self.global_memory_unit, global.cached.max()),
+            ),
+            (
+                "global_swap_free_min",
+                make_conversion(self.global_memory_unit, global.swap_free.min()),
+            ),
+            (
+                "global_swap_free_max",
+                make_conversion(self.global_memory_unit, global.swap_free.max()),
+            ),
         ]
         .into_iter()
         .map(|(name, value)| Metric::new(name, value, global_unit, Self::get_name()))
         .collect();
 
         if let Some(anon) = global.anon {
-            let min_anon = global_conv(anon.min());
-            let max_anon = global_conv(anon.max());
-
-            global_memory_metrics.push(Metric::new(
-                "global_anon_max",
-                max_anon,
-                global_unit,
-                Self::get_name(),
-            ));
-            global_memory_metrics.push(Metric::new(
-                "global_anon_min",
-                min_anon,
-                global_unit,
-                Self::get_name(),
-            ));
+            let anon: Vec<_> = [("global_anon_max", anon.0), ("global_anon_min", anon.1)]
+                .into_iter()
+                .map(|(name, value)| {
+                    let value = make_conversion(self.global_memory_unit, value);
+                    Metric::new(name, value, global_unit, Self::get_name())
+                })
+                .collect();
+            global_memory_metrics.extend(anon);
         }
 
         Ok(proc_memory_metrics
@@ -280,16 +292,6 @@ impl MetricReader for Procfs {
 
     fn get_name() -> &'static str {
         "procfs"
-    }
-}
-
-fn make_conv(unit: MemoryUnit) -> fn(u64) -> MetricValue {
-    #[allow(clippy::cast_precision_loss)]
-    match unit {
-        MemoryUnit::Bytes => |b| MetricValue::UnsignedInteger(b),
-        MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1_024),
-        MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / 1_048_576.0, Some(2)),
-        MemoryUnit::Giga => |b| MetricValue::Float(b as f64 / 1_073_741_824.0, Some(2)),
     }
 }
 

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -139,10 +139,7 @@ impl MetricReader for Procfs {
             loop {
                 ticker.next().await;
 
-                let pids = match collect_all_children(pid) {
-                    Ok(c) => c,
-                    Err(_) => continue,
-                };
+                let pids = collect_all_children(pid);
                 trace!("Found pids {pids:?}.");
 
                 let (vm_size, rss, pss, shared, anon) = pids
@@ -152,7 +149,9 @@ impl MetricReader for Procfs {
                     .fold((0, 0, 0, 0, 0), |acc, (vm, r, ps, sh, an)| {
                         (acc.0 + vm, acc.1 + r, acc.2 + ps, acc.3 + sh, acc.4 + an)
                     });
-                trace!("vm_size: {vm_size}, rss: {rss}, pss: {pss}, shared: {shared}, anon: {anon}.");
+                trace!(
+                    "vm_size: {vm_size}, rss: {rss}, pss: {pss}, shared: {shared}, anon: {anon}."
+                );
 
                 let mut counters = current_counters.lock().await;
                 counters.update(vm_size, rss, pss, shared, anon);
@@ -177,7 +176,7 @@ impl MetricReader for Procfs {
     }
 
     async fn measure(&mut self) -> Result<()> {
-        let pids = collect_all_children(self.pid)?;
+        let pids = collect_all_children(self.pid);
 
         let (read_bytes, write_bytes) = pids
             .into_iter()
@@ -228,12 +227,15 @@ impl MetricReader for Procfs {
     fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
         let memory_unit = self.memory_unit.into();
 
-        let memory_counters = counters.memory_counters;
+        let mut memory_counters = counters.memory_counters;
+        memory_counters.remove_sentinel_values();
 
         let conv: fn(u64) -> MetricValue = match self.memory_unit {
             MemoryUnit::Bytes => |b| MetricValue::UnsignedInteger(b),
             MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1024),
+            #[allow(clippy::cast_precision_loss)]
             MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0), Some(2)),
+            #[allow(clippy::cast_precision_loss)]
             MemoryUnit::Giga => {
                 |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0 * 1024.0), Some(2))
             }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -5,8 +5,8 @@ use joule_profiler_core::{
     types::{Metric, MetricValue, Metrics},
     unit::{MetricUnit, Unit, UnitPrefix},
 };
-use log::{debug, trace};
-use procfs::process::Process;
+use log::{debug, trace, warn};
+use procfs::{Current, FromRead, process::Process};
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -14,10 +14,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 
-use crate::{
-    counters::{Counters, IoCounters, MemoryCounters},
-    utils::collect_all_children,
-};
+use crate::{counters::Counters, utils::collect_all_children};
 
 pub mod counters;
 mod utils;
@@ -71,17 +68,31 @@ impl From<MemoryUnit> for MetricUnit {
 
 type Result<T> = std::result::Result<T, ProcfsError>;
 
+pub struct MemorySnapshot {
+    proc_vm_size: u64,
+    proc_rss: u64,
+    proc_pss: u64,
+    proc_shared: u64,
+    proc_anon: u64,
+
+    global_mem_available: Option<u64>,
+    global_mem_free: u64,
+    global_cached: u64,
+    global_anon: Option<u64>,
+    global_swap_free: u64,
+}
+
 #[derive(Debug, Default)]
 pub struct Procfs {
     pid: i32,
     poll_interval: Option<Duration>,
-    memory_counters: Arc<Mutex<MemoryCounters>>,
-    io_counters: IoCounters,
+    counters: Arc<Mutex<Counters>>,
     handle: Option<JoinHandle<Result<()>>>,
-    memory_unit: MemoryUnit,
+    proc_memory_unit: MemoryUnit,
+    global_memory_unit: MemoryUnit,
 }
 
-fn read_memory(process: &Process) -> Result<(u64, u64, u64, u64, u64)> {
+fn read_proc_memory(process: &Process) -> Result<(u64, u64, u64, u64, u64)> {
     let vm_size = process.stat()?.vsize;
     trace!("Querying process {} smaps_rollup.", process.pid);
     let smaps = process.smaps_rollup()?;
@@ -104,6 +115,19 @@ fn read_memory(process: &Process) -> Result<(u64, u64, u64, u64, u64)> {
     Ok((vm_size, rss, pss, shared, anon))
 }
 
+fn read_global_memory() -> Result<(Option<u64>, u64, u64, Option<u64>, u64)> {
+    let meminfo = procfs::Meminfo::from_file(procfs::Meminfo::PATH)?;
+    trace!("Querying global meminfo from {}", procfs::Meminfo::PATH);
+
+    Ok((
+        meminfo.mem_available,
+        meminfo.mem_free,
+        meminfo.cached,
+        meminfo.anon_pages,
+        meminfo.swap_free,
+    ))
+}
+
 fn read_io(process: &Process) -> Result<(u64, u64)> {
     trace!("Querying process {} io.", process.pid);
     let io = process.io()?;
@@ -114,9 +138,42 @@ impl Procfs {
     pub fn new(poll_interval: Option<Duration>) -> Self {
         Self {
             poll_interval,
+            global_memory_unit: MemoryUnit::Giga,
             ..Default::default()
         }
     }
+}
+
+fn read_memory_counters(pids: &[i32]) -> Result<MemorySnapshot> {
+    let (proc_vm_size, proc_rss, proc_pss, proc_shared, proc_anon) = pids
+        .iter()
+        .filter_map(|p| Process::new(*p).ok())
+        .filter_map(|p| read_proc_memory(&p).ok())
+        .fold((0, 0, 0, 0, 0), |acc, (vm, r, ps, sh, an)| {
+            (acc.0 + vm, acc.1 + r, acc.2 + ps, acc.3 + sh, acc.4 + an)
+        });
+    trace!(
+        "vm_size: {proc_vm_size}, rss: {proc_rss}, pss: {proc_pss}, shared: {proc_shared}, anon: {proc_anon}."
+    );
+
+    let (global_mem_available, global_mem_free, global_cached, global_anon, global_swap_free) =
+        read_global_memory()?;
+    trace!(
+        "mem_available: {global_mem_available:?}, mem_free: {global_mem_free}, cached: {global_cached}, anon: {global_anon:?}, swap_free: {global_swap_free}."
+    );
+
+    Ok(MemorySnapshot {
+        proc_vm_size,
+        proc_rss,
+        proc_pss,
+        proc_shared,
+        proc_anon,
+        global_mem_available,
+        global_mem_free,
+        global_cached,
+        global_anon,
+        global_swap_free,
+    })
 }
 
 impl MetricReader for Procfs {
@@ -130,7 +187,7 @@ impl MetricReader for Procfs {
             return Ok(());
         };
 
-        let current_counters = self.memory_counters.clone();
+        let current_counters = self.counters.clone();
 
         let handle = tokio::spawn(async move {
             debug!("Starting procfs polling.");
@@ -142,19 +199,35 @@ impl MetricReader for Procfs {
                 let pids = collect_all_children(pid);
                 trace!("Found pids {pids:?}.");
 
-                let (vm_size, rss, pss, shared, anon) = pids
+                let snapshot = read_memory_counters(&pids)?;
+
+                let (read_bytes, write_bytes) = pids
                     .into_iter()
                     .filter_map(|p| Process::new(p).ok())
-                    .filter_map(|p| read_memory(&p).ok())
-                    .fold((0, 0, 0, 0, 0), |acc, (vm, r, ps, sh, an)| {
-                        (acc.0 + vm, acc.1 + r, acc.2 + ps, acc.3 + sh, acc.4 + an)
-                    });
-                trace!(
-                    "vm_size: {vm_size}, rss: {rss}, pss: {pss}, shared: {shared}, anon: {anon}."
-                );
+                    .filter_map(|p| read_io(&p).ok())
+                    .fold((0, 0), |acc, (r, w)| (acc.0 + r, acc.1 + w));
 
                 let mut counters = current_counters.lock().await;
-                counters.update(vm_size, rss, pss, shared, anon);
+
+                counters.memory_counters.update_proc(
+                    snapshot.proc_vm_size,
+                    snapshot.proc_rss,
+                    snapshot.proc_pss,
+                    snapshot.proc_shared,
+                    snapshot.proc_anon,
+                );
+                counters.memory_counters.update_global(
+                    snapshot.global_mem_available,
+                    snapshot.global_mem_free,
+                    snapshot.global_cached,
+                    snapshot.global_anon,
+                    snapshot.global_swap_free,
+                );
+
+                counters.io_counters.end_read_bytes =
+                    counters.io_counters.end_read_bytes.max(read_bytes);
+                counters.io_counters.end_write_bytes =
+                    counters.io_counters.end_write_bytes.max(write_bytes);
             }
         });
 
@@ -178,113 +251,213 @@ impl MetricReader for Procfs {
     async fn measure(&mut self) -> Result<()> {
         let pids = collect_all_children(self.pid);
 
+        let snapshot = read_memory_counters(&pids)?;
+        let mut counters = self.counters.lock().await;
+        counters.memory_counters.update_proc(
+            snapshot.proc_vm_size,
+            snapshot.proc_rss,
+            snapshot.proc_pss,
+            snapshot.proc_shared,
+            snapshot.proc_anon,
+        );
+        counters.memory_counters.update_global(
+            snapshot.global_mem_available,
+            snapshot.global_mem_free,
+            snapshot.global_cached,
+            snapshot.global_anon,
+            snapshot.global_swap_free,
+        );
+
         let (read_bytes, write_bytes) = pids
             .into_iter()
             .filter_map(|p| Process::new(p).ok())
             .filter_map(|p| read_io(&p).ok())
             .fold((0, 0), |acc, (r, w)| (acc.0 + r, acc.1 + w));
 
-        self.io_counters.end_read_bytes = read_bytes;
-        self.io_counters.end_write_bytes = write_bytes;
+        counters.io_counters.end_read_bytes = counters.io_counters.end_read_bytes.max(read_bytes);
+        counters.io_counters.end_write_bytes =
+            counters.io_counters.end_write_bytes.max(write_bytes);
+
+        warn!("{read_bytes} {write_bytes}");
 
         Ok(())
     }
 
     async fn retrieve(&mut self) -> Result<Self::Type> {
-        let mut lock = self.memory_counters.lock().await;
-        let memory_counters = lock.clone();
-        lock.reset_phase();
+        let mut lock = self.counters.lock().await;
+        let counters = *lock;
+        lock.memory_counters.reset_phase();
 
-        let counters = Counters {
-            memory_counters,
-            io_counters: self.io_counters,
-        };
-
-        self.io_counters.begin_read_bytes = self.io_counters.end_read_bytes;
-        self.io_counters.begin_write_bytes = self.io_counters.end_write_bytes;
+        lock.io_counters.begin_read_bytes = counters.io_counters.end_read_bytes;
+        lock.io_counters.begin_write_bytes = counters.io_counters.end_write_bytes;
 
         Ok(counters)
     }
 
     fn get_sensors(&self) -> Result<Sensors> {
-        Ok([
-            "vm_size_min",
-            "vm_size_max",
-            "rss_min",
-            "rss_max",
-            "pss_min",
-            "pss_max",
-            "shared_min",
-            "shared_max",
-            "anon_min",
-            "anon_max",
+        let proc_unit: MetricUnit = self.proc_memory_unit.into();
+        let global_unit: MetricUnit = self.global_memory_unit.into();
+
+        let proc_sensors = [
+            "proc_vm_size_min",
+            "proc_vm_size_max",
+            "proc_rss_min",
+            "proc_rss_max",
+            "proc_pss_min",
+            "proc_pss_max",
+            "proc_shared_min",
+            "proc_shared_max",
+            "proc_anon_min",
+            "proc_anon_max",
         ]
         .into_iter()
-        .map(|name| Sensor::new(name, self.memory_unit.into(), Self::get_name()))
-        .collect())
-    }
+        .map(|name| Sensor::new(name, proc_unit, Self::get_name()));
 
-    fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
-        let memory_unit = self.memory_unit.into();
-
-        let mut memory_counters = counters.memory_counters;
-        memory_counters.remove_sentinel_values();
-
-        let conv: fn(u64) -> MetricValue = match self.memory_unit {
-            MemoryUnit::Bytes => |b| MetricValue::UnsignedInteger(b),
-            MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1024),
-            #[allow(clippy::cast_precision_loss)]
-            MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0), Some(2)),
-            #[allow(clippy::cast_precision_loss)]
-            MemoryUnit::Giga => {
-                |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0 * 1024.0), Some(2))
-            }
-        };
-
-        let memory_metrics: Metrics = [
-            ("vm_size_min", conv(memory_counters.min_vm_size)),
-            ("vm_size_max", conv(memory_counters.max_vm_size)),
-            ("rss_min", conv(memory_counters.min_rss)),
-            ("rss_max", conv(memory_counters.max_rss)),
-            ("pss_min", conv(memory_counters.min_pss)),
-            ("pss_max", conv(memory_counters.max_pss)),
-            ("shared_min", conv(memory_counters.min_shared)),
-            ("shared_max", conv(memory_counters.max_shared)),
-            ("anon_min", conv(memory_counters.min_anon)),
-            ("anon_max", conv(memory_counters.max_anon)),
-        ]
-        .into_iter()
-        .map(|(name, value)| Metric::new(name, value, memory_unit, Self::get_name()))
-        .collect();
-
-        let io_counters = counters.io_counters;
-        let read_bytes = io_counters
-            .end_read_bytes
-            .saturating_sub(io_counters.begin_read_bytes);
-
-        let write_bytes = io_counters
-            .end_write_bytes
-            .saturating_sub(io_counters.begin_write_bytes);
-
-        let io_metrics = vec![
-            Metric::new(
-                "io_read_bytes",
-                read_bytes,
+        let io_sensors = vec![
+            Sensor::new(
+                "proc_io_read_bytes",
                 IO_COUNTERS_METRIC_UNIT,
                 Self::get_name(),
             ),
-            Metric::new(
-                "io_write_bytes",
-                write_bytes,
+            Sensor::new(
+                "proc_io_write_bytes",
                 IO_COUNTERS_METRIC_UNIT,
                 Self::get_name(),
             ),
         ];
 
-        Ok(memory_metrics.into_iter().chain(io_metrics).collect())
+        let global_sensors = [
+            "global_mem_used_min",
+            "global_mem_used_max",
+            "global_cached_min",
+            "global_cached_max",
+            "global_anon_min",
+            "global_anon_max",
+            "global_swap_free_min",
+            "global_swap_free_max",
+        ]
+        .into_iter()
+        .map(|name| Sensor::new(name, global_unit, Self::get_name()));
+
+        Ok(proc_sensors
+            .chain(global_sensors)
+            .chain(io_sensors)
+            .collect())
+    }
+
+    fn to_metrics(&self, counters: Self::Type) -> Result<Metrics> {
+        let proc_unit: MetricUnit = self.proc_memory_unit.into();
+        let global_unit: MetricUnit = self.global_memory_unit.into();
+        let proc_conv = make_conv(self.proc_memory_unit);
+        let global_conv = make_conv(self.global_memory_unit);
+
+        let mut memory_counters = counters.memory_counters;
+        memory_counters.remove_sentinel_values();
+
+        let proc = &memory_counters.proc;
+        let proc_memory_metrics: Metrics = [
+            ("proc_vm_size_min", proc_conv(proc.min_vm_size)),
+            ("proc_vm_size_max", proc_conv(proc.max_vm_size)),
+            ("proc_rss_min", proc_conv(proc.min_rss)),
+            ("proc_rss_max", proc_conv(proc.max_rss)),
+            ("proc_pss_min", proc_conv(proc.min_pss)),
+            ("proc_pss_max", proc_conv(proc.max_pss)),
+            ("proc_shared_min", proc_conv(proc.min_shared)),
+            ("proc_shared_max", proc_conv(proc.max_shared)),
+            ("proc_anon_min", proc_conv(proc.min_anon)),
+            ("proc_anon_max", proc_conv(proc.max_anon)),
+        ]
+        .into_iter()
+        .map(|(name, value)| Metric::new(name, value, proc_unit, Self::get_name()))
+        .collect();
+
+        let global = &memory_counters.global;
+        let mem_total = procfs::Meminfo::from_file(procfs::Meminfo::PATH)?.mem_total;
+
+        let mem_used = |mem_available: Option<u64>, mem_free: u64, cached: u64| -> u64 {
+            if let Some(available) = mem_available {
+                mem_total - available
+            } else {
+                mem_total.saturating_sub(mem_free + cached)
+            }
+        };
+
+        let max_mem_used = mem_used(
+            global.min_mem_available,
+            global.min_mem_free,
+            global.min_cached,
+        );
+        let min_mem_used = mem_used(
+            global.max_mem_available,
+            global.max_mem_free,
+            global.max_cached,
+        );
+
+        let mut global_memory_metrics: Metrics = [
+            ("global_mem_used_min", global_conv(min_mem_used)),
+            ("global_mem_used_max", global_conv(max_mem_used)),
+            ("global_cached_min", global_conv(global.min_cached)),
+            ("global_cached_max", global_conv(global.max_cached)),
+            ("global_swap_free_min", global_conv(global.min_swap_free)),
+            ("global_swap_free_max", global_conv(global.max_swap_free)),
+        ]
+        .into_iter()
+        .map(|(name, value)| Metric::new(name, value, global_unit, Self::get_name()))
+        .collect();
+
+        if let Some(max_anon) = global.max_anon
+            && let Some(min_anon) = global.min_anon
+        {
+            let max_anon = global_conv(max_anon);
+            let min_anon = global_conv(min_anon);
+            global_memory_metrics.push(Metric::new(
+                "global_anon_max",
+                max_anon,
+                global_unit,
+                Self::get_name(),
+            ));
+            global_memory_metrics.push(Metric::new(
+                "global_anon_min",
+                min_anon,
+                global_unit,
+                Self::get_name(),
+            ));
+        }
+
+        let io = counters.io_counters;
+        println!("{io:?}");
+        let io_metrics: Metrics = [
+            (
+                "proc_io_read_bytes",
+                io.end_read_bytes.saturating_sub(io.begin_read_bytes),
+            ),
+            (
+                "proc_io_write_bytes",
+                io.end_write_bytes.saturating_sub(io.begin_write_bytes),
+            ),
+        ]
+        .into_iter()
+        .map(|(name, value)| Metric::new(name, value, IO_COUNTERS_METRIC_UNIT, Self::get_name()))
+        .collect();
+
+        Ok(proc_memory_metrics
+            .into_iter()
+            .chain(global_memory_metrics)
+            .chain(io_metrics)
+            .collect())
     }
 
     fn get_name() -> &'static str {
         "procfs"
+    }
+}
+
+fn make_conv(unit: MemoryUnit) -> fn(u64) -> MetricValue {
+    #[allow(clippy::cast_precision_loss)]
+    match unit {
+        MemoryUnit::Bytes => |b| MetricValue::UnsignedInteger(b),
+        MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1_024),
+        MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / 1_048_576.0, Some(2)),
+        MemoryUnit::Giga => |b| MetricValue::Float(b as f64 / 1_073_741_824.0, Some(2)),
     }
 }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -1,3 +1,8 @@
+//! Procfs metric source for Joule Profiler.
+//!
+//! Provides memory and I/O metrics for a process and it's children and system-wide,
+//! by reading Linux's `/proc` filesystem via the `procfs` crate.
+
 use futures::StreamExt;
 use joule_profiler_core::{
     sensor::{Sensor, Sensors},
@@ -14,12 +19,14 @@ use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 
 use crate::{
+    config::ProcfsConfig,
     counters::{Counters, MinMax},
     error::ProcfsError,
-    snapshot::{GlobalSnapshot, ProcSnapshot, read_global, read_proc},
-    utils::{MemoryUnit, collect_all_children, make_conversion},
+    snapshot::{ProcSnapshot, measure_global, measure_proc},
+    utils::{MemoryUnit, make_conversion},
 };
 
+pub mod config;
 pub mod counters;
 pub mod error;
 mod snapshot;
@@ -32,28 +39,61 @@ const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {
 
 type Result<T> = std::result::Result<T, ProcfsError>;
 
+/// Procfs-based metric source.
+///
+/// Reads memory and I/O metrics from `/proc` for a target process and its
+/// entire child hierarchy, as well as system-wide memory statistics.
+///
+/// Metrics are accumulated as min/max over each measurement phase.
+/// A phase starts on [`MetricReader::measure`] and ends on [`MetricReader::retrieve`],
+/// which returns the counters and resets them for the next phase.
+///
+/// If a `poll_interval` is configured, a background task polls `/proc` continuously
+/// at that interval in addition to explicit [`MetricReader::measure`] calls.
+///
+/// # Example
+///
+/// ```no_run
+/// use joule_profiler_source_procfs::{Procfs, config::ProcfsConfig};
+///
+/// let source = Procfs::new(&ProcfsConfig::default()).unwrap();
+/// ```
 #[derive(Debug, Default)]
 pub struct Procfs {
+    /// pid of the profiled process, initialized at -1.
     pid: i32,
 
+    /// The polling interval of the source if set, else no polling.
     poll_interval: Option<Duration>,
+
+    /// Current metrics counters.
     counters: Arc<Mutex<Counters>>,
+
+    /// The handle to the polling task.
     handle: Option<JoinHandle<Result<()>>>,
 
+    /// The unit in which to convert proc memory metrics.
     proc_memory_unit: MemoryUnit,
+
+    /// The unit in which to convert global memory metrics.
     global_memory_unit: MemoryUnit,
 
+    /// Total physical memory in bytes, read once at construction from `/proc/meminfo`.
     mem_total: u64,
 }
 
 impl Procfs {
-    pub fn new(poll_interval: Option<Duration>) -> Result<Self> {
+    /// Creates a new `Procfs` source from the given configuration.
+    ///
+    /// Reads `MemTotal` from `/proc/meminfo` at construction time.
+    pub fn new(config: &ProcfsConfig) -> Result<Self> {
         let mem_total = Meminfo::from_file(Meminfo::PATH)?.mem_total;
         Ok(Self {
             pid: -1,
             mem_total,
-            poll_interval,
-            global_memory_unit: MemoryUnit::Giga,
+            poll_interval: config.poll_interval,
+            global_memory_unit: config.global_memory_unit,
+            proc_memory_unit: config.proc_memory_unit,
             ..Default::default()
         })
     }
@@ -63,6 +103,7 @@ impl MetricReader for Procfs {
     type Type = Counters;
     type Error = ProcfsError;
 
+    /// Initializes the source to `pid` and starts the background poller if a `poll_interval` is configured.
     async fn init(&mut self, pid: i32) -> Result<()> {
         self.pid = pid;
 
@@ -98,19 +139,25 @@ impl MetricReader for Procfs {
         Ok(())
     }
 
+    /// Aborts the background poller if still running, or propagates its error if it already finished.
     async fn join(&mut self) -> Result<()> {
         if let Some(handle) = self.handle.take() {
             if handle.is_finished() {
+                trace!("Joining polling task.");
                 if let Ok(res) = handle.await {
                     return res;
                 }
             } else {
+                trace!("Aborting polling task.");
                 handle.abort();
             }
         }
         Ok(())
     }
 
+    /// Takes a single snapshot of process and global counters and updates them.
+    ///
+    /// If the process is not found, an empty snapshot is used.
     async fn measure(&mut self) -> Result<()> {
         let proc = match measure_proc(self.pid) {
             Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => Ok(ProcSnapshot::default()),
@@ -125,6 +172,7 @@ impl MetricReader for Procfs {
         Ok(())
     }
 
+    /// Returns the accumulated counters for the current phase and resets them.
     async fn retrieve(&mut self) -> Result<Self::Type> {
         let mut lock = self.counters.lock().await;
         let counters = *lock;
@@ -224,23 +272,12 @@ impl MetricReader for Procfs {
         .collect();
 
         let global = counters.global;
-
-        let mem_used =
-            |mem_available: Option<MinMax>, mem_free: MinMax, cached: MinMax| -> MinMax {
-                if let Some(available) = mem_available {
-                    MinMax(
-                        self.mem_total.saturating_sub(available.max()),
-                        self.mem_total.saturating_sub(available.min()),
-                    )
-                } else {
-                    MinMax(
-                        self.mem_total.saturating_sub(mem_free.min() + cached.min()),
-                        self.mem_total.saturating_sub(mem_free.max() + cached.max()),
-                    )
-                }
-            };
-
-        let mem_used = mem_used(global.mem_available, global.mem_free, global.cached);
+        let mem_used = compute_mem_used(
+            self.mem_total,
+            global.mem_available,
+            global.mem_free,
+            global.cached,
+        );
 
         let mut global_memory_metrics: Metrics = [
             (
@@ -295,14 +332,29 @@ impl MetricReader for Procfs {
     }
 }
 
-fn measure_proc(pid: i32) -> Result<ProcSnapshot> {
-    trace!("Retrieving process hierarchy from pid {pid}.");
-    let pids = collect_all_children(pid);
-    trace!("Found pids {pids:?}. Reading process procfs counters.");
-    read_proc(&pids)
-}
-
-fn measure_global() -> Result<GlobalSnapshot> {
-    trace!("Reading global procfs counters.");
-    read_global()
+/// Computes used memory as `MemTotal - MemAvailable`.
+///
+/// If `MemAvailable` is present in `/proc/meminfo`, it is used directly (preferred).
+/// Otherwise, falls back to `MemTotal - (MemFree + Cached)`, which is less accurate
+/// but universally available.
+///
+/// Note: min/max are inverted relative to `available` since higher availability
+/// means lower usage.
+fn compute_mem_used(
+    mem_total: u64,
+    mem_available: Option<MinMax>,
+    mem_free: MinMax,
+    cached: MinMax,
+) -> MinMax {
+    if let Some(available) = mem_available {
+        MinMax(
+            mem_total.saturating_sub(available.max()),
+            mem_total.saturating_sub(available.min()),
+        )
+    } else {
+        MinMax(
+            mem_total.saturating_sub(mem_free.max() + cached.max()),
+            mem_total.saturating_sub(mem_free.min() + cached.min()),
+        )
+    }
 }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -17,7 +17,10 @@ use crate::counters::{Counters, IoCounters, MemoryCounters};
 
 pub mod counters;
 
-const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {prefix: UnitPrefix::None, unit: Unit::Byte};
+const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {
+    prefix: UnitPrefix::None,
+    unit: Unit::Byte,
+};
 
 #[derive(Error, Debug)]
 pub enum ProcfsError {
@@ -157,7 +160,7 @@ impl MetricReader for Procfs {
 
     async fn measure(&mut self) -> Result<()> {
         let process = self.process.as_ref().ok_or(ProcfsError::NotInitialized)?;
-        
+
         match read_io(process) {
             Ok((read_bytes, write_bytes)) => {
                 self.io_counters.end_read_bytes = read_bytes;
@@ -184,7 +187,10 @@ impl MetricReader for Procfs {
         let memory_counters = lock.clone();
         lock.reset_phase();
 
-        let counters = Counters { memory_counters, io_counters: self.io_counters };
+        let counters = Counters {
+            memory_counters,
+            io_counters: self.io_counters,
+        };
 
         self.io_counters.begin_read_bytes = self.io_counters.end_read_bytes;
         self.io_counters.begin_write_bytes = self.io_counters.end_write_bytes;
@@ -194,15 +200,15 @@ impl MetricReader for Procfs {
 
     fn get_sensors(&self) -> Result<Sensors> {
         Ok([
-            "vm_size",
+            "vm_size_min",
             "vm_size_max",
-            "rss",
+            "rss_min",
             "rss_max",
-            "pss",
+            "pss_min",
             "pss_max",
-            "shared",
+            "shared_min",
             "shared_max",
-            "anon",
+            "anon_min",
             "anon_max",
         ]
         .into_iter()
@@ -215,85 +221,56 @@ impl MetricReader for Procfs {
 
         let memory_counters = counters.memory_counters;
 
-        let (conv, conv_delta): (fn(u64) -> MetricValue, fn(i64) -> MetricValue) =
-            match self.memory_unit {
-                MemoryUnit::Bytes => (
-                    |b| MetricValue::UnsignedInteger(b),
-                    |s| MetricValue::SignedInteger(s),
-                ),
-                MemoryUnit::Kilo => (
-                    |b| MetricValue::UnsignedInteger(b / 1024),
-                    |s| MetricValue::SignedInteger(s / 1024),
-                ),
-                MemoryUnit::Mega => (
-                    |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0), Some(2)),
-                    |s| MetricValue::Float(s as f64 / (1024.0 * 1024.0), Some(2)),
-                ),
-                MemoryUnit::Giga => (
-                    |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0 * 1024.0), Some(2)),
-                    |s| MetricValue::Float(s as f64 / (1024.0 * 1024.0 * 1024.0), Some(2)),
-                ),
-            };
+        let conv: fn(u64) -> MetricValue = match self.memory_unit {
+            MemoryUnit::Bytes => |b| MetricValue::UnsignedInteger(b),
+            MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1024),
+            MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0), Some(2)),
+            MemoryUnit::Giga => {
+                |b| MetricValue::Float(b as f64 / (1024.0 * 1024.0 * 1024.0), Some(2))
+            }
+        };
 
         let memory_metrics: Metrics = [
-            ("vm_size", conv(memory_counters.vm_size)),
+            ("vm_size_min", conv(memory_counters.min_vm_size)),
             ("vm_size_max", conv(memory_counters.max_vm_size)),
-            ("rss", conv(memory_counters.rss)),
+            ("rss_min", conv(memory_counters.min_rss)),
             ("rss_max", conv(memory_counters.max_rss)),
-            ("pss", conv(memory_counters.pss)),
+            ("pss_min", conv(memory_counters.min_pss)),
             ("pss_max", conv(memory_counters.max_pss)),
-            ("shared", conv(memory_counters.shared)),
+            ("shared_min", conv(memory_counters.min_shared)),
             ("shared_max", conv(memory_counters.max_shared)),
-            ("anon", conv(memory_counters.anon)),
+            ("anon_min", conv(memory_counters.min_anon)),
             ("anon_max", conv(memory_counters.max_anon)),
         ]
         .into_iter()
         .map(|(name, value)| Metric::new(name, value, memory_unit, Self::get_name()))
         .collect();
 
-        let memory_deltas: Metrics = [
-            (
-                "vm_size_delta",
-                conv_delta(MemoryCounters::delta(memory_counters.vm_size, memory_counters.phase_start_vm_size)),
-            ),
-            (
-                "rss_delta",
-                conv_delta(MemoryCounters::delta(memory_counters.rss, memory_counters.phase_start_rss)),
-            ),
-            (
-                "pss_delta",
-                conv_delta(MemoryCounters::delta(memory_counters.pss, memory_counters.phase_start_pss)),
-            ),
-            (
-                "shared_delta",
-                conv_delta(MemoryCounters::delta(memory_counters.shared, memory_counters.phase_start_shared)),
-            ),
-            (
-                "anon_delta",
-                conv_delta(MemoryCounters::delta(memory_counters.anon, memory_counters.phase_start_anon)),
-            ),
-        ]
-        .into_iter()
-        .map(|(name, value)| Metric::new(name, value, memory_unit, Self::get_name()))
-        .collect();
-
         let io_counters = counters.io_counters;
-        let read_bytes =
-    io_counters
-        .end_read_bytes
-        .saturating_sub(io_counters.begin_read_bytes);
+        let read_bytes = io_counters
+            .end_read_bytes
+            .saturating_sub(io_counters.begin_read_bytes);
 
-        let write_bytes =
-    io_counters
-        .end_write_bytes
-        .saturating_sub(io_counters.begin_write_bytes);
+        let write_bytes = io_counters
+            .end_write_bytes
+            .saturating_sub(io_counters.begin_write_bytes);
 
         let io_metrics = vec![
-            Metric::new("read_bytes", read_bytes, IO_COUNTERS_METRIC_UNIT, Self::get_name()),
-            Metric::new("write_bytes", write_bytes, IO_COUNTERS_METRIC_UNIT, Self::get_name()),
+            Metric::new(
+                "io_read_bytes",
+                read_bytes,
+                IO_COUNTERS_METRIC_UNIT,
+                Self::get_name(),
+            ),
+            Metric::new(
+                "io_write_bytes",
+                write_bytes,
+                IO_COUNTERS_METRIC_UNIT,
+                Self::get_name(),
+            ),
         ];
 
-        Ok(memory_metrics.into_iter().chain(memory_deltas).chain(io_metrics).collect())
+        Ok(memory_metrics.into_iter().chain(io_metrics).collect())
     }
 
     fn get_name() -> &'static str {

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -12,10 +12,11 @@ use joule_profiler_core::{
 };
 use log::{debug, trace};
 use procfs::{Current, FromRead, Meminfo};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     config::ProcfsConfig,
@@ -37,6 +38,7 @@ const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {
 };
 
 type Result<T> = std::result::Result<T, ProcfsError>;
+type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 
 /// Procfs-based metric source.
 ///
@@ -68,8 +70,8 @@ pub struct Procfs {
     /// Current metrics counters.
     counters: Arc<Mutex<Counters>>,
 
-    /// The handle to the polling task.
-    handle: Option<JoinHandle<Result<()>>>,
+    /// The handle to the polling task and it's cancellation token.
+    handle: Option<WorkerHandle>,
 
     /// Total physical memory in bytes, read once at construction from `/proc/meminfo`.
     mem_total: u64,
@@ -88,6 +90,45 @@ impl Procfs {
             ..Default::default()
         })
     }
+
+    fn spawn_worker(
+        pid: i32,
+        counters: Arc<Mutex<Counters>>,
+        poll_interval: Duration,
+    ) -> Result<WorkerHandle> {
+        let mut ticker = Interval::new_interval(poll_interval)?;
+        let cancellation_token = CancellationToken::new();
+        let cancellation_token_clone = cancellation_token.clone();
+
+        let handle = tokio::spawn(async move {
+            debug!("Starting procfs polling.");
+
+            loop {
+                tokio::select! {
+                    _ = ticker.next() => {
+                        trace!("Polled procfs source.");
+
+                        let proc = match measure_proc(pid) {
+                            Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => {
+                                Ok(ProcSnapshot::default())
+                            }
+                            r => r,
+                        }?;
+
+                        let global = measure_global()?;
+                        let mut counters = counters.lock().await;
+                        counters.update(&proc, &global);
+                    }
+                    () = cancellation_token.cancelled() => {
+                        debug!("Cgroup worker stopped.");
+                        break;
+                    }
+                }
+            }
+            Ok(())
+        });
+        Ok((cancellation_token_clone, handle))
+    }
 }
 
 impl MetricReader for Procfs {
@@ -98,50 +139,20 @@ impl MetricReader for Procfs {
     async fn init(&mut self, pid: i32) -> Result<()> {
         self.pid = pid;
 
-        let Some(interval) = self.config.poll_interval else {
-            return Ok(());
-        };
+        if let Some(poll_interval) = self.config.poll_interval {
+            let counters = self.counters.clone();
+            let handle = Self::spawn_worker(pid, counters, poll_interval)?;
+            self.handle = Some(handle);
+        }
 
-        let counters = self.counters.clone();
-
-        let handle = tokio::spawn(async move {
-            debug!("Starting procfs polling.");
-            let mut ticker = Interval::new_interval(interval)?;
-
-            loop {
-                ticker.next().await;
-                trace!("procfs source poll.");
-
-                let proc = match measure_proc(pid) {
-                    Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => {
-                        Ok(ProcSnapshot::default())
-                    }
-                    r => r,
-                }?;
-
-                let global = measure_global()?;
-
-                let mut counters = counters.lock().await;
-                counters.update(&proc, &global);
-            }
-        });
-
-        self.handle = Some(handle);
         Ok(())
     }
 
     /// Aborts the background poller if still running, or propagates its error if it already finished.
     async fn join(&mut self) -> Result<()> {
-        if let Some(handle) = self.handle.take() {
-            if handle.is_finished() {
-                trace!("Joining polling task.");
-                if let Ok(res) = handle.await {
-                    return res;
-                }
-            } else {
-                trace!("Aborting polling task.");
-                handle.abort();
-            }
+        if let Some((cancellation_token, handle)) = self.handle.take() {
+            cancellation_token.cancel();
+            handle.await??;
         }
         Ok(())
     }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -13,7 +13,6 @@ use joule_profiler_core::{
 use log::{debug, trace};
 use procfs::{Current, FromRead, Meminfo};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
@@ -23,7 +22,7 @@ use crate::{
     counters::{Counters, MinMax},
     error::ProcfsError,
     snapshot::{ProcSnapshot, measure_global, measure_proc},
-    utils::{MemoryUnit, make_conversion},
+    utils::make_conversion,
 };
 
 pub mod config;
@@ -56,27 +55,21 @@ type Result<T> = std::result::Result<T, ProcfsError>;
 /// ```no_run
 /// use joule_profiler_source_procfs::{Procfs, config::ProcfsConfig};
 ///
-/// let source = Procfs::new(&ProcfsConfig::default()).unwrap();
+/// let source = Procfs::new(ProcfsConfig::default()).unwrap();
 /// ```
 #[derive(Debug, Default)]
 pub struct Procfs {
+    /// procfs source configuration.
+    config: ProcfsConfig,
+
     /// pid of the profiled process, initialized at -1.
     pid: i32,
-
-    /// The polling interval of the source if set, else no polling.
-    poll_interval: Option<Duration>,
 
     /// Current metrics counters.
     counters: Arc<Mutex<Counters>>,
 
     /// The handle to the polling task.
     handle: Option<JoinHandle<Result<()>>>,
-
-    /// The unit in which to convert proc memory metrics.
-    proc_memory_unit: MemoryUnit,
-
-    /// The unit in which to convert global memory metrics.
-    global_memory_unit: MemoryUnit,
 
     /// Total physical memory in bytes, read once at construction from `/proc/meminfo`.
     mem_total: u64,
@@ -86,14 +79,12 @@ impl Procfs {
     /// Creates a new `Procfs` source from the given configuration.
     ///
     /// Reads `MemTotal` from `/proc/meminfo` at construction time.
-    pub fn new(config: &ProcfsConfig) -> Result<Self> {
+    pub fn new(config: ProcfsConfig) -> Result<Self> {
         let mem_total = Meminfo::from_file(Meminfo::PATH)?.mem_total;
         Ok(Self {
+            config,
             pid: -1,
             mem_total,
-            poll_interval: config.poll_interval,
-            global_memory_unit: config.global_memory_unit,
-            proc_memory_unit: config.proc_memory_unit,
             ..Default::default()
         })
     }
@@ -107,7 +98,7 @@ impl MetricReader for Procfs {
     async fn init(&mut self, pid: i32) -> Result<()> {
         self.pid = pid;
 
-        let Some(interval) = self.poll_interval else {
+        let Some(interval) = self.config.poll_interval else {
             return Ok(());
         };
 
@@ -181,8 +172,8 @@ impl MetricReader for Procfs {
     }
 
     fn get_sensors(&self) -> Result<Sensors> {
-        let proc_memory_unit: MetricUnit = self.proc_memory_unit.into();
-        let global_memory_unit: MetricUnit = self.global_memory_unit.into();
+        let proc_memory_unit: MetricUnit = self.config.proc_memory_unit.into();
+        let global_memory_unit: MetricUnit = self.config.global_memory_unit.into();
 
         let proc_sensors = [
             "proc_vm_size_min",
@@ -232,8 +223,8 @@ impl MetricReader for Procfs {
     }
 
     fn to_metrics(&self, mut counters: Self::Type) -> Result<Metrics> {
-        let proc_unit: MetricUnit = self.proc_memory_unit.into();
-        let global_unit: MetricUnit = self.global_memory_unit.into();
+        let proc_unit: MetricUnit = self.config.proc_memory_unit.into();
+        let global_unit: MetricUnit = self.config.global_memory_unit.into();
 
         counters.remove_sentinels();
         let proc = counters.proc;
@@ -252,7 +243,7 @@ impl MetricReader for Procfs {
         ]
         .into_iter()
         .map(|(name, value)| {
-            let value = make_conversion(self.proc_memory_unit, value);
+            let value = make_conversion(self.config.proc_memory_unit, value);
             Metric::new(name, value, proc_unit, Self::get_name())
         })
         .collect();
@@ -279,30 +270,32 @@ impl MetricReader for Procfs {
             global.cached,
         );
 
+        let global_memory_unit = self.config.global_memory_unit;
+
         let mut global_memory_metrics: Metrics = [
             (
                 "global_mem_used_min",
-                make_conversion(self.global_memory_unit, mem_used.min()),
+                make_conversion(global_memory_unit, mem_used.min()),
             ),
             (
                 "global_mem_used_max",
-                make_conversion(self.global_memory_unit, mem_used.max()),
+                make_conversion(global_memory_unit, mem_used.max()),
             ),
             (
                 "global_cached_min",
-                make_conversion(self.global_memory_unit, global.cached.min()),
+                make_conversion(global_memory_unit, global.cached.min()),
             ),
             (
                 "global_cached_max",
-                make_conversion(self.global_memory_unit, global.cached.max()),
+                make_conversion(global_memory_unit, global.cached.max()),
             ),
             (
                 "global_swap_free_min",
-                make_conversion(self.global_memory_unit, global.swap_free.min()),
+                make_conversion(global_memory_unit, global.swap_free.min()),
             ),
             (
                 "global_swap_free_max",
-                make_conversion(self.global_memory_unit, global.swap_free.max()),
+                make_conversion(global_memory_unit, global.swap_free.max()),
             ),
         ]
         .into_iter()
@@ -313,7 +306,7 @@ impl MetricReader for Procfs {
             let anon: Vec<_> = [("global_anon_max", anon.0), ("global_anon_min", anon.1)]
                 .into_iter()
                 .map(|(name, value)| {
-                    let value = make_conversion(self.global_memory_unit, value);
+                    let value = make_conversion(global_memory_unit, value);
                     Metric::new(name, value, global_unit, Self::get_name())
                 })
                 .collect();

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -92,13 +92,11 @@ impl Procfs {
     ///
     /// Reads `MemTotal` from `/proc/meminfo` at construction time.
     pub fn new(config: ProcfsConfig) -> Result<Self> {
-        let backend = ProcfsBackend;
-        let mem_total = backend.mem_total()?;
         Ok(Self {
             config,
             pid: -1,
-            mem_total,
-            backend: Arc::new(backend),
+            mem_total: 0,
+            backend: Arc::new(ProcfsBackend),
             counters: Arc::default(),
             detected_processes: Arc::default(),
             polling_task_handle: None,
@@ -213,6 +211,7 @@ impl<B: Backend> MetricReader for Procfs<B> {
     /// Initializes the source to `pid` and starts the background poller if a `poll_interval` is configured.
     async fn init(&mut self, pid: i32) -> Result<()> {
         self.pid = pid;
+        self.mem_total = self.backend.mem_total()?;
         *self.detected_processes.lock().await = self.backend.collect_children(pid);
 
         if let Some(detection_poll_interval) = self.config.process_detection_poll_interval {
@@ -428,5 +427,276 @@ impl<B: Backend> MetricReader for Procfs<B> {
 
     fn get_name() -> &'static str {
         "procfs"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Duration};
+
+    use joule_profiler_core::source::MetricReader;
+    use tokio::time::sleep;
+
+    use crate::{
+        Procfs, backend::MockBackend, config::ProcfsConfig, error::ProcfsError,
+        snapshot::GlobalSnapshot,
+    };
+
+    fn create_source(backend: MockBackend) -> Procfs<MockBackend> {
+        let source = Procfs {
+            backend: Arc::new(backend),
+            pid: 1,
+            config: ProcfsConfig::default(),
+            mem_total: 0,
+            counters: Arc::default(),
+            detected_processes: Arc::default(),
+            polling_task_handle: None,
+            process_discovery_task_handle: None,
+        };
+        source
+    }
+
+    #[tokio::test]
+    async fn test_init_function_initializes_field_correctly() {
+        let mem_total = 4096;
+        let pid = 1;
+        let children: HashSet<_> = vec![pid, 2].into_iter().collect();
+
+        let mut backend = MockBackend::new();
+
+        backend
+            .expect_collect_children()
+            .returning(move |_| vec![pid, 2].into_iter().collect());
+
+        backend
+            .expect_mem_total()
+            .once()
+            .returning(move || Ok(mem_total));
+
+        let mut source = create_source(backend);
+
+        source.init(pid).await.unwrap();
+
+        assert_eq!(source.mem_total, mem_total);
+        assert!(source.detected_processes.lock().await.eq(&children));
+        assert_eq!(source.pid, pid);
+    }
+
+    #[tokio::test]
+    async fn test_process_detection_polling_updates_processes_list() {
+        let children: HashSet<_> = vec![1, 2, 3, 4].into_iter().collect();
+
+        let mut backend = MockBackend::new();
+        backend
+            .expect_collect_children()
+            .once()
+            .returning(|_| HashSet::new());
+
+        backend
+            .expect_collect_children()
+            .returning(|_| vec![1, 2, 3, 4].into_iter().collect());
+
+        backend.expect_mem_total().once().returning(|| Ok(0));
+        let mut source = create_source(backend);
+        source.config.process_detection_poll_interval = Some(Duration::from_millis(1));
+        assert!(source.detected_processes.lock().await.eq(&HashSet::new()));
+
+        source.init(1).await.unwrap();
+
+        sleep(Duration::from_millis(5)).await;
+
+        assert!(source.detected_processes.lock().await.eq(&children));
+    }
+
+    #[tokio::test]
+    async fn test_polling_task_updates_counters() {
+        let mut backend = MockBackend::new();
+        backend
+            .expect_collect_children()
+            .returning(|_| vec![1].into_iter().collect());
+
+        backend.expect_measure_global().once().returning(|| {
+            Ok(GlobalSnapshot {
+                anon: Some(100),
+                cached: 200,
+                mem_available: Some(300),
+                mem_free: 400,
+                swap_free: 500,
+            })
+        });
+
+        backend.expect_read_proc().returning(|_, _| Ok(()));
+
+        backend.expect_measure_global().once().returning(|| {
+            Ok(GlobalSnapshot {
+                anon: Some(200),
+                cached: 400,
+                mem_available: Some(600),
+                mem_free: 800,
+                swap_free: 1000,
+            })
+        });
+
+        backend.expect_mem_total().once().returning(|| Ok(0));
+
+        let mut source = create_source(backend);
+        let global_counters = source.counters.lock().await.global;
+        assert!(global_counters.anon.is_none());
+        assert!(global_counters.cached.min().is_none());
+        assert!(global_counters.cached.max().is_none());
+        assert!(global_counters.mem_available.is_none());
+        assert!(global_counters.mem_free.min().is_none());
+        assert!(global_counters.mem_free.max().is_none());
+        assert!(global_counters.swap_free.min().is_none());
+        assert!(global_counters.swap_free.max().is_none());
+
+        source.config.poll_interval = Some(Duration::from_millis(10));
+        source.init(1).await.unwrap();
+
+        sleep(Duration::from_millis(20)).await;
+
+        let global_counters = source.counters.lock().await.global;
+
+        assert_eq!(global_counters.anon.unwrap().min(), Some(100));
+        assert_eq!(global_counters.anon.unwrap().max(), Some(200));
+        assert_eq!(global_counters.cached.min(), Some(200));
+        assert_eq!(global_counters.cached.max(), Some(400));
+        assert_eq!(global_counters.mem_available.unwrap().min(), Some(300));
+        assert_eq!(global_counters.mem_available.unwrap().max(), Some(600));
+        assert_eq!(global_counters.mem_free.min(), Some(400));
+        assert_eq!(global_counters.mem_free.max(), Some(800));
+        assert_eq!(global_counters.swap_free.min(), Some(500));
+        assert_eq!(global_counters.swap_free.max(), Some(1000));
+    }
+
+    #[tokio::test]
+    async fn test_measure_updates_counters_once() {
+        let mut backend = MockBackend::new();
+
+        backend
+            .expect_collect_children()
+            .returning(|_| vec![1].into_iter().collect());
+
+        backend.expect_read_proc().returning(|_, _| Ok(()));
+
+        backend.expect_measure_global().returning(|| {
+            Ok(GlobalSnapshot {
+                anon: Some(100),
+                cached: 200,
+                mem_available: Some(300),
+                mem_free: 400,
+                swap_free: 500,
+            })
+        });
+
+        backend.expect_mem_total().once().returning(|| Ok(1000));
+
+        let mut source = create_source(backend);
+
+        source.init(1).await.unwrap();
+        source.measure().await.unwrap();
+
+        let counters = source.counters.lock().await;
+
+        assert_eq!(counters.global.cached.max(), Some(200));
+        assert_eq!(counters.global.cached.max(), Some(200));
+        assert_eq!(counters.global.mem_available.unwrap().max(), Some(300));
+        assert_eq!(counters.global.mem_free.max(), Some(400));
+        assert_eq!(counters.global.swap_free.max(), Some(500));
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_resets_counters() {
+        let mut backend = MockBackend::new();
+
+        backend
+            .expect_collect_children()
+            .returning(|_| vec![1].into_iter().collect());
+
+        backend.expect_read_proc().returning(|_, _| Ok(()));
+
+        backend.expect_measure_global().returning(|| {
+            Ok(GlobalSnapshot {
+                anon: Some(10),
+                cached: 20,
+                mem_available: Some(30),
+                mem_free: 40,
+                swap_free: 50,
+            })
+        });
+
+        backend.expect_mem_total().once().returning(|| Ok(1000));
+
+        let mut source = create_source(backend);
+        source.init(1).await.unwrap();
+
+        source.measure().await.unwrap();
+
+        let first = source.retrieve().await.unwrap();
+        let second = source.retrieve().await.unwrap();
+
+        assert!(first.global.cached.max().is_some());
+        assert!(second.global.cached.max().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_dead_pid_removed_from_detected_processes() {
+        use procfs::ProcError;
+
+        let mut backend = MockBackend::new();
+
+        backend
+            .expect_collect_children()
+            .returning(|_| vec![1, 2].into_iter().collect());
+
+        backend.expect_read_proc().returning(|pid, _| {
+            if pid == 2 {
+                Err(ProcfsError::Procfs(ProcError::NotFound(Some(
+                    PathBuf::new(),
+                ))))
+            } else {
+                Ok(())
+            }
+        });
+
+        backend
+            .expect_measure_global()
+            .returning(|| Ok(GlobalSnapshot::default()));
+
+        backend.expect_mem_total().once().returning(|| Ok(1000));
+
+        let mut source = create_source(backend);
+        source.init(1).await.unwrap();
+
+        source.measure().await.unwrap();
+
+        let processes = source.detected_processes.lock().await;
+
+        assert!(processes.contains(&1));
+        assert!(!processes.contains(&2));
+    }
+
+    #[tokio::test]
+    async fn test_join_stops_polling_task() {
+        let mut backend = MockBackend::new();
+
+        backend
+            .expect_collect_children()
+            .returning(|_| vec![1].into_iter().collect());
+
+        backend.expect_mem_total().once().returning(|| Ok(0));
+
+        backend.expect_read_proc().returning(|_, _| Ok(()));
+
+        backend
+            .expect_measure_global()
+            .returning(|| Ok(GlobalSnapshot::default()));
+
+        let mut source = create_source(backend);
+        source.config.poll_interval = Some(Duration::from_millis(5));
+        source.init(1).await.unwrap();
+        sleep(Duration::from_millis(15)).await;
+
+        source.join().await.unwrap();
     }
 }

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -38,6 +38,8 @@ const IO_COUNTERS_METRIC_UNIT: MetricUnit = MetricUnit {
     unit: Unit::Byte,
 };
 
+const PROCFS_SOURCE_NAME: &str = "procfs";
+
 type Result<T> = std::result::Result<T, ProcfsError>;
 type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 
@@ -210,6 +212,7 @@ impl<B: Backend> MetricReader for Procfs<B> {
 
     /// Initializes the source to `pid` and starts the background poller if a `poll_interval` is configured.
     async fn init(&mut self, pid: i32) -> Result<()> {
+        debug!("Initializing procfs source.");
         self.pid = pid;
         self.mem_total = self.backend.mem_total()?;
         *self.detected_processes.lock().await = self.backend.collect_children(pid);
@@ -241,6 +244,7 @@ impl<B: Backend> MetricReader for Procfs<B> {
 
     /// Aborts the background poller if still running, or propagates its error if it already finished.
     async fn join(&mut self) -> Result<()> {
+        debug!("Joining procfs source.");
         if let Some((cancellation_token, handle)) = self.polling_task_handle.take() {
             cancellation_token.cancel();
             handle.await??;
@@ -426,7 +430,7 @@ impl<B: Backend> MetricReader for Procfs<B> {
     }
 
     fn get_name() -> &'static str {
-        "procfs"
+        PROCFS_SOURCE_NAME
     }
 }
 

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -11,21 +11,22 @@ use joule_profiler_core::{
     unit::{MetricUnit, Unit, UnitPrefix},
 };
 use log::{debug, trace};
-use procfs::{Current, FromRead, Meminfo};
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_timerfd::Interval;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    backend::{Backend, ProcfsBackend},
     config::ProcfsConfig,
     counters::{Counters, compute_mem_used},
     error::ProcfsError,
-    snapshot::{ProcSnapshot, measure_global, measure_proc},
+    snapshot::ProcSnapshot,
     utils::make_conversion,
 };
 
+mod backend;
 pub mod config;
 pub mod counters;
 pub mod error;
@@ -59,10 +60,13 @@ type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 ///
 /// let source = Procfs::new(ProcfsConfig::default()).unwrap();
 /// ```
-#[derive(Debug, Default)]
-pub struct Procfs {
+#[derive(Debug)]
+pub struct Procfs<B: Backend = ProcfsBackend> {
     /// procfs source configuration.
     config: ProcfsConfig,
+
+    /// The backend used to interract with procfs. Used for testing.
+    backend: Arc<B>,
 
     /// pid of the profiled process, initialized at -1.
     pid: i32,
@@ -71,10 +75,16 @@ pub struct Procfs {
     counters: Arc<Mutex<Counters>>,
 
     /// The handle to the polling task and it's cancellation token.
-    handle: Option<WorkerHandle>,
+    polling_task_handle: Option<WorkerHandle>,
+
+    /// The handle to the polling task and it's cancellation token.
+    process_discovery_task_handle: Option<WorkerHandle>,
 
     /// Total physical memory in bytes, read once at construction from `/proc/meminfo`.
     mem_total: u64,
+
+    /// The current processes to be measured, updated at each poll from the process discovery task.
+    detected_processes: Arc<Mutex<HashSet<i32>>>,
 }
 
 impl Procfs {
@@ -82,18 +92,26 @@ impl Procfs {
     ///
     /// Reads `MemTotal` from `/proc/meminfo` at construction time.
     pub fn new(config: ProcfsConfig) -> Result<Self> {
-        let mem_total = Meminfo::from_file(Meminfo::PATH)?.mem_total;
+        let backend = ProcfsBackend;
+        let mem_total = backend.mem_total()?;
         Ok(Self {
             config,
             pid: -1,
             mem_total,
-            ..Default::default()
+            backend: Arc::new(backend),
+            counters: Arc::default(),
+            detected_processes: Arc::default(),
+            polling_task_handle: None,
+            process_discovery_task_handle: None,
         })
     }
+}
 
-    fn spawn_worker(
-        pid: i32,
+impl<B: Backend> Procfs<B> {
+    fn spawn_polling_worker(
+        backend: Arc<B>,
         counters: Arc<Mutex<Counters>>,
+        detected_processes: Arc<Mutex<HashSet<i32>>>,
         poll_interval: Duration,
     ) -> Result<WorkerHandle> {
         let mut ticker = Interval::new_interval(poll_interval)?;
@@ -107,20 +125,10 @@ impl Procfs {
                 tokio::select! {
                     _ = ticker.next() => {
                         trace!("Polled procfs source.");
-
-                        let proc = match measure_proc(pid) {
-                            Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => {
-                                Ok(ProcSnapshot::default())
-                            }
-                            r => r,
-                        }?;
-
-                        let global = measure_global()?;
-                        let mut counters = counters.lock().await;
-                        counters.update(&proc, &global);
+                        Self::measure_and_update_pids(&backend, &counters, &detected_processes).await?;
                     }
                     () = cancellation_token.cancelled() => {
-                        debug!("Cgroup worker stopped.");
+                        debug!("procfs worker stopped.");
                         break;
                     }
                 }
@@ -129,20 +137,104 @@ impl Procfs {
         });
         Ok((cancellation_token_clone, handle))
     }
+
+    fn spawn_process_discovery_worker(
+        backend: Arc<B>,
+        pid: i32,
+        detected_processes: Arc<Mutex<HashSet<i32>>>,
+        poll_interval: Duration,
+    ) -> Result<WorkerHandle> {
+        let mut ticker = Interval::new_interval(poll_interval)?;
+        let cancellation_token = CancellationToken::new();
+        let cancellation_token_clone = cancellation_token.clone();
+
+        let handle = tokio::spawn(async move {
+            debug!("Starting procfs process discovery worker.");
+
+            loop {
+                tokio::select! {
+                    _ = ticker.next() => {
+                        trace!("Polled procfs discovery task.");
+                        *detected_processes.lock().await = backend.collect_children(pid);
+                    }
+                    () = cancellation_token.cancelled() => {
+                        debug!("procfs process discovery worker stopped.");
+                        break;
+                    }
+                }
+            }
+            Ok(())
+        });
+        Ok((cancellation_token_clone, handle))
+    }
+
+    async fn measure_and_update_pids(
+        backend: &B,
+        counters: &Arc<Mutex<Counters>>,
+        detected_processes: &Arc<Mutex<HashSet<i32>>>,
+    ) -> Result<()> {
+        let mut present_pids = HashSet::new();
+        let pids = detected_processes.lock().await.clone();
+        let mut snapshot = ProcSnapshot::default();
+        let mut pids_updated = false;
+
+        for pid in pids {
+            match backend.read_proc(pid, &mut snapshot) {
+                Ok(()) => {
+                    present_pids.insert(pid);
+                    Ok(())
+                }
+                Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => {
+                    trace!("PID {pid} not present, removing it from processes list.");
+                    pids_updated = true;
+                    Ok(())
+                }
+                r => r,
+            }?;
+        }
+
+        let global = backend.measure_global()?;
+        let mut counters = counters.lock().await;
+        counters.update(&snapshot, &global);
+
+        if pids_updated {
+            trace!("Updating processes list: {present_pids:?}");
+            *detected_processes.lock().await = present_pids;
+        }
+
+        Ok(())
+    }
 }
 
-impl MetricReader for Procfs {
+impl<B: Backend> MetricReader for Procfs<B> {
     type Type = Counters;
     type Error = ProcfsError;
 
     /// Initializes the source to `pid` and starts the background poller if a `poll_interval` is configured.
     async fn init(&mut self, pid: i32) -> Result<()> {
         self.pid = pid;
+        *self.detected_processes.lock().await = self.backend.collect_children(pid);
+
+        if let Some(detection_poll_interval) = self.config.process_detection_poll_interval {
+            let process_discovery_handle = Self::spawn_process_discovery_worker(
+                self.backend.clone(),
+                pid,
+                self.detected_processes.clone(),
+                detection_poll_interval,
+            )?;
+            self.process_discovery_task_handle = Some(process_discovery_handle);
+        }
 
         if let Some(poll_interval) = self.config.poll_interval {
             let counters = self.counters.clone();
-            let handle = Self::spawn_worker(pid, counters, poll_interval)?;
-            self.handle = Some(handle);
+
+            let handle = Self::spawn_polling_worker(
+                self.backend.clone(),
+                counters,
+                self.detected_processes.clone(),
+                poll_interval,
+            )?;
+            self.polling_task_handle = Some(handle);
         }
 
         Ok(())
@@ -150,7 +242,7 @@ impl MetricReader for Procfs {
 
     /// Aborts the background poller if still running, or propagates its error if it already finished.
     async fn join(&mut self) -> Result<()> {
-        if let Some((cancellation_token, handle)) = self.handle.take() {
+        if let Some((cancellation_token, handle)) = self.polling_task_handle.take() {
             cancellation_token.cancel();
             handle.await??;
         }
@@ -161,16 +253,8 @@ impl MetricReader for Procfs {
     ///
     /// If the process is not found, an empty snapshot is used.
     async fn measure(&mut self) -> Result<()> {
-        let proc = match measure_proc(self.pid) {
-            Err(ProcfsError::Procfs(procfs::ProcError::NotFound(_))) => Ok(ProcSnapshot::default()),
-            r => r,
-        }?;
-
-        let global = measure_global()?;
-
-        let mut counters = self.counters.lock().await;
-        counters.update(&proc, &global);
-
+        Self::measure_and_update_pids(&self.backend, &self.counters, &self.detected_processes)
+            .await?;
         Ok(())
     }
 

--- a/sources/procfs/src/lib.rs
+++ b/sources/procfs/src/lib.rs
@@ -70,9 +70,6 @@ pub struct Procfs<B: Backend = ProcfsBackend> {
     /// The backend used to interract with procfs. Used for testing.
     backend: Arc<B>,
 
-    /// pid of the profiled process, initialized at -1.
-    pid: i32,
-
     /// Current metrics counters.
     counters: Arc<Mutex<Counters>>,
 
@@ -96,7 +93,6 @@ impl Procfs {
     pub fn new(config: ProcfsConfig) -> Result<Self> {
         Ok(Self {
             config,
-            pid: -1,
             mem_total: 0,
             backend: Arc::new(ProcfsBackend),
             counters: Arc::default(),
@@ -213,7 +209,6 @@ impl<B: Backend> MetricReader for Procfs<B> {
     /// Initializes the source to `pid` and starts the background poller if a `poll_interval` is configured.
     async fn init(&mut self, pid: i32) -> Result<()> {
         debug!("Initializing procfs source.");
-        self.pid = pid;
         self.mem_total = self.backend.mem_total()?;
         *self.detected_processes.lock().await = self.backend.collect_children(pid);
 
@@ -449,7 +444,6 @@ mod tests {
     fn create_source(backend: MockBackend) -> Procfs<MockBackend> {
         let source = Procfs {
             backend: Arc::new(backend),
-            pid: 1,
             config: ProcfsConfig::default(),
             mem_total: 0,
             counters: Arc::default(),
@@ -483,7 +477,6 @@ mod tests {
 
         assert_eq!(source.mem_total, mem_total);
         assert!(source.detected_processes.lock().await.eq(&children));
-        assert_eq!(source.pid, pid);
     }
 
     #[tokio::test]

--- a/sources/procfs/src/snapshot.rs
+++ b/sources/procfs/src/snapshot.rs
@@ -1,68 +1,107 @@
 use log::trace;
 use procfs::{Current, FromRead, Meminfo, process::Process};
 
-use crate::Result;
+use crate::{Result, utils::collect_all_children};
 
+/// Snapshot of memory and I/O measurements for a process hierarchy.
+///
+/// All fields are summed across the process and all its descendants.
+/// Memory values are in bytes.
 #[derive(Default)]
 pub struct ProcSnapshot {
+    /// Virtual memory size, from `/proc/{pid}/stat`.
     pub vm_size: u64,
+
+    /// Resident set size.
     pub rss: u64,
+
+    /// Proportional set size (shared pages divided by the count of process using them).
     pub pss: u64,
+
+    /// Shared memory (clean + dirty).
     pub shared: u64,
+
+    /// Anonymous memory (not backed by a file).
     pub anon: u64,
 
+    /// Cumulative bytes read since process start.
     pub read_bytes: u64,
+
+    /// Cumulative bytes written since process start.
     pub write_bytes: u64,
 }
 
-pub fn read_proc(pids: &[i32]) -> Result<ProcSnapshot> {
-    let mut snapshot = ProcSnapshot::default();
+/// Reads memory and I/O stats for a single pid and adds them into `snapshot`.
+///
+/// Silently ignores `PermissionDenied` on I/O reads, which can happen
+/// if the process exits between the smaps and io reads.
+fn read_proc_pid(pid: i32, snapshot: &mut ProcSnapshot) -> Result<()> {
+    let process = Process::new(pid)?;
 
-    for pid in pids {
-        let process = Process::new(*pid)?;
-        trace!("Querying process {} stat.", process.pid);
-        let vm_size = process.stat()?.vsize;
-        snapshot.vm_size += vm_size;
+    trace!("Querying process {} stat.", process.pid);
+    snapshot.vm_size += process.stat()?.vsize;
 
-        trace!("Querying process {} smaps_rollup.", process.pid);
-        let smaps = process.smaps_rollup()?;
-        let map = if let Some(entry) = smaps.memory_map_rollup.0.first() {
-            &entry.extension.map
-        } else {
-            continue;
-        };
-
+    trace!("Querying process {} smaps_rollup.", process.pid);
+    let smaps = process.smaps_rollup()?;
+    if let Some(entry) = smaps.memory_map_rollup.0.first() {
+        let map = &entry.extension.map;
         snapshot.rss += map.get("Rss").copied().unwrap_or(0);
         snapshot.pss += map.get("Pss").copied().unwrap_or(0);
         snapshot.anon += map.get("Anonymous").copied().unwrap_or(0);
         snapshot.shared += map.get("Shared_Clean").copied().unwrap_or(0)
             + map.get("Shared_Dirty").copied().unwrap_or(0);
-
-        trace!("Querying process {} io.", process.pid);
-
-        // Match because procfs throws permission denied if process terminated.
-        match process.io() {
-            Ok(io) => {
-                snapshot.read_bytes += io.rchar;
-                snapshot.write_bytes += io.wchar;
-            }
-            Err(procfs::ProcError::PermissionDenied(_)) => {}
-            Err(err) => return Err(err.into()),
-        }
     }
 
+    trace!("Querying process {} io.", process.pid);
+    match process.io() {
+        Ok(io) => {
+            snapshot.read_bytes += io.rchar;
+            snapshot.write_bytes += io.wchar;
+        }
+        Err(procfs::ProcError::PermissionDenied(_)) => {}
+        Err(err) => return Err(err.into()),
+    }
+
+    Ok(())
+}
+
+pub fn measure_proc(pid: i32) -> Result<ProcSnapshot> {
+    trace!("Retrieving process hierarchy from pid {pid}.");
+    let pids = collect_all_children(pid);
+    trace!("Found pids {pids:?}. Reading process procfs counters.");
+
+    let mut snapshot = ProcSnapshot::default();
+    for pid in pids {
+        read_proc_pid(pid, &mut snapshot)?;
+    }
     Ok(snapshot)
 }
 
+/// Point-in-time system-wide memory statistics from `/proc/meminfo`.
+///
+/// All values are in bytes. Optional fields are absent when the kernel
+/// does not expose them (e.g. `MemAvailable` on old kernels, `AnonPages`
+/// on some minimal configurations).
 pub struct GlobalSnapshot {
+    /// Estimate of available memory.
+    /// Preferred over `mem_free + cached` for computing used memory.
     pub mem_available: Option<u64>,
+
+    /// Free memory, used if `mem_available` is not accessible.
     pub mem_free: u64,
+
+    /// Cached memory.
     pub cached: u64,
+
+    /// Anonymous pages (heap, stack, mmaps).
     pub anon: Option<u64>,
+
+    /// Free swap space.
     pub swap_free: u64,
 }
 
-pub fn read_global() -> Result<GlobalSnapshot> {
+/// Reads system-wide memory statistics from `/proc/meminfo`.
+pub fn measure_global() -> Result<GlobalSnapshot> {
     let meminfo = Meminfo::from_file(Meminfo::PATH)?;
     trace!("Querying global meminfo from {}", procfs::Meminfo::PATH);
 

--- a/sources/procfs/src/snapshot.rs
+++ b/sources/procfs/src/snapshot.rs
@@ -39,9 +39,16 @@ pub fn read_proc(pids: &[i32]) -> Result<ProcSnapshot> {
             + map.get("Shared_Dirty").copied().unwrap_or(0);
 
         trace!("Querying process {} io.", process.pid);
-        let io = process.io()?;
-        snapshot.read_bytes += io.rchar;
-        snapshot.write_bytes += io.wchar;
+
+        // Match because procfs throws permission denied if process terminated.
+        match process.io() {
+            Ok(io) => {
+                snapshot.read_bytes += io.rchar;
+                snapshot.write_bytes += io.wchar;
+            }
+            Err(procfs::ProcError::PermissionDenied(_)) => {}
+            Err(err) => return Err(err.into()),
+        }
     }
 
     Ok(snapshot)

--- a/sources/procfs/src/snapshot.rs
+++ b/sources/procfs/src/snapshot.rs
@@ -1,0 +1,69 @@
+use log::trace;
+use procfs::{Current, FromRead, Meminfo, process::Process};
+
+use crate::Result;
+
+#[derive(Default)]
+pub struct ProcSnapshot {
+    pub vm_size: u64,
+    pub rss: u64,
+    pub pss: u64,
+    pub shared: u64,
+    pub anon: u64,
+
+    pub read_bytes: u64,
+    pub write_bytes: u64,
+}
+
+pub fn read_proc(pids: &[i32]) -> Result<ProcSnapshot> {
+    let mut snapshot = ProcSnapshot::default();
+
+    for pid in pids {
+        let process = Process::new(*pid)?;
+        trace!("Querying process {} stat.", process.pid);
+        let vm_size = process.stat()?.vsize;
+        snapshot.vm_size += vm_size;
+
+        trace!("Querying process {} smaps_rollup.", process.pid);
+        let smaps = process.smaps_rollup()?;
+        let map = if let Some(entry) = smaps.memory_map_rollup.0.first() {
+            &entry.extension.map
+        } else {
+            continue;
+        };
+
+        snapshot.rss += map.get("Rss").copied().unwrap_or(0);
+        snapshot.pss += map.get("Pss").copied().unwrap_or(0);
+        snapshot.anon += map.get("Anonymous").copied().unwrap_or(0);
+        snapshot.shared += map.get("Shared_Clean").copied().unwrap_or(0)
+            + map.get("Shared_Dirty").copied().unwrap_or(0);
+
+        trace!("Querying process {} io.", process.pid);
+        let io = process.io()?;
+        snapshot.read_bytes += io.rchar;
+        snapshot.write_bytes += io.wchar;
+    }
+
+    Ok(snapshot)
+}
+
+pub struct GlobalSnapshot {
+    pub mem_available: Option<u64>,
+    pub mem_free: u64,
+    pub cached: u64,
+    pub anon: Option<u64>,
+    pub swap_free: u64,
+}
+
+pub fn read_global() -> Result<GlobalSnapshot> {
+    let meminfo = Meminfo::from_file(Meminfo::PATH)?;
+    trace!("Querying global meminfo from {}", procfs::Meminfo::PATH);
+
+    Ok(GlobalSnapshot {
+        mem_available: meminfo.mem_available,
+        mem_free: meminfo.mem_free,
+        cached: meminfo.cached,
+        anon: meminfo.anon_pages,
+        swap_free: meminfo.swap_free,
+    })
+}

--- a/sources/procfs/src/snapshot.rs
+++ b/sources/procfs/src/snapshot.rs
@@ -1,13 +1,8 @@
-use log::trace;
-use procfs::{Current, FromRead, Meminfo, process::Process};
-
-use crate::{Result, utils::collect_all_children};
-
 /// Snapshot of memory and I/O measurements for a process hierarchy.
 ///
 /// All fields are summed across the process and all its descendants.
 /// Memory values are in bytes.
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct ProcSnapshot {
     /// Virtual memory size, from `/proc/{pid}/stat`.
     pub vm_size: u64,
@@ -31,57 +26,12 @@ pub struct ProcSnapshot {
     pub write_bytes: u64,
 }
 
-/// Reads memory and I/O stats for a single pid and adds them into `snapshot`.
-///
-/// Silently ignores `PermissionDenied` on I/O reads, which can happen
-/// if the process exits between the smaps and io reads.
-fn read_proc_pid(pid: i32, snapshot: &mut ProcSnapshot) -> Result<()> {
-    let process = Process::new(pid)?;
-
-    trace!("Querying process {} stat.", process.pid);
-    snapshot.vm_size += process.stat()?.vsize;
-
-    trace!("Querying process {} smaps_rollup.", process.pid);
-    let smaps = process.smaps_rollup()?;
-    if let Some(entry) = smaps.memory_map_rollup.0.first() {
-        let map = &entry.extension.map;
-        snapshot.rss += map.get("Rss").copied().unwrap_or(0);
-        snapshot.pss += map.get("Pss").copied().unwrap_or(0);
-        snapshot.anon += map.get("Anonymous").copied().unwrap_or(0);
-        snapshot.shared += map.get("Shared_Clean").copied().unwrap_or(0)
-            + map.get("Shared_Dirty").copied().unwrap_or(0);
-    }
-
-    trace!("Querying process {} io.", process.pid);
-    match process.io() {
-        Ok(io) => {
-            snapshot.read_bytes += io.rchar;
-            snapshot.write_bytes += io.wchar;
-        }
-        Err(procfs::ProcError::PermissionDenied(_)) => {}
-        Err(err) => return Err(err.into()),
-    }
-
-    Ok(())
-}
-
-pub fn measure_proc(pid: i32) -> Result<ProcSnapshot> {
-    trace!("Retrieving process hierarchy from pid {pid}.");
-    let pids = collect_all_children(pid);
-    trace!("Found pids {pids:?}. Reading process procfs counters.");
-
-    let mut snapshot = ProcSnapshot::default();
-    for pid in pids {
-        read_proc_pid(pid, &mut snapshot)?;
-    }
-    Ok(snapshot)
-}
-
 /// Point-in-time system-wide memory statistics from `/proc/meminfo`.
 ///
 /// All values are in bytes. Optional fields are absent when the kernel
 /// does not expose them (e.g. `MemAvailable` on old kernels, `AnonPages`
 /// on some minimal configurations).
+#[derive(Default, Clone, Copy)]
 pub struct GlobalSnapshot {
     /// Estimate of available memory.
     /// Preferred over `mem_free + cached` for computing used memory.
@@ -98,18 +48,4 @@ pub struct GlobalSnapshot {
 
     /// Free swap space.
     pub swap_free: u64,
-}
-
-/// Reads system-wide memory statistics from `/proc/meminfo`.
-pub fn measure_global() -> Result<GlobalSnapshot> {
-    let meminfo = Meminfo::from_file(Meminfo::PATH)?;
-    trace!("Querying global meminfo from {}", procfs::Meminfo::PATH);
-
-    Ok(GlobalSnapshot {
-        mem_available: meminfo.mem_available,
-        mem_free: meminfo.mem_free,
-        cached: meminfo.cached,
-        anon: meminfo.anon_pages,
-        swap_free: meminfo.swap_free,
-    })
 }

--- a/sources/procfs/src/utils.rs
+++ b/sources/procfs/src/utils.rs
@@ -22,13 +22,12 @@ fn read_task_children(pid: i32) -> Vec<i32> {
         .filter(|&child_pid| {
             Process::new(child_pid)
                 .and_then(|p| p.status())
-                .map(|s| s.pid == s.tgid)
-                .unwrap_or(false)
+                .is_ok_and(|s| s.pid == s.tgid)
         })
         .collect()
 }
 
-pub fn collect_all_children(root_pid: i32) -> Result<Vec<i32>, std::io::Error> {
+pub fn collect_all_children(root_pid: i32) -> Vec<i32> {
     let mut pids: Vec<i32> = vec![root_pid];
     let mut queue: VecDeque<i32> = VecDeque::from([root_pid]);
 
@@ -40,6 +39,5 @@ pub fn collect_all_children(root_pid: i32) -> Result<Vec<i32>, std::io::Error> {
             }
         }
     }
-
-    Ok(pids)
+    pids
 }

--- a/sources/procfs/src/utils.rs
+++ b/sources/procfs/src/utils.rs
@@ -1,4 +1,7 @@
-use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
+use joule_profiler_core::{
+    types::MetricValue,
+    unit::{MetricUnit, Unit, UnitPrefix},
+};
 use procfs::process::Process;
 use std::collections::VecDeque;
 
@@ -73,4 +76,14 @@ impl From<MemoryUnit> for MetricUnit {
             },
         }
     }
+}
+
+pub fn make_conversion(unit: MemoryUnit, value: u64) -> MetricValue {
+    #[allow(clippy::cast_precision_loss)]
+    (match unit {
+        MemoryUnit::Bytes => |b| MetricValue::UnsignedInteger(b),
+        MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1_024),
+        MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / 1_048_576.0, Some(2)),
+        MemoryUnit::Giga => |b| MetricValue::Float(b as f64 / 1_073_741_824.0, Some(2)),
+    })(value)
 }

--- a/sources/procfs/src/utils.rs
+++ b/sources/procfs/src/utils.rs
@@ -5,7 +5,11 @@ use joule_profiler_core::{
 use procfs::process::Process;
 use std::collections::VecDeque;
 
-fn read_task_children(pid: i32) -> Vec<i32> {
+/// Reads direct child of pid (threads excluded).
+///
+/// Reads `/proc/{pid}/task/{tid}/children` for each thread of the process,
+/// then filters out threads by keeping only processes.
+fn read_child_processes(pid: i32) -> Vec<i32> {
     let Ok(process) = Process::new(pid) else {
         return vec![];
     };
@@ -23,20 +27,28 @@ fn read_task_children(pid: i32) -> Vec<i32> {
                 .filter_map(|s| s.parse::<i32>().ok())
                 .collect::<Vec<_>>()
         })
-        .filter(|&child_pid| {
-            Process::new(child_pid)
-                .and_then(|p| p.status())
-                .is_ok_and(|s| s.pid == s.tgid)
-        })
+        .filter(|&child_pid| is_process(child_pid))
         .collect()
 }
 
+/// Returns `true` if `pid` is a process leader (not a thread).
+///
+/// A thread has `pid != tgid` in `/proc/{pid}/status`.
+/// The process leader has `pid == tgid`.
+fn is_process(pid: i32) -> bool {
+    Process::new(pid)
+        .and_then(|p| p.status())
+        .is_ok_and(|s| s.pid == s.tgid)
+}
+
+/// Collects `root_pid` and all its descendant recursively.
+/// Threads are excluded, only process leaders are returned.
 pub fn collect_all_children(root_pid: i32) -> Vec<i32> {
     let mut pids: Vec<i32> = vec![root_pid];
     let mut queue: VecDeque<i32> = VecDeque::from([root_pid]);
 
     while let Some(pid) = queue.pop_front() {
-        for child_pid in read_task_children(pid) {
+        for child_pid in read_child_processes(pid) {
             if !pids.contains(&child_pid) {
                 pids.push(child_pid);
                 queue.push_back(child_pid);
@@ -78,12 +90,16 @@ impl From<MemoryUnit> for MetricUnit {
     }
 }
 
+/// Convert bytes to the provided unit.
+/// If the unit is bigger than Kilo, then it becomes a float and is rounded to 2 decimals.
 pub fn make_conversion(unit: MemoryUnit, value: u64) -> MetricValue {
     #[allow(clippy::cast_precision_loss)]
     (match unit {
         MemoryUnit::Bytes => |b| MetricValue::UnsignedInteger(b),
-        MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1_024),
-        MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / 1_048_576.0, Some(2)),
-        MemoryUnit::Giga => |b| MetricValue::Float(b as f64 / 1_073_741_824.0, Some(2)),
+        MemoryUnit::Kilo => |b| MetricValue::UnsignedInteger(b / 1024),
+        MemoryUnit::Mega => |b| MetricValue::Float(b as f64 / f64::from(1024 * 1024), Some(2)),
+        MemoryUnit::Giga => {
+            |b| MetricValue::Float(b as f64 / f64::from(1024 * 1024 * 1024), Some(2))
+        }
     })(value)
 }

--- a/sources/procfs/src/utils.rs
+++ b/sources/procfs/src/utils.rs
@@ -1,3 +1,4 @@
+use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
 use procfs::process::Process;
 use std::collections::VecDeque;
 
@@ -40,4 +41,36 @@ pub fn collect_all_children(root_pid: i32) -> Vec<i32> {
         }
     }
     pids
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryUnit {
+    Bytes,
+    Kilo,
+    #[default]
+    Mega,
+    Giga,
+}
+
+impl From<MemoryUnit> for MetricUnit {
+    fn from(unit: MemoryUnit) -> Self {
+        match unit {
+            MemoryUnit::Bytes => MetricUnit {
+                prefix: UnitPrefix::None,
+                unit: Unit::Byte,
+            },
+            MemoryUnit::Kilo => MetricUnit {
+                prefix: UnitPrefix::Kilo,
+                unit: Unit::Byte,
+            },
+            MemoryUnit::Mega => MetricUnit {
+                prefix: UnitPrefix::Mega,
+                unit: Unit::Byte,
+            },
+            MemoryUnit::Giga => MetricUnit {
+                prefix: UnitPrefix::Giga,
+                unit: Unit::Byte,
+            },
+        }
+    }
 }

--- a/sources/procfs/src/utils.rs
+++ b/sources/procfs/src/utils.rs
@@ -1,0 +1,45 @@
+use std::collections::VecDeque;
+use procfs::process::Process;
+
+fn read_task_children(pid: i32) -> Vec<i32> {
+    let Ok(process) = Process::new(pid) else {
+        return vec![];
+    };
+    let Ok(tasks) = process.tasks() else {
+        return vec![];
+    };
+
+    tasks
+        .flatten()
+        .flat_map(|task| {
+            let path = format!("/proc/{}/task/{}/children", pid, task.tid);
+            std::fs::read_to_string(&path)
+                .unwrap_or_default()
+                .split_whitespace()
+                .filter_map(|s| s.parse::<i32>().ok())
+                .collect::<Vec<_>>()
+        })
+        .filter(|&child_pid| {
+            Process::new(child_pid)
+                .and_then(|p| p.status())
+                .map(|s| s.pid == s.tgid)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+pub fn collect_all_children(root_pid: i32) -> Result<Vec<i32>, std::io::Error> {
+    let mut pids: Vec<i32> = vec![root_pid];
+    let mut queue: VecDeque<i32> = VecDeque::from([root_pid]);
+
+    while let Some(pid) = queue.pop_front() {
+        for child_pid in read_task_children(pid) {
+            if !pids.contains(&child_pid) {
+                pids.push(child_pid);
+                queue.push_back(child_pid);
+            }
+        }
+    }
+
+    Ok(pids)
+}

--- a/sources/procfs/src/utils.rs
+++ b/sources/procfs/src/utils.rs
@@ -1,5 +1,5 @@
-use std::collections::VecDeque;
 use procfs::process::Process;
+use std::collections::VecDeque;
 
 fn read_task_children(pid: i32) -> Vec<i32> {
     let Ok(process) = Process::new(pid) else {

--- a/sources/procfs/src/utils.rs
+++ b/sources/procfs/src/utils.rs
@@ -3,13 +3,12 @@ use joule_profiler_core::{
     unit::{MetricUnit, Unit, UnitPrefix},
 };
 use procfs::process::Process;
-use std::collections::VecDeque;
 
 /// Reads direct child of pid (threads excluded).
 ///
 /// Reads `/proc/{pid}/task/{tid}/children` for each thread of the process,
 /// then filters out threads by keeping only processes.
-fn read_child_processes(pid: i32) -> Vec<i32> {
+pub fn read_child_processes(pid: i32) -> Vec<i32> {
     let Ok(process) = Process::new(pid) else {
         return vec![];
     };
@@ -39,23 +38,6 @@ fn is_process(pid: i32) -> bool {
     Process::new(pid)
         .and_then(|p| p.status())
         .is_ok_and(|s| s.pid == s.tgid)
-}
-
-/// Collects `root_pid` and all its descendant recursively.
-/// Threads are excluded, only process leaders are returned.
-pub fn collect_all_children(root_pid: i32) -> Vec<i32> {
-    let mut pids: Vec<i32> = vec![root_pid];
-    let mut queue: VecDeque<i32> = VecDeque::from([root_pid]);
-
-    while let Some(pid) = queue.pop_front() {
-        for child_pid in read_child_processes(pid) {
-            if !pids.contains(&child_pid) {
-                pids.push(child_pid);
-                queue.push_back(child_pid);
-            }
-        }
-    }
-    pids
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Description

This pull request adds a new metric source based on the Linux procfs interface.

procfs allows to retrieve various process and system-wide metrics on memory or I/O. 

## Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Improvement
* [x] Documentation
* [ ] Other (please specify):

## Related Issues

The related issue is #19.

## Changes Made

* Procfs source implementation
* Documentation of the source and README
* Tests implementation

## Checklist

* [x] My code follows the project style
* [x] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass

## Additional Notes

Procfs allows only to retrieve the information of a process without it's children, this means that we have to detect the children of the profiled process recursively and measure these children too.

In the implementation of the source, a tokio asynchronous task is spawned with a configurable polling interval (default is 1 second) to construct the process hierarchy of the profiled process.
A second tokio task is also used to measure continuously the metrics to detect the most accurate bounds for each metrics.
Uncoupling these two concerns minimizes the overhead introduced and also allows the user to have more control on the source. 

