### PR TITLE
Bugfix/37 init timeout error

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = "1.0.100"
 env_logger = "0.11.8"
 clap = { version = "4.5.53", features = ["derive"] }
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
+humantime = "2.3.0"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
         profiler.add_source(perf_event);
     }
 
-    let config = Config::from(cli);
+    let config = Config::try_from(cli)?;
 
     match config.command {
         Command::Profile(profile_config) => {

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use clap::Parser;
 
 /// Arguments for profiling mode.
@@ -11,12 +13,8 @@ pub struct ProfileArgs {
     ///   - START -> `first_token`
     ///   - `token_i` -> `token_i+1`
     ///   - `last_token` -> END
-    #[arg(
-        long = "token-pattern",
-        default_value = "__[A-Z0-9_]+__",
-        value_name = "REGEX"
-    )]
-    pub token_pattern: String,
+    #[arg(long = "token-pattern", value_name = "REGEX")]
+    pub token_pattern: Option<String>,
 
     /// Redirect profiled program stdout to this file.
     #[arg(short = 'o', long = "stdout-file")]
@@ -33,4 +31,9 @@ pub struct ProfileArgs {
     /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
     #[arg(long = "use-root")]
     pub use_root: bool,
+
+    /// Duration before aborting sources initialization.
+    #[clap(value_parser = humantime::parse_duration)]
+    #[arg(long = "init-timeout")]
+    pub init_timeout: Option<Duration>,
 }

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -13,8 +13,12 @@ pub struct ProfileArgs {
     ///   - START -> `first_token`
     ///   - `token_i` -> `token_i+1`
     ///   - `last_token` -> END
-    #[arg(long = "token-pattern", value_name = "REGEX")]
-    pub token_pattern: Option<String>,
+    #[arg(
+        long = "token-pattern",
+        default_value = "__[A-Z0-9_]+__",
+        value_name = "REGEX"
+    )]
+    pub token_pattern: String,
 
     /// Redirect profiled program stdout to this file.
     #[arg(short = 'o', long = "stdout-file")]
@@ -34,6 +38,6 @@ pub struct ProfileArgs {
 
     /// Duration before aborting sources initialization.
     #[clap(value_parser = humantime::parse_duration)]
-    #[arg(long = "init-timeout")]
-    pub init_timeout: Option<Duration>,
+    #[arg(long = "init-timeout", default_value = "1s")]
+    pub init_timeout: Duration,
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,7 +4,7 @@ use clap::{ArgAction, Parser, ValueEnum};
 
 use anyhow::Result;
 pub use commands::ProfilerCommand;
-use joule_profiler_core::config::{Command, Config, ProfileConfig};
+use joule_profiler_core::config::{Command, Config, ProfileConfigBuilder};
 
 use crate::output::{
     displayer::Displayer,
@@ -80,23 +80,35 @@ impl CliArgs {
     }
 }
 
-impl From<CliArgs> for Config {
-    fn from(cli_args: CliArgs) -> Self {
+impl TryFrom<CliArgs> for Config {
+    type Error = anyhow::Error;
+
+    fn try_from(cli_args: CliArgs) -> Result<Self, anyhow::Error> {
         let command = match cli_args.command {
-            ProfilerCommand::Profile(profile_args) => Command::Profile(ProfileConfig {
-                stdout_file: profile_args.stdout_file,
-                cmd: profile_args.cmd,
-                token_pattern: profile_args.token_pattern,
-                use_root: profile_args.use_root,
-            }),
+            ProfilerCommand::Profile(profile_args) => {
+                let mut builder = ProfileConfigBuilder::default();
+                if let Some(stdout_file) = profile_args.stdout_file {
+                    builder.stdout_file(stdout_file);
+                }
+                builder.cmd(profile_args.cmd);
+                if let Some(token_pattern) = profile_args.token_pattern {
+                    builder.token_pattern(token_pattern);
+                }
+                builder.use_root(profile_args.use_root);
+                if let Some(init_timeout) = profile_args.init_timeout {
+                    builder.init_timeout(init_timeout);
+                }
+
+                Command::Profile(builder.build()?)
+            }
 
             ProfilerCommand::ListSensors => Command::ListSensors,
         };
 
-        Config {
+        Ok(Config {
             command,
             rapl_path: cli_args.rapl_path,
-        }
+        })
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -87,17 +87,17 @@ impl TryFrom<CliArgs> for Config {
         let command = match cli_args.command {
             ProfilerCommand::Profile(profile_args) => {
                 let mut builder = ProfileConfigBuilder::default();
-                if let Some(stdout_file) = profile_args.stdout_file {
-                    builder.stdout_file(stdout_file);
-                }
-                builder.cmd(profile_args.cmd);
-                builder.token_pattern(profile_args.token_pattern);
-                builder.use_root(profile_args.use_root);
-                builder.init_timeout(profile_args.init_timeout);
 
-                Command::Profile(builder.build()?)
+                let config = builder
+                    .cmd(profile_args.cmd)
+                    .stdout_file(profile_args.stdout_file)
+                    .token_pattern(profile_args.token_pattern)
+                    .use_root(profile_args.use_root)
+                    .init_timeout(profile_args.init_timeout)
+                    .build()?;
+
+                Command::Profile(config)
             }
-
             ProfilerCommand::ListSensors => Command::ListSensors,
         };
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -91,13 +91,9 @@ impl TryFrom<CliArgs> for Config {
                     builder.stdout_file(stdout_file);
                 }
                 builder.cmd(profile_args.cmd);
-                if let Some(token_pattern) = profile_args.token_pattern {
-                    builder.token_pattern(token_pattern);
-                }
+                builder.token_pattern(profile_args.token_pattern);
                 builder.use_root(profile_args.use_root);
-                if let Some(init_timeout) = profile_args.init_timeout {
-                    builder.init_timeout(init_timeout);
-                }
+                builder.init_timeout(profile_args.init_timeout);
 
                 Command::Profile(builder.build()?)
             }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -13,6 +13,7 @@
 //!     cmd: vec!["sleep".into(), "1".into()],
 //!     token_pattern: "__[A-Z0-9_]+__".into(),
 //!     use_root: false,
+//!     init_timeout: std::time::Duration::from_secs(1),
 //! };
 //!
 //! let config = Config {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -53,7 +53,6 @@ pub enum Command {
 #[derive(Debug, Clone, Builder)]
 pub struct ProfileConfig {
     /// Optional file to redirect the profiled program stdout.
-    #[builder(default, setter(strip_option))]
     pub stdout_file: Option<String>,
 
     /// Command and arguments to execute.

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -26,9 +26,6 @@ use std::time::Duration;
 
 use derive_builder::Builder;
 
-const PHASE_TOKEN_DEFAULT_REGEX_PATTERN: &str = "__[A-Z0-9_]+__";
-const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(1);
-
 /// Top-level configuration for Joule Profiler.
 #[derive(Debug)]
 pub struct Config {
@@ -59,13 +56,11 @@ pub struct ProfileConfig {
     pub cmd: Vec<String>,
 
     /// Regex used to detect phase tokens in program output.
-    #[builder(default = PHASE_TOKEN_DEFAULT_REGEX_PATTERN.to_string())]
     pub token_pattern: String,
 
     /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
     pub use_root: bool,
 
     /// Duration before aborting sources initialization.
-    #[builder(default = DEFAULT_INIT_TIMEOUT)]
     pub init_timeout: Duration,
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -21,9 +21,12 @@
 //! };
 //! ```
 
+use std::time::Duration;
+
 use derive_builder::Builder;
 
 const PHASE_TOKEN_DEFAULT_REGEX_PATTERN: &str = "__[A-Z0-9_]+__";
+const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Top-level configuration for Joule Profiler.
 #[derive(Debug)]
@@ -61,4 +64,8 @@ pub struct ProfileConfig {
 
     /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
     pub use_root: bool,
+
+    /// Duration before aborting sources initialization.
+    #[builder(default = DEFAULT_INIT_TIMEOUT)]
+    pub init_timeout: Duration,
 }

--- a/core/src/orchestrator/mod.rs
+++ b/core/src/orchestrator/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! This module defines the core logic for metric sources orchestration through [`SourceOrchestrator`] structure.
 
+use std::time::Duration;
+
 use crate::aggregate::sensor_result::SensorResult;
 use crate::orchestrator::error::OrchestratorError;
 use crate::source::types::SourceEvent;
@@ -38,10 +40,14 @@ pub struct SourceOrchestrator {
 impl SourceOrchestrator {
     /// Starts all the metric sources.
     ///
-    /// The function shares the atomic integer representing the profiled program's pid, used by some sources for per-process profiling (e.g. `perf_event`).
+    /// The function uses a one shot sender to forward the profiled program's pid to the sources, used by some for per-process profiling (e.g. `perf_event`).
     /// Stores the sources handles and the channels senders to be able to gracefully join the sources and send events.
     #[inline]
-    pub fn run(&mut self, sources: Vec<Box<dyn MetricSource>>) -> Result<(), OrchestratorError> {
+    pub fn run(
+        &mut self,
+        sources: Vec<Box<dyn MetricSource>>,
+        init_timeout: Duration,
+    ) -> Result<(), OrchestratorError> {
         if sources.is_empty() {
             return Err(OrchestratorError::NoSourceConfigured);
         }
@@ -50,7 +56,7 @@ impl SourceOrchestrator {
         let mut handles = Vec::with_capacity(nb_sources);
 
         for source in sources {
-            let (handle, control_sender, init_sender) = source.run();
+            let (handle, control_sender, init_sender) = source.run(init_timeout);
             handles.push(SourceHandle {
                 handle,
                 control_sender,
@@ -263,7 +269,9 @@ mod tests {
     async fn finalize_without_measurements_returns_not_enough_snapshots() {
         let mut orchestrator = SourceOrchestrator::default();
         let (source, _) = mock_source();
-        orchestrator.run(vec![source]).unwrap();
+        orchestrator
+            .run(vec![source], Duration::from_secs(1))
+            .unwrap();
         orchestrator.init(0).unwrap();
 
         assert!(matches!(
@@ -277,7 +285,7 @@ mod tests {
         let mut orchestrator = SourceOrchestrator::default();
 
         assert!(matches!(
-            orchestrator.run(vec![]),
+            orchestrator.run(vec![], Duration::from_secs(1)),
             Err(OrchestratorError::NoSourceConfigured)
         ));
     }
@@ -286,7 +294,9 @@ mod tests {
     async fn event_reaches_worker() {
         let (source, state) = mock_source();
         let mut orchestrator = SourceOrchestrator::default();
-        orchestrator.run(vec![source]).unwrap();
+        orchestrator
+            .run(vec![source], Duration::from_secs(1))
+            .unwrap();
 
         let _ = orchestrator.measure().await;
         let _ = orchestrator.init(0);
@@ -306,7 +316,9 @@ mod tests {
         let (source, state) = mock_source();
 
         let mut orchestrator = SourceOrchestrator::default();
-        orchestrator.run(vec![source]).unwrap();
+        orchestrator
+            .run(vec![source], Duration::from_secs(1))
+            .unwrap();
 
         orchestrator.init(42).unwrap();
 
@@ -324,7 +336,9 @@ mod tests {
         let source: Box<dyn MetricSource> = reader.into();
         let mut orchestrator = SourceOrchestrator::default();
 
-        orchestrator.run(vec![source]).unwrap();
+        orchestrator
+            .run(vec![source], Duration::from_secs(1))
+            .unwrap();
         orchestrator.init(0).unwrap();
         orchestrator.measure().await.unwrap();
         let result = orchestrator.finalize().await;

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -114,7 +114,7 @@ impl JouleProfiler {
 
         let sources = std::mem::take(&mut self.sources);
         trace!("Starting orchestrator with {} source(s)", sources.len());
-        self.orchestrator.run(sources)?;
+        self.orchestrator.run(sources, config.init_timeout)?;
 
         info!("Starting measurements");
         let (command_duration_ms, timestamp, exit_code, detected_phases) =
@@ -433,6 +433,7 @@ mod tests {
     use regex::Regex;
     use std::fs;
     use std::io::{BufReader, Cursor, Read};
+    use std::time::Duration;
     use tempfile::TempDir;
 
     fn joule_profiler() -> JouleProfiler {
@@ -448,6 +449,7 @@ mod tests {
             token_pattern: "__PHASE__".to_string(),
             stdout_file: None,
             use_root: false,
+            init_timeout: Duration::from_secs(1),
         }
     }
 
@@ -676,6 +678,7 @@ mod tests {
             token_pattern: "[[invalid[[[regex[[".to_string(),
             stdout_file: None,
             use_root: false,
+            init_timeout: Duration::from_secs(1),
         };
         profiler.add_source(MockMetricReader::new());
         let result = profiler.profile(&config).await;

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -53,6 +53,7 @@ pub mod types;
 ///     token_pattern: "__PHASE__".to_string(),
 ///     stdout_file: None,
 ///     use_root: false,
+///     init_timeout: std::time::Duration::from_secs(1),
 /// };
 ///
 /// let results = profiler.profile(&config).await.unwrap();

--- a/core/src/source/error.rs
+++ b/core/src/source/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, time::Duration};
 use thiserror::Error;
 
 /// Errors that can occur when reading or aggregating metrics from a source.
@@ -12,8 +12,10 @@ pub enum MetricSourceError {
     ErrorRetrievingCounters,
 
     /// The initialization of the source lasted more than the authorized time.
-    #[error("Source initialization timeout.")]
-    InitTimeout,
+    #[error(
+        "source initialization timed out after {0:?}. Use --init-timeout to increase the limit."
+    )]
+    InitTimeout(Duration),
 
     /// Error propagated from a custom metric source.
     #[error(transparent)]

--- a/core/src/source/mod.rs
+++ b/core/src/source/mod.rs
@@ -5,6 +5,8 @@
 //! Implementations are boxed for flexibility, while internally resolving
 //! concrete types to minimize the profiler overhead.
 
+use std::time::Duration;
+
 use tokio::sync::{mpsc, oneshot};
 
 pub(crate) mod accumulator;
@@ -29,6 +31,7 @@ pub(crate) trait MetricSource: Send {
     /// Spawn the source worker and return its handle, control channel and initialization channel.
     fn run(
         self: Box<Self>,
+        init_timeout: Duration,
     ) -> (
         SourceWorkerHandle,
         mpsc::Sender<SourceEvent>,
@@ -49,6 +52,7 @@ where
     /// This transformation allows to monomorphize the metric source and discover its type after its launch.
     fn run(
         self: Box<Self>,
+        init_timeout: Duration,
     ) -> (
         SourceWorkerHandle,
         mpsc::Sender<SourceEvent>,
@@ -56,8 +60,10 @@ where
     ) {
         let (control_sender, control_receiver) = mpsc::channel(4);
         let (init_sender, init_receiver) = oneshot::channel();
-        let handle =
-            tokio::spawn(async move { self.run_worker(control_receiver, init_receiver).await });
+        let handle = tokio::spawn(async move {
+            self.run_worker(control_receiver, init_receiver, init_timeout)
+                .await
+        });
         (handle, control_sender, init_sender)
     }
 

--- a/core/src/source/runtime.rs
+++ b/core/src/source/runtime.rs
@@ -39,11 +39,12 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
         mut self,
         mut receiver: mpsc::Receiver<SourceEvent>,
         init_receiver: oneshot::Receiver<i32>,
+        init_timeout: Duration,
     ) -> Result<(SensorResult, Box<dyn MetricSource>), MetricSourceError> {
-        let pid = timeout(Duration::from_secs(1), init_receiver)
+        let pid = timeout(init_timeout, init_receiver)
             .await
             .map_err(IntoMetricSourceError::into_metric_source_error)?
-            .map_err(|_| MetricSourceError::InitTimeout)?;
+            .map_err(|_| MetricSourceError::InitTimeout(init_timeout))?;
 
         self.init_source(pid).await?;
 
@@ -217,7 +218,9 @@ mod tests {
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        rt.run_worker(rx, pid(0)).await.unwrap();
+        rt.run_worker(rx, pid(0), Duration::from_secs(1))
+            .await
+            .unwrap();
 
         assert_eq!(counts.lock().unwrap().measure, 2);
     }
@@ -229,7 +232,9 @@ mod tests {
         let (tx, rx) = mpsc::channel(16);
 
         tx.send(SourceEvent::JoinWorker).await.unwrap();
-        rt.run_worker(rx, pid(42)).await.unwrap();
+        rt.run_worker(rx, pid(42), Duration::from_secs(1))
+            .await
+            .unwrap();
 
         assert_eq!(counts.lock().unwrap().init, 1);
     }
@@ -247,7 +252,11 @@ mod tests {
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        assert!(rt.run_worker(rx, pid(0)).await.is_err());
+        assert!(
+            rt.run_worker(rx, pid(0), Duration::from_secs(1))
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -259,7 +268,9 @@ mod tests {
         tx.send(SourceEvent::NewPhase).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        rt.run_worker(rx, pid(0)).await.unwrap();
+        rt.run_worker(rx, pid(0), Duration::from_secs(1))
+            .await
+            .unwrap();
 
         assert_eq!(counts.lock().unwrap().retrieve, 1);
     }
@@ -271,7 +282,9 @@ mod tests {
         let (tx, rx) = mpsc::channel(16);
 
         tx.send(SourceEvent::JoinWorker).await.unwrap();
-        rt.run_worker(rx, pid(0)).await.unwrap();
+        rt.run_worker(rx, pid(0), Duration::from_secs(1))
+            .await
+            .unwrap();
 
         assert_eq!(counts.lock().unwrap().join, 1);
     }
@@ -287,7 +300,11 @@ mod tests {
         tx.send(SourceEvent::NewPhase).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        assert!(rt.run_worker(rx, pid(0)).await.is_ok());
+        assert!(
+            rt.run_worker(rx, pid(0), Duration::from_secs(1))
+                .await
+                .is_ok()
+        );
 
         let c = counts.lock().unwrap();
         assert_eq!(c.measure, 2);

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use joule_profiler_core::{
     JouleProfiler,
     config::ProfileConfig,
@@ -53,6 +55,7 @@ fn config(cmd: Vec<String>, pattern: &str) -> ProfileConfig {
         token_pattern: pattern.to_string(),
         stdout_file: None,
         use_root: false,
+        init_timeout: Duration::from_secs(1),
     }
 }
 


### PR DESCRIPTION
## Description

This pull request adds a new CLI flag to be able to configure the sources initialization timeout.
Before, the delay was set to one and couldn't be modified by the user, which can lead to unavoidable crashes in slow environments. 

## Type of Change

* [x] Bug fix
* [x] New feature
* [ ] Improvement
* [ ] Documentation

## Related Issues

The related issue is #37.

## Changes Made

* Added CLI flag --init-timeout to be able to configure the sources initialization timeout.

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [ ] I have added/updated documentation if needed
* [x] All tests pass

## Additional Notes

Addressing reviews from JOSS.
