### PR TITLE
refactor: replace TryInto by TryFrom for RaplDomainType and removed u…

### DIFF
--- a/sources/rapl/src/domain_type.rs
+++ b/sources/rapl/src/domain_type.rs
@@ -67,21 +67,28 @@ impl Display for RaplDomainType {
     }
 }
 
-impl TryInto<RaplDomainType> for String {
+impl TryFrom<&str> for RaplDomainType {
     type Error = RaplError;
 
-    fn try_into(self) -> Result<RaplDomainType, RaplError> {
-        let name_lower = self.to_lowercase();
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let eq = |s| value.eq_ignore_ascii_case(s);
 
-        let domain_type = match name_lower.as_str() {
-            domain if domain.starts_with("package") => RaplDomainType::Package,
-            "energy-pkg" => RaplDomainType::Package,
-            "core" | "pp0" | "energy-cores" => RaplDomainType::Core,
-            "uncore" | "pp1" | "energy-uncore" | "energy-gpu" => RaplDomainType::Uncore,
-            "dram" | "ram" | "energy-ram" => RaplDomainType::Dram,
-            "psys" | "platform" | "energy-psys" => RaplDomainType::Psys,
-            _ => return Err(RaplError::UnknownDomain(name_lower)),
+        let domain_type = if eq("core") || eq("pp0") || eq("energy-cores") {
+            RaplDomainType::Core
+        } else if eq("uncore") || eq("pp1") || eq("energy-uncore") || eq("energy-gpu") {
+            RaplDomainType::Uncore
+        } else if eq("dram") || eq("ram") || eq("energy-ram") {
+            RaplDomainType::Dram
+        } else if (value.len() >= 7 && value[..7].eq_ignore_ascii_case("package"))
+            || eq("energy-pkg")
+        {
+            RaplDomainType::Package
+        } else if eq("psys") || eq("platform") || eq("energy-psys") {
+            RaplDomainType::Psys
+        } else {
+            return Err(RaplError::UnknownDomain(value.to_string()));
         };
+
         Ok(domain_type)
     }
 }
@@ -91,11 +98,11 @@ mod test {
     use crate::{RaplError, domain_type::RaplDomainType};
 
     fn str_to_domain(domain: &str) -> RaplDomainType {
-        domain.to_string().try_into().unwrap()
+        RaplDomainType::try_from(domain).unwrap()
     }
 
     fn str_to_domain_err(domain: &str) -> RaplError {
-        let result: Result<RaplDomainType, RaplError> = domain.to_string().try_into();
+        let result: Result<RaplDomainType, RaplError> = RaplDomainType::try_from(domain);
         result.unwrap_err()
     }
 

--- a/sources/rapl/src/powercap/domain.rs
+++ b/sources/rapl/src/powercap/domain.rs
@@ -124,7 +124,10 @@ fn add_domain_if_energy(dir: &Path, out: &mut Vec<RaplDomain>) -> Result<()> {
         Ok(n) => n,
         Err(e) => match e.kind() {
             ErrorKind::NotFound => {
-                warn!("Directory {} missing energy_uj file, ignored.", dir.display());
+                warn!(
+                    "Directory {} missing energy_uj file, ignored.",
+                    dir.display()
+                );
                 return Ok(());
             }
             _ => return Err(e)?,
@@ -149,7 +152,10 @@ fn add_domain_if_energy(dir: &Path, out: &mut Vec<RaplDomain>) -> Result<()> {
         let domain = RaplDomain::try_new(path, name_trimmed, socket, max_energy_uj)?;
         out.push(domain);
     } else {
-        warn!("Domain {} missing max_energy_range_uj, ignored.", dir.display());
+        warn!(
+            "Domain {} missing max_energy_range_uj, ignored.",
+            dir.display()
+        );
     }
 
     Ok(())

--- a/sources/rapl/src/powercap/domain.rs
+++ b/sources/rapl/src/powercap/domain.rs
@@ -30,10 +30,10 @@ impl RaplDomain {
     /// Create a new RAPL domain from the given path, name, socket, and max energy
     ///
     /// Converts the string name into a `RaplDomainType`
-    pub fn try_new(path: PathBuf, name: String, socket: u32, max_energy_uj: u64) -> Result<Self> {
+    pub fn try_new(path: PathBuf, name: &str, socket: u32, max_energy_uj: u64) -> Result<Self> {
         let domain = Self {
             path,
-            domain_type: name.try_into()?,
+            domain_type: RaplDomainType::try_from(name)?,
             socket,
             max_energy_uj,
         };
@@ -112,7 +112,7 @@ fn discover_domains(base: &str) -> Result<Vec<RaplDomain>> {
     Ok(domains)
 }
 
-/// Adds a RAPL domain to the output vector if it contains an `energy_uj` file.
+/// Adds a RAPL domain to the output vector if it contains an `energy_uj` and a `max_energy_uj` files.
 fn add_domain_if_energy(dir: &Path, out: &mut Vec<RaplDomain>) -> Result<()> {
     let path = dir.join("energy_uj");
     if !path.exists() {
@@ -120,10 +120,17 @@ fn add_domain_if_energy(dir: &Path, out: &mut Vec<RaplDomain>) -> Result<()> {
         return Ok(());
     }
 
-    let name = fs::read_to_string(dir.join("name"))
-        .unwrap_or_else(|_| "unknown".to_string())
-        .trim()
-        .to_string();
+    let name = match fs::read_to_string(dir.join("name")) {
+        Ok(n) => n,
+        Err(e) => match e.kind() {
+            ErrorKind::NotFound => {
+                warn!("Directory {} missing energy_uj file, ignored.", dir.display());
+                return Ok(());
+            }
+            _ => return Err(e)?,
+        },
+    };
+    let name_trimmed = name.trim();
 
     let socket = extract_socket_number(dir);
 
@@ -138,12 +145,11 @@ fn add_domain_if_energy(dir: &Path, out: &mut Vec<RaplDomain>) -> Result<()> {
         .flatten();
 
     if let Some(max_energy_uj) = max_energy_uj_option {
-        debug!("Found domain: name={name}, socket={socket}, max_energy_uj={max_energy_uj}");
-
-        let domain = RaplDomain::try_new(path, name, socket, max_energy_uj)?;
+        debug!("Found domain: name={name_trimmed}, socket={socket}, max_energy_uj={max_energy_uj}");
+        let domain = RaplDomain::try_new(path, name_trimmed, socket, max_energy_uj)?;
         out.push(domain);
     } else {
-        warn!("Domain {} missing max_energy_range_uj", dir.display());
+        warn!("Domain {} missing max_energy_range_uj, ignored.", dir.display());
     }
 
     Ok(())


### PR DESCRIPTION
## Description

The RaplDomainType struct was implemented by the TryInto<RaplDomainType> for String. In rust we should always prefer the From trait over the Into trait, this pull request adresses this coding style issue.
Also, an unnecessary String allocation is made in order to be able to match the lowercase String. This heap allocation has been replaced by calling the `eq_ignore_ascii_case` function that does not allocate another String.

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] Improvement
* [ ] Documentation

## Related Issues

The related issue is #46.

## Changes Made

* Changed TryInto to TryFrom trait for RaplDomainType for more idiomatic implementation.
* Removed unnecessary String allocation by not calling to_lowercase but by matching lowercase ascii characters.

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass