### PR TITLE
fix: check command not empty before spawning process to avoid panic

### DIFF
--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -16,6 +16,9 @@ pub enum JouleProfilerError {
     #[error("Command not found: {0}")]
     CommandNotFound(String),
 
+    #[error("The provided command is empty.")]
+    EmptyCommand,
+
     /// The output file could not be created at the given path.
     #[error("Failed to create output file: {0}")]
     OutputFileCreationFailed(String),

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -348,7 +348,12 @@ fn spawn_profiled_command(config: &ProfileConfig) -> Result<Child> {
 /// - The `SUDO_USER` environment variable cannot be retrieved, even so the user is root.
 /// - The user uid cannot be retrieved with it's username provided by the environment variable.  
 pub fn init_command(cmd: &[String], use_root: bool) -> Result<Command> {
-    let mut command = process::Command::new(&cmd[0]);
+    let mut command = if let Some(program) = cmd.first() {
+        process::Command::new(program)
+    } else {
+        return Err(JouleProfilerError::EmptyCommand);
+    };
+
     if cmd.len() > 1 {
         command.args(&cmd[1..]);
     }


### PR DESCRIPTION
## Description

This pull request fixes the bug that occur when the provided command is empty, that makes Joule Profiler panic.
It can happen only when using the library because the CLI arguments prevent that to occur.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Documentation

## Related Issues

The related issue is #44.

## Changes Made

* Check that the provided command is not empty to avoid panic.

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [ ] I have added/updated documentation if needed
* [x] All tests pass