### PR TITLE
feat: added library usage example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "core",
     "cli",
     "sources/*"
-]
+, "examples/library_usage"]
 
 [workspace.package]
 edition = "2024"
@@ -17,7 +17,7 @@ readme = "README.md"
 joule-profiler-core = { path = "core", version = "1.0.2" }
 
 log = "0.4.28"
-tokio = { version = "1.25", features = ["time", "rt-multi-thread", "macros", "sync", "rt"] }
+tokio = { version = "1.52.3", features = ["time", "rt-multi-thread", "macros", "sync", "rt"] }
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.17"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ resolver = "2"
 members = [
     "core",
     "cli",
-    "sources/*"
-, "examples/library_usage"]
+    "sources/*",
+    "examples/library_usage"
+]
 
 [workspace.package]
 edition = "2024"

--- a/examples/library_usage.rs
+++ b/examples/library_usage.rs
@@ -1,0 +1,35 @@
+//! This file provides a simple example of the Joule Profiler library usage.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use joule_profiler_core::JouleProfiler;
+use joule_profiler_core::config::ProfileConfig;
+use joule_profiler_source_rapl::perf;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Instanciate Joule Profiler.
+    let mut profiler = JouleProfiler::new();
+
+    // Add sources.
+    let rapl = perf::Rapl::new(None)?;
+    profiler.add_source(rapl);
+    // ...
+
+    // Profile config.
+    let profile_config = ProfileConfig {
+        stdout_file: None,
+        cmd: vec!["sleep".into(), "1".into()],
+        token_pattern: "__[A-Z0-9_]+__".into(),
+        use_root: false,
+        init_timeout: Duration::from_secs(1),
+    };
+
+    // Launch profiling.
+    let results = profiler.profile(&profile_config).await?;
+
+    println!("{results:?}");
+
+    Ok(())
+}

--- a/examples/library_usage/Cargo.toml
+++ b/examples/library_usage/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "library_usage_example"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[dependencies]
+anyhow = "1.0.102"
+joule-profiler-core = { version = "1.0.2", path = "../../core" }
+joule-profiler-source-rapl = { version = "1.0.2", path = "../../sources/rapl" }
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/examples/library_usage/README.md
+++ b/examples/library_usage/README.md
@@ -1,0 +1,8 @@
+# Joule Profiler library usage example
+
+This crate provides an example of usage of Joule Profiler library.
+
+Run the example:
+```bash
+cargo run --bin library_usage_example
+```

--- a/examples/library_usage/src/main.rs
+++ b/examples/library_usage/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     // Launch profiling.
     let results = profiler.profile(&profile_config).await?;
 
-    println!("{results:?}");
+    println!("{results:#?}");
 
     Ok(())
 }


### PR DESCRIPTION
## Description

This pull request adds a library usage example to show how to easily setup Joule Profiler using the library.
The example can be launched from the root directory with the command:
cargo run --bin library_usage_example

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Improvement
* [x] Documentation

## Related Issues

The issue related is #48.

## Changes Made

* Added a library usage example.
* Upgrade tokio version to 1.52.3.

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass
