### PR TITLE
Orchestrator refactoring and documentation, initialization validation to avoid delay

### DIFF
--- a/core/src/orchestrator/error.rs
+++ b/core/src/orchestrator/error.rs
@@ -6,10 +6,6 @@ use tokio::{sync::mpsc::error::SendError, task::JoinError};
 /// Errors that can occur during orchestration.
 #[derive(Debug, Error)]
 pub enum OrchestratorError {
-    /// Returned when there's no metric sources configured to profile the program with.
-    #[error("No metric sources configured.")]
-    NoSourceConfigured,
-
     /// Happens when an error occur while joining sources.
     #[error("Join error")]
     JoinError(

--- a/core/src/orchestrator/error.rs
+++ b/core/src/orchestrator/error.rs
@@ -27,8 +27,8 @@ pub enum OrchestratorError {
     ),
 
     /// Returned when an error occured while sending the initialization event.
-    #[error("Cannot initialize {0} source.")]
-    InitializationError(String),
+    #[error("Cannot initialize source: {0}.")]
+    InitializationError(&'static str),
 
     /// Phase count mismatch between two sensor sources during aggregation.
     #[error(

--- a/core/src/orchestrator/mod.rs
+++ b/core/src/orchestrator/mod.rs
@@ -69,7 +69,11 @@ impl SourceOrchestrator {
         Ok(())
     }
 
-    /// Measures the metrics of each metric source.
+    /// Send a measure event to each metrics source.
+    ///
+    /// This function ensure event submission, but is does not ensure
+    /// measurement completion and that the measure will be taken directly after it.
+    /// At high concurrency and with many running sources, the measurement can be made lately.
     #[inline]
     pub async fn measure(&mut self) -> Result<(), OrchestratorError> {
         self.send_event(SourceEvent::Measure).await
@@ -79,16 +83,16 @@ impl SourceOrchestrator {
     /// Called when the program execution is stopped to inizialize sources requiring pid filtering (e.g. `perf_event`).
     #[inline]
     pub fn init(&mut self, pid: i32) -> Result<(), OrchestratorError> {
-        for source_handle in &mut self.handles {
-            if let Some(init_sender) = source_handle.init_sender.take()
-                && init_sender.send(pid).is_err()
+        self.handles.iter_mut().try_for_each(|h| {
+            if let Some(sender) = h.init_sender.take()
+                && sender.send(pid).is_err()
             {
                 return Err(OrchestratorError::InitializationError(
                     "Failed to initialize sources.".to_string(),
                 ));
             }
-        }
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Initializes a new phase for each metric source.
@@ -123,20 +127,16 @@ impl SourceOrchestrator {
     ///
     /// If an error is encountered in a source, then the worker is aborted and the error is returned.
     async fn send_event(&mut self, event: SourceEvent) -> Result<(), OrchestratorError> {
-        let futures: Vec<_> = self
-            .handles
-            .iter_mut()
-            .enumerate()
-            .map(|(i, source_handle)| async move {
-                source_handle
-                    .control_sender
-                    .send(event)
-                    .await
-                    .map_err(|send_err| (i, send_err))
-            })
-            .collect();
-
-        if let Err((failed_index, send_err)) = try_join_all(futures).await {
+        if let Err((failed_index, send_err)) = try_join_all(
+            self.handles
+                .iter_mut()
+                .enumerate()
+                .map(
+                    |(i, h)| async move { h.control_sender.send(event).await.map_err(|e| (i, e)) },
+                ),
+        )
+        .await
+        {
             Err(self.handle_event_error(failed_index, send_err.into()).await)
         } else {
             Ok(())
@@ -171,14 +171,14 @@ impl SourceOrchestrator {
 
         let handles = std::mem::take(&mut self.handles);
 
-        let mut results = Vec::with_capacity(handles.len());
-        let mut sources = Vec::with_capacity(handles.len());
+        let results = try_join_all(handles.into_iter().map(|h| h.handle)).await?;
 
-        for source_handle in handles {
-            let (result, source) = source_handle.handle.await??;
-            results.push(result);
-            sources.push(source);
-        }
+        let (results, sources) = results
+            .into_iter()
+            .map(|r| r.map_err(OrchestratorError::from))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .unzip();
 
         Ok((results, sources))
     }

--- a/core/src/orchestrator/mod.rs
+++ b/core/src/orchestrator/mod.rs
@@ -6,9 +6,11 @@ use std::time::Duration;
 
 use crate::aggregate::sensor_result::SensorResult;
 use crate::orchestrator::error::OrchestratorError;
+use crate::source::error::IntoMetricSourceError;
 use crate::source::types::SourceEvent;
 use crate::source::{MetricSource, MetricSourceError};
 use futures::future::try_join_all;
+use tokio::time::timeout;
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinHandle,
@@ -16,15 +18,39 @@ use tokio::{
 
 pub mod error;
 
+/// The size of the control channel to send event.
+/// It should not have a huge size because if the buffer is full,
+/// it means that the sources are slower to measure than the phases durations.
+pub const CONTROL_CHANNEL_SIZE: usize = 16;
+
 /// The handle describing the return type of a source worker.
 type TaskHandle = JoinHandle<Result<(SensorResult, Box<dyn MetricSource>), MetricSourceError>>;
+
+struct InitChannel {
+    sender: oneshot::Sender<i32>,
+    validation: oneshot::Receiver<Result<(), MetricSourceError>>,
+}
+
+impl InitChannel {
+    async fn initialize(self, pid: i32) -> Result<(), OrchestratorError> {
+        self.sender
+            .send(pid)
+            .map_err(|_| OrchestratorError::InitializationError("Failed to send PID"))?;
+
+        self.validation
+            .await
+            .map_err(|e| OrchestratorError::MetricSourceError(e.into_metric_source_error()))??;
+
+        Ok(())
+    }
+}
 
 struct SourceHandle {
     /// The event channel sender used to manage the metric sources.
     control_sender: mpsc::Sender<SourceEvent>,
 
-    /// The oneshot sender used to initialized sources.
-    init_sender: Option<oneshot::Sender<i32>>,
+    /// The channels used for sources initializations.
+    init_channel: Option<InitChannel>,
 
     /// The handle of the worker task, used for joining sources gracefully.
     handle: TaskHandle,
@@ -35,6 +61,7 @@ struct SourceHandle {
 #[derive(Default)]
 pub struct SourceOrchestrator {
     handles: Vec<SourceHandle>,
+    init_timeout: Duration,
 }
 
 impl SourceOrchestrator {
@@ -51,19 +78,33 @@ impl SourceOrchestrator {
         if sources.is_empty() {
             return Err(OrchestratorError::NoSourceConfigured);
         }
-
-        let nb_sources = sources.len();
-        let mut handles = Vec::with_capacity(nb_sources);
+        let mut handles = Vec::with_capacity(sources.len());
 
         for source in sources {
-            let (handle, control_sender, init_sender) = source.run(init_timeout);
+            let (control_sender, control_receiver) = mpsc::channel(CONTROL_CHANNEL_SIZE);
+            let (init_sender, init_receiver) = oneshot::channel();
+            let (init_validation_sender, init_validation_receiver) = oneshot::channel();
+
+            let handle = source.run(
+                control_receiver,
+                init_receiver,
+                init_validation_sender,
+                init_timeout,
+            );
+
+            let init_channel = InitChannel {
+                sender: init_sender,
+                validation: init_validation_receiver,
+            };
+
             handles.push(SourceHandle {
                 handle,
                 control_sender,
-                init_sender: Some(init_sender),
+                init_channel: Some(init_channel),
             });
         }
 
+        self.init_timeout = init_timeout;
         self.handles = handles;
 
         Ok(())
@@ -81,18 +122,21 @@ impl SourceOrchestrator {
 
     /// Initializes each metric source.
     /// Called when the program execution is stopped to inizialize sources requiring pid filtering (e.g. `perf_event`).
-    #[inline]
-    pub fn init(&mut self, pid: i32) -> Result<(), OrchestratorError> {
-        self.handles.iter_mut().try_for_each(|h| {
-            if let Some(sender) = h.init_sender.take()
-                && sender.send(pid).is_err()
-            {
-                return Err(OrchestratorError::InitializationError(
-                    "Failed to initialize sources.".to_string(),
-                ));
+    /// Wait for all sources to be initialized and to receive their validation.
+    pub async fn init(&mut self, pid: i32) -> Result<(), OrchestratorError> {
+        let futures = self.handles.iter_mut().map(|handle| async move {
+            if let Some(init_channel) = handle.init_channel.take() {
+                init_channel.initialize(pid).await
+            } else {
+                Ok(())
             }
-            Ok(())
-        })
+        });
+
+        timeout(self.init_timeout, try_join_all(futures))
+            .await
+            .map_err(|_| OrchestratorError::InitializationError("init timeout reached"))??;
+
+        Ok(())
     }
 
     /// Initializes a new phase for each metric source.
@@ -272,7 +316,7 @@ mod tests {
         orchestrator
             .run(vec![source], Duration::from_secs(1))
             .unwrap();
-        orchestrator.init(0).unwrap();
+        orchestrator.init(0).await.unwrap();
 
         assert!(matches!(
             orchestrator.finalize().await,
@@ -299,7 +343,7 @@ mod tests {
             .unwrap();
 
         let _ = orchestrator.measure().await;
-        let _ = orchestrator.init(0);
+        let _ = orchestrator.init(0).await;
         let _ = orchestrator.join().await;
 
         tokio::task::yield_now().await;
@@ -320,7 +364,7 @@ mod tests {
             .run(vec![source], Duration::from_secs(1))
             .unwrap();
 
-        orchestrator.init(42).unwrap();
+        orchestrator.init(42).await.unwrap();
 
         // wait for initialization
         tokio::task::yield_now().await;
@@ -339,7 +383,7 @@ mod tests {
         orchestrator
             .run(vec![source], Duration::from_secs(1))
             .unwrap();
-        orchestrator.init(0).unwrap();
+        orchestrator.init(0).await.unwrap();
         orchestrator.measure().await.unwrap();
         let result = orchestrator.finalize().await;
 

--- a/core/src/orchestrator/mod.rs
+++ b/core/src/orchestrator/mod.rs
@@ -6,15 +6,13 @@ use std::time::Duration;
 
 use crate::aggregate::sensor_result::SensorResult;
 use crate::orchestrator::error::OrchestratorError;
-use crate::source::error::IntoMetricSourceError;
 use crate::source::types::SourceEvent;
 use crate::source::{MetricSource, MetricSourceError};
+use crate::util::time::get_timestamp_micros;
 use futures::future::try_join_all;
+use log::{debug, trace};
 use tokio::time::timeout;
-use tokio::{
-    sync::{mpsc, oneshot},
-    task::JoinHandle,
-};
+use tokio::{sync::mpsc, task::JoinHandle};
 
 pub mod error;
 
@@ -26,31 +24,9 @@ pub const CONTROL_CHANNEL_SIZE: usize = 16;
 /// The handle describing the return type of a source worker.
 type TaskHandle = JoinHandle<Result<(SensorResult, Box<dyn MetricSource>), MetricSourceError>>;
 
-struct InitChannel {
-    sender: oneshot::Sender<i32>,
-    validation: oneshot::Receiver<Result<(), MetricSourceError>>,
-}
-
-impl InitChannel {
-    async fn initialize(self, pid: i32) -> Result<(), OrchestratorError> {
-        self.sender
-            .send(pid)
-            .map_err(|_| OrchestratorError::InitializationError("Failed to send PID"))?;
-
-        self.validation
-            .await
-            .map_err(|e| OrchestratorError::MetricSourceError(e.into_metric_source_error()))??;
-
-        Ok(())
-    }
-}
-
 struct SourceHandle {
     /// The event channel sender used to manage the metric sources.
     control_sender: mpsc::Sender<SourceEvent>,
-
-    /// The channels used for sources initialization.
-    init_channel: Option<InitChannel>,
 
     /// The handle of the worker task, used for joining sources gracefully.
     handle: TaskHandle,
@@ -58,54 +34,90 @@ struct SourceHandle {
 
 /// Orchestrates the metric sources and send them the profiler's messages through asynchronous channels.
 /// It is a proxy between the profiler and the sources and is responsible of their lifecycle.
-#[derive(Default)]
-pub struct SourceOrchestrator {
+pub struct Orchestrator {
+    /// Sources initialized through [`SourceOrchestrator::init`], not yet started by [`SourceOrchestrator::run`].
+    sources: Vec<Box<dyn MetricSource>>,
+
     handles: Vec<SourceHandle>,
-    init_timeout: Duration,
 }
 
-impl SourceOrchestrator {
-    /// Starts all the metric sources.
+impl Orchestrator {
+    pub fn new(sources: Vec<Box<dyn MetricSource>>) -> Self {
+        Self {
+            sources,
+            handles: Vec::new(),
+        }
+    }
+
+    /// Initializes each metric source with the profiled program's pid, bounded by `init_timeout`.
     ///
-    /// The function uses a one shot sender to forward the profiled program's pid to the sources, used by some for per-process profiling (e.g. `perf_event`).
-    /// Stores the sources handles and the channels senders to be able to gracefully join the sources and send events.
-    #[inline]
-    pub fn run(
+    /// Used by some sources for per-process profiling (e.g. `perf_event`).
+    /// Stores the initialized sources, ready to be started with [`SourceOrchestrator::run`].
+    ///
+    /// Each source is initialized in its own task: some [`MetricReader::init`](`crate::source::MetricReader::init`)
+    /// implementations perform blocking work without yielding, which would otherwise prevent
+    /// `init_timeout` from being enforced if awaited directly on the calling task.
+    pub async fn init(
         &mut self,
-        sources: Vec<Box<dyn MetricSource>>,
+        pid: i32,
         init_timeout: Duration,
     ) -> Result<(), OrchestratorError> {
+        trace!(
+            "Initializing {} source(s) with pid {pid}",
+            self.sources.len()
+        );
+        let sources = std::mem::take(&mut self.sources);
+        let tasks = sources.into_iter().map(|mut source| {
+            tokio::spawn(async move {
+                let result = source.init(pid).await;
+                (source, result)
+            })
+        });
+
+        let begin_init_timestamp = get_timestamp_micros();
+        let initialized = timeout(init_timeout, try_join_all(tasks))
+            .await
+            .map_err(|_| OrchestratorError::InitializationError("init timeout reached"))??;
+        let end_init_timestamp = get_timestamp_micros();
+        debug!(
+            "Sources initialized in {}μs.",
+            end_init_timestamp - begin_init_timestamp
+        );
+
+        self.sources = initialized
+            .into_iter()
+            .map(|(source, result)| result.map(|()| source))
+            .collect::<Result<Vec<_>, MetricSourceError>>()?;
+
+        Ok(())
+    }
+
+    /// Starts all the metric sources, already initialized through [`SourceOrchestrator::init`].
+    ///
+    /// Stores the sources handles and the channels senders to be able to gracefully join the sources and send events.
+    #[inline]
+    pub fn run(&mut self) -> Result<(), OrchestratorError> {
+        trace!(
+            "Starting orchestrator with {} source(s)",
+            self.sources.len()
+        );
+        let sources = std::mem::take(&mut self.sources);
+
         if sources.is_empty() {
             return Err(OrchestratorError::NoSourceConfigured);
         }
-        let mut handles = Vec::with_capacity(sources.len());
 
-        for source in sources {
-            let (control_sender, control_receiver) = mpsc::channel(CONTROL_CHANNEL_SIZE);
-            let (init_sender, init_receiver) = oneshot::channel();
-            let (init_validation_sender, init_validation_receiver) = oneshot::channel();
-
-            let handle = source.run(
-                control_receiver,
-                init_receiver,
-                init_validation_sender,
-                init_timeout,
-            );
-
-            let init_channel = InitChannel {
-                sender: init_sender,
-                validation: init_validation_receiver,
-            };
-
-            handles.push(SourceHandle {
-                handle,
-                control_sender,
-                init_channel: Some(init_channel),
-            });
-        }
-
-        self.init_timeout = init_timeout;
-        self.handles = handles;
+        self.handles = sources
+            .into_iter()
+            .map(|source| {
+                let (control_sender, control_receiver) = mpsc::channel(CONTROL_CHANNEL_SIZE);
+                let handle = source.run(control_receiver);
+                SourceHandle {
+                    control_sender,
+                    handle,
+                }
+            })
+            .collect();
 
         Ok(())
     }
@@ -118,25 +130,6 @@ impl SourceOrchestrator {
     #[inline]
     pub async fn measure(&mut self) -> Result<(), OrchestratorError> {
         self.send_event(SourceEvent::Measure).await
-    }
-
-    /// Initializes each metric source.
-    /// Called when the program execution is stopped to inizialize sources requiring pid filtering (e.g. `perf_event`).
-    /// Wait for all sources to be initialized and to receive their validation.
-    pub async fn init(&mut self, pid: i32) -> Result<(), OrchestratorError> {
-        let futures = self.handles.iter_mut().map(|handle| async move {
-            if let Some(init_channel) = handle.init_channel.take() {
-                init_channel.initialize(pid).await
-            } else {
-                Ok(())
-            }
-        });
-
-        timeout(self.init_timeout, try_join_all(futures))
-            .await
-            .map_err(|_| OrchestratorError::InitializationError("init timeout reached"))??;
-
-        Ok(())
     }
 
     /// Initializes a new phase for each metric source.
@@ -311,12 +304,10 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_without_measurements_returns_not_enough_snapshots() {
-        let mut orchestrator = SourceOrchestrator::default();
         let (source, _) = mock_source();
-        orchestrator
-            .run(vec![source], Duration::from_secs(1))
-            .unwrap();
-        orchestrator.init(0).await.unwrap();
+        let mut orchestrator = Orchestrator::new(vec![source]);
+        orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
+        orchestrator.run().unwrap();
 
         assert!(matches!(
             orchestrator.finalize().await,
@@ -326,10 +317,10 @@ mod tests {
 
     #[tokio::test]
     async fn run_orchestrator_with_no_source_returns_error() {
-        let mut orchestrator = SourceOrchestrator::default();
+        let mut orchestrator = Orchestrator::new(Vec::new());
 
         assert!(matches!(
-            orchestrator.run(vec![], Duration::from_secs(1)),
+            orchestrator.run(),
             Err(OrchestratorError::NoSourceConfigured)
         ));
     }
@@ -337,13 +328,11 @@ mod tests {
     #[tokio::test]
     async fn event_reaches_worker() {
         let (source, state) = mock_source();
-        let mut orchestrator = SourceOrchestrator::default();
-        orchestrator
-            .run(vec![source], Duration::from_secs(1))
-            .unwrap();
+        let mut orchestrator = Orchestrator::new(vec![source]);
+        orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
+        orchestrator.run().unwrap();
 
         let _ = orchestrator.measure().await;
-        let _ = orchestrator.init(0).await;
         let _ = orchestrator.join().await;
 
         tokio::task::yield_now().await;
@@ -358,18 +347,34 @@ mod tests {
     #[tokio::test]
     async fn init_initializes_source_with_right_pid() {
         let (source, state) = mock_source();
+        let mut orchestrator = Orchestrator::new(vec![source]);
 
-        let mut orchestrator = SourceOrchestrator::default();
-        orchestrator
-            .run(vec![source], Duration::from_secs(1))
-            .unwrap();
-
-        orchestrator.init(42).await.unwrap();
-
-        // wait for initialization
-        tokio::task::yield_now().await;
+        orchestrator.init(42, Duration::from_secs(1)).await.unwrap();
 
         assert_eq!(state.lock().unwrap().pid, 42);
+    }
+
+    // Requires a multi-threaded runtime: a blocking `init` occupies its own worker thread,
+    // relying on another worker thread being free to enforce `init_timeout`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn init_times_out_on_blocking_source() {
+        let mut reader = MockMetricReader::new();
+        reader.expect_init().returning(|_| {
+            // Simulates a `MetricReader::init` implementation performing blocking
+            // work without ever yielding (e.g. a blocking syscall or file read),
+            // which must not prevent `init_timeout` from being enforced.
+            std::thread::sleep(Duration::from_millis(200));
+            Ok(())
+        });
+        let source: Box<dyn MetricSource> = reader.into();
+        let mut orchestrator = Orchestrator::new(vec![source]);
+
+        let result = orchestrator.init(0, Duration::from_millis(20)).await;
+
+        assert!(matches!(
+            result,
+            Err(OrchestratorError::InitializationError(_))
+        ));
     }
 
     #[tokio::test]
@@ -378,12 +383,10 @@ mod tests {
         reader.expect_init().returning(|_| Ok(()));
         reader.expect_measure().returning(|| Err(MockError));
         let source: Box<dyn MetricSource> = reader.into();
-        let mut orchestrator = SourceOrchestrator::default();
+        let mut orchestrator = Orchestrator::new(vec![source]);
 
-        orchestrator
-            .run(vec![source], Duration::from_secs(1))
-            .unwrap();
-        orchestrator.init(0).await.unwrap();
+        orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
+        orchestrator.run().unwrap();
         orchestrator.measure().await.unwrap();
         let result = orchestrator.finalize().await;
 

--- a/core/src/orchestrator/mod.rs
+++ b/core/src/orchestrator/mod.rs
@@ -35,7 +35,6 @@ struct SourceHandle {
 /// Orchestrates the metric sources and send them the profiler's messages through asynchronous channels.
 /// It is a proxy between the profiler and the sources and is responsible of their lifecycle.
 pub struct Orchestrator {
-    /// Sources initialized through [`SourceOrchestrator::init`], not yet started by [`SourceOrchestrator::run`].
     sources: Vec<Box<dyn MetricSource>>,
 
     handles: Vec<SourceHandle>,
@@ -96,16 +95,12 @@ impl Orchestrator {
     ///
     /// Stores the sources handles and the channels senders to be able to gracefully join the sources and send events.
     #[inline]
-    pub fn run(&mut self) -> Result<(), OrchestratorError> {
+    pub fn run(&mut self) {
         trace!(
             "Starting orchestrator with {} source(s)",
             self.sources.len()
         );
         let sources = std::mem::take(&mut self.sources);
-
-        if sources.is_empty() {
-            return Err(OrchestratorError::NoSourceConfigured);
-        }
 
         self.handles = sources
             .into_iter()
@@ -118,8 +113,6 @@ impl Orchestrator {
                 }
             })
             .collect();
-
-        Ok(())
     }
 
     /// Send a measure event to each metrics source.
@@ -307,7 +300,7 @@ mod tests {
         let (source, _) = mock_source();
         let mut orchestrator = Orchestrator::new(vec![source]);
         orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
-        orchestrator.run().unwrap();
+        orchestrator.run();
 
         assert!(matches!(
             orchestrator.finalize().await,
@@ -316,21 +309,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_orchestrator_with_no_source_returns_error() {
-        let mut orchestrator = Orchestrator::new(Vec::new());
-
-        assert!(matches!(
-            orchestrator.run(),
-            Err(OrchestratorError::NoSourceConfigured)
-        ));
-    }
-
-    #[tokio::test]
     async fn event_reaches_worker() {
         let (source, state) = mock_source();
         let mut orchestrator = Orchestrator::new(vec![source]);
         orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
-        orchestrator.run().unwrap();
+        orchestrator.run();
 
         let _ = orchestrator.measure().await;
         let _ = orchestrator.join().await;
@@ -386,7 +369,7 @@ mod tests {
         let mut orchestrator = Orchestrator::new(vec![source]);
 
         orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
-        orchestrator.run().unwrap();
+        orchestrator.run();
         orchestrator.measure().await.unwrap();
         let result = orchestrator.finalize().await;
 

--- a/core/src/orchestrator/mod.rs
+++ b/core/src/orchestrator/mod.rs
@@ -49,7 +49,7 @@ struct SourceHandle {
     /// The event channel sender used to manage the metric sources.
     control_sender: mpsc::Sender<SourceEvent>,
 
-    /// The channels used for sources initializations.
+    /// The channels used for sources initialization.
     init_channel: Option<InitChannel>,
 
     /// The handle of the worker task, used for joining sources gracefully.

--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -57,6 +57,10 @@ pub enum JouleProfilerError {
         std::io::Error,
     ),
 
+    /// Returned when there's no metric sources configured to profile the program with.
+    #[error("No metric sources configured.")]
+    NoSourceConfigured,
+
     /// A process control operation (e.g. kill, wait) failed.
     #[error("Process control failed: {0}")]
     ProcessControlFailed(String),

--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -25,7 +25,7 @@ pub enum JouleProfilerError {
 
     /// The provided token pattern is not a valid regular expression.
     #[error("Invalid regex pattern: {0}")]
-    InvalidPattern(String),
+    InvalidPattern(#[from] regex::Error),
 
     /// Failed to capture the profiled command's stdout.
     #[error("Stdout capture failed")]

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -17,7 +17,7 @@ use std::{
 pub mod error;
 
 use crate::config::ProfileConfig;
-use crate::orchestrator::SourceOrchestrator;
+use crate::orchestrator::Orchestrator;
 use crate::phase::{PhaseInfo, PhaseToken};
 use crate::profiler::types::{MeasurePhasesReturnType, Phase, ProfilerResults, Result};
 use crate::sensor::{Sensor, Sensors};
@@ -61,9 +61,6 @@ pub mod types;
 /// ```
 #[derive(Default)]
 pub struct JouleProfiler {
-    /// The sources orchestrator, managing sources and sending them the events sent by the profiler.
-    orchestrator: SourceOrchestrator,
-
     /// The different metric sources.
     sources: Vec<Box<dyn MetricSource>>,
 }
@@ -108,20 +105,31 @@ impl JouleProfiler {
 
     /// Profiles a program spawned with the configured command and return the aggregated results.
     ///
-    /// It starts the orchestrator with the metric sources and profile the program.
+    /// It spawns the program, initializes the metric sources with its pid, starts the
+    /// orchestrator, and profiles the program.
     pub async fn profile(&mut self, config: &ProfileConfig) -> Result<ProfilerResults> {
         info!("Running phase-based profiling");
         debug!("Phase regex: {}", config.token_pattern);
 
+        let regex = Regex::new(&config.token_pattern)?;
+
         let sources = std::mem::take(&mut self.sources);
-        trace!("Starting orchestrator with {} source(s)", sources.len());
-        self.orchestrator.run(sources, config.init_timeout)?;
+        let mut orchestrator = Orchestrator::new(sources);
+
+        debug!("Spawning command: {:?}", config.cmd);
+        let mut child = spawn_profiled_command(config)?;
+        let pid = child.id().cast_signed();
+
+        pause_prosess(pid)?;
+        orchestrator.init(pid, config.init_timeout).await?;
+        orchestrator.run()?;
 
         info!("Starting measurements");
-        let (command_duration_ms, timestamp, exit_code, detected_phases) =
-            self.measure_phases(config).await?;
+        let (command_duration_ms, timestamp, exit_code, detected_phases) = self
+            .measure_phases(&mut orchestrator, config, &regex, &mut child, pid)
+            .await?;
 
-        let (sources_results, sources) = self.orchestrator.finalize().await?;
+        let (sources_results, sources) = orchestrator.finalize().await?;
         self.sources = sources;
 
         let mut phases: Vec<_> = detected_phases
@@ -170,33 +178,27 @@ impl JouleProfiler {
         })
     }
 
-    /// Spawn the configured command and profile it, separating its execution into phases through tokens matching
-    /// a configured regular expression.
+    /// Profile the already spawned and paused command, separating its execution into phases
+    /// through tokens matching a configured regular expression.
     ///
     /// The profiling is composed of several steps:
     ///
-    /// - Firstly, the program is spawned and its pid is retrieved.
-    /// - The process is immediately stopped using a SIGSTOP signal to configure the sources without introducing a significant overhead.
-    /// - The first measure is made and the process is then resume.
+    /// - The metric sources have already been initialized with the profiled program's pid and the process paused
+    ///   (see [`JouleProfiler::profile`]), to configure the sources without introducing a significant overhead.
+    /// - The first measure is made and the process is then resumed.
     /// - The profiler listens for phase token in the standard output of the profiled process and make a measure for every token detected.
     /// - When the program exited, the profiler makes a last measure to compute the last phase metrics.
     ///
     /// After the profiling, results are aggregated into a common structure.
-    async fn measure_phases(&mut self, config: &ProfileConfig) -> Result<MeasurePhasesReturnType> {
-        debug!("Compiling phase regex");
-
-        let regex = Regex::new(&config.token_pattern).map_err(|err| {
-            JouleProfilerError::InvalidPattern(format!("{}: {}", config.token_pattern, err))
-        })?;
-
+    async fn measure_phases(
+        &mut self,
+        orchestrator: &mut Orchestrator,
+        config: &ProfileConfig,
+        regex: &Regex,
+        child: &mut Child,
+        pid: i32,
+    ) -> Result<MeasurePhasesReturnType> {
         let mut sink = create_output_sink(config.stdout_file.as_ref())?;
-
-        debug!("Spawning command: {:?}", config.cmd);
-        let mut child = spawn_profiled_command(config)?;
-        let pid = child.id().cast_signed();
-
-        pause_prosess(pid)?;
-        self.orchestrator.init(pid).await?;
 
         let child_stdout = child
             .stdout
@@ -209,16 +211,17 @@ impl JouleProfiler {
         let begin_timestamp = get_timestamp_micros();
         trace!("Begin timestamp: {begin_timestamp}");
 
-        self.orchestrator.measure().await?;
+        orchestrator.measure().await?;
 
         resume_process(pid)?;
 
         detected_phases.push(PhaseInfo::start(begin_timestamp));
 
         self.detect_and_handle_phases_from_program_output(
+            orchestrator,
             &mut detected_phases,
             reader,
-            &regex,
+            regex,
             &mut sink,
         )
         .await?;
@@ -228,14 +231,14 @@ impl JouleProfiler {
         let end_timestamp = get_timestamp_micros();
         trace!("End timestamp: {end_timestamp}");
 
-        self.orchestrator.measure().await?;
-        self.orchestrator.new_phase().await?;
+        orchestrator.measure().await?;
+        orchestrator.new_phase().await?;
 
         let duration_ms = (end_timestamp - begin_timestamp) / 1000;
 
         detected_phases.push(PhaseInfo::end(end_timestamp));
 
-        let exit_code = wait_for_child_exit(&mut child)?;
+        let exit_code = wait_for_child_exit(child)?;
 
         info!("Command finished: duration={duration_ms} ms exit_code={exit_code}");
 
@@ -248,6 +251,7 @@ impl JouleProfiler {
     /// a measure is made and a new phase begins.
     async fn detect_and_handle_phases_from_program_output<R, W>(
         &mut self,
+        orchestrator: &mut Orchestrator,
         phases: &mut Vec<PhaseInfo>,
         mut reader: R,
         regex: &Regex,
@@ -284,8 +288,6 @@ impl JouleProfiler {
                 }
             }
 
-            trace!("STDOUT[{line_number}]: {line}");
-
             writeln!(sink, "{line}")?;
 
             if let Some(token) = phase_token_in_line(regex, &line) {
@@ -293,8 +295,8 @@ impl JouleProfiler {
 
                 debug!("Detected phase at line {line_number}, token '{token}'");
 
-                self.orchestrator.measure().await?;
-                self.orchestrator.new_phase().await?;
+                orchestrator.measure().await?;
+                orchestrator.new_phase().await?;
 
                 let phase_info = PhaseInfo {
                     token: PhaseToken::Token(token.to_owned()),
@@ -424,7 +426,7 @@ fn resume_process(pid: i32) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::config::ProfileConfig;
-    use crate::orchestrator::SourceOrchestrator;
+    use crate::orchestrator::Orchestrator;
     use crate::phase::PhaseToken;
     use crate::profiler::{
         create_output_sink, phase_token_in_line, spawn_profiled_command, wait_for_child_exit,
@@ -442,7 +444,6 @@ mod tests {
 
     fn joule_profiler() -> JouleProfiler {
         JouleProfiler {
-            orchestrator: SourceOrchestrator::default(),
             sources: Vec::new(),
         }
     }
@@ -488,6 +489,7 @@ mod tests {
     #[tokio::test]
     async fn detect_multiple_phases() {
         let mut profiler = joule_profiler();
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let regex = Regex::new("__[A-Z0-9_]+__").unwrap();
         let cursor = Cursor::new("__PHASE1__\n__PHASE2__\n__PHASE3__");
         let reader = BufReader::new(cursor);
@@ -495,7 +497,13 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
 
         profiler
-            .detect_and_handle_phases_from_program_output(&mut phases, reader, &regex, &mut sink)
+            .detect_and_handle_phases_from_program_output(
+                &mut orchestrator,
+                &mut phases,
+                reader,
+                &regex,
+                &mut sink,
+            )
             .await
             .unwrap();
 
@@ -508,13 +516,20 @@ mod tests {
     #[tokio::test]
     async fn detect_no_phases() {
         let mut profiler = joule_profiler();
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let regex = Regex::new("__[A-Z0-9_]+__").unwrap();
         let cursor = Cursor::new("hello\nworld\nno phases here");
         let reader = BufReader::new(cursor);
         let mut phases = Vec::new();
         let mut sink: Vec<u8> = Vec::new();
         profiler
-            .detect_and_handle_phases_from_program_output(&mut phases, reader, &regex, &mut sink)
+            .detect_and_handle_phases_from_program_output(
+                &mut orchestrator,
+                &mut phases,
+                reader,
+                &regex,
+                &mut sink,
+            )
             .await
             .unwrap();
 
@@ -524,6 +539,7 @@ mod tests {
     #[tokio::test]
     async fn detect_empty_output() {
         let mut profiler = joule_profiler();
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let regex = Regex::new("__PHASE__").unwrap();
         let cursor = Cursor::new("");
         let reader = BufReader::new(cursor);
@@ -531,7 +547,13 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
 
         profiler
-            .detect_and_handle_phases_from_program_output(&mut phases, reader, &regex, &mut sink)
+            .detect_and_handle_phases_from_program_output(
+                &mut orchestrator,
+                &mut phases,
+                reader,
+                &regex,
+                &mut sink,
+            )
             .await
             .unwrap();
 
@@ -541,6 +563,7 @@ mod tests {
     #[tokio::test]
     async fn detect_phase_in_middle_of_line() {
         let mut profiler = joule_profiler();
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let regex = Regex::new("__PHASE[0-9]+__").unwrap();
         let cursor = Cursor::new("start __PHASE1__ end");
         let reader = BufReader::new(cursor);
@@ -548,7 +571,13 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
 
         profiler
-            .detect_and_handle_phases_from_program_output(&mut phases, reader, &regex, &mut sink)
+            .detect_and_handle_phases_from_program_output(
+                &mut orchestrator,
+                &mut phases,
+                reader,
+                &regex,
+                &mut sink,
+            )
             .await
             .unwrap();
 
@@ -560,6 +589,7 @@ mod tests {
     #[tokio::test]
     async fn detect_correct_line_numbers() {
         let mut profiler = joule_profiler();
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let regex = Regex::new("__PHASE[0-9]+__").unwrap();
         let cursor = Cursor::new("a\nb\n__PHASE1__\nc\n__PHASE2__");
         let reader = BufReader::new(cursor);
@@ -567,7 +597,13 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
 
         profiler
-            .detect_and_handle_phases_from_program_output(&mut phases, reader, &regex, &mut sink)
+            .detect_and_handle_phases_from_program_output(
+                &mut orchestrator,
+                &mut phases,
+                reader,
+                &regex,
+                &mut sink,
+            )
             .await
             .unwrap();
 
@@ -582,6 +618,7 @@ mod tests {
         use tempfile::NamedTempFile;
 
         let mut profiler = joule_profiler();
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let regex = Regex::new("__PHASE__").unwrap();
         let cursor = Cursor::new("hello\n__PHASE__\nworld");
         let reader = BufReader::new(cursor);
@@ -591,6 +628,7 @@ mod tests {
 
         profiler
             .detect_and_handle_phases_from_program_output(
+                &mut orchestrator,
                 &mut phases,
                 reader,
                 &regex,
@@ -608,6 +646,7 @@ mod tests {
     #[tokio::test]
     async fn skips_invalid_utf8_lines() {
         let mut profiler = joule_profiler();
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let regex = Regex::new("__PHASE__").unwrap();
 
         let bytes = vec![
@@ -619,7 +658,13 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
 
         profiler
-            .detect_and_handle_phases_from_program_output(&mut phases, reader, &regex, &mut sink)
+            .detect_and_handle_phases_from_program_output(
+                &mut orchestrator,
+                &mut phases,
+                reader,
+                &regex,
+                &mut sink,
+            )
             .await
             .unwrap();
 

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -114,6 +114,9 @@ impl JouleProfiler {
         let regex = Regex::new(&config.token_pattern)?;
 
         let sources = std::mem::take(&mut self.sources);
+        if sources.is_empty() {
+            return Err(JouleProfilerError::NoSourceConfigured);
+        }
         let mut orchestrator = Orchestrator::new(sources);
 
         debug!("Spawning command: {:?}", config.cmd);
@@ -122,7 +125,7 @@ impl JouleProfiler {
 
         pause_prosess(pid)?;
         orchestrator.init(pid, config.init_timeout).await?;
-        orchestrator.run()?;
+        orchestrator.run();
 
         info!("Starting measurements");
         let (command_duration_ms, timestamp, exit_code, detected_phases) = self
@@ -448,6 +451,10 @@ mod tests {
         }
     }
 
+    fn orchestrator() -> Orchestrator {
+        Orchestrator::new(Vec::new())
+    }
+
     fn create_test_config(cmd: Vec<String>) -> ProfileConfig {
         ProfileConfig {
             cmd,
@@ -489,7 +496,7 @@ mod tests {
     #[tokio::test]
     async fn detect_multiple_phases() {
         let mut profiler = joule_profiler();
-        let mut orchestrator = Orchestrator::new(Vec::new());
+        let mut orchestrator = orchestrator();
         let regex = Regex::new("__[A-Z0-9_]+__").unwrap();
         let cursor = Cursor::new("__PHASE1__\n__PHASE2__\n__PHASE3__");
         let reader = BufReader::new(cursor);
@@ -516,7 +523,7 @@ mod tests {
     #[tokio::test]
     async fn detect_no_phases() {
         let mut profiler = joule_profiler();
-        let mut orchestrator = Orchestrator::new(Vec::new());
+        let mut orchestrator = orchestrator();
         let regex = Regex::new("__[A-Z0-9_]+__").unwrap();
         let cursor = Cursor::new("hello\nworld\nno phases here");
         let reader = BufReader::new(cursor);
@@ -539,7 +546,7 @@ mod tests {
     #[tokio::test]
     async fn detect_empty_output() {
         let mut profiler = joule_profiler();
-        let mut orchestrator = Orchestrator::new(Vec::new());
+        let mut orchestrator = orchestrator();
         let regex = Regex::new("__PHASE__").unwrap();
         let cursor = Cursor::new("");
         let reader = BufReader::new(cursor);
@@ -563,7 +570,7 @@ mod tests {
     #[tokio::test]
     async fn detect_phase_in_middle_of_line() {
         let mut profiler = joule_profiler();
-        let mut orchestrator = Orchestrator::new(Vec::new());
+        let mut orchestrator = orchestrator();
         let regex = Regex::new("__PHASE[0-9]+__").unwrap();
         let cursor = Cursor::new("start __PHASE1__ end");
         let reader = BufReader::new(cursor);
@@ -618,7 +625,7 @@ mod tests {
         use tempfile::NamedTempFile;
 
         let mut profiler = joule_profiler();
-        let mut orchestrator = Orchestrator::new(Vec::new());
+        let mut orchestrator = orchestrator();
         let regex = Regex::new("__PHASE__").unwrap();
         let cursor = Cursor::new("hello\n__PHASE__\nworld");
         let reader = BufReader::new(cursor);
@@ -646,7 +653,7 @@ mod tests {
     #[tokio::test]
     async fn skips_invalid_utf8_lines() {
         let mut profiler = joule_profiler();
-        let mut orchestrator = Orchestrator::new(Vec::new());
+        let mut orchestrator = orchestrator();
         let regex = Regex::new("__PHASE__").unwrap();
 
         let bytes = vec![
@@ -870,5 +877,14 @@ mod tests {
         let mut profiler = joule_profiler();
         let sensors = profiler.list_sensors().unwrap();
         assert!(sensors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_with_no_source_returns_no_source_configured_error() {
+        let config = create_test_config(vec!["test".to_string()]);
+        assert!(matches!(
+            joule_profiler().profile(&config).await,
+            Err(JouleProfilerError::NoSourceConfigured)
+        ));
     }
 }

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -173,8 +173,6 @@ impl JouleProfiler {
     /// Spawn the configured command and profile it, separating its execution into phases through tokens matching
     /// a configured regular expression.
     ///
-    /// The shared pid atomic integer is used to configure the sources supporting pid filtering (e.g. `perf_event`)
-    ///
     /// The profiling is composed of several steps:
     ///
     /// - Firstly, the program is spawned and its pid is retrieved.
@@ -198,7 +196,7 @@ impl JouleProfiler {
         let pid = child.id().cast_signed();
 
         pause_prosess(pid)?;
-        self.orchestrator.init(pid)?;
+        self.orchestrator.init(pid).await?;
 
         let child_stdout = child
             .stdout

--- a/core/src/source/mod.rs
+++ b/core/src/source/mod.rs
@@ -5,9 +5,10 @@
 //! Implementations are boxed for flexibility, while internally resolving
 //! concrete types to minimize the profiler overhead.
 
-use std::time::Duration;
+use std::future::Future;
+use std::pin::Pin;
 
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 pub(crate) mod accumulator;
 pub mod error;
@@ -16,7 +17,6 @@ pub(crate) mod runtime;
 pub(crate) mod types;
 
 use crate::sensor::Sensors;
-use crate::source::runtime::MetricSourceRuntime;
 use crate::source::types::{SourceEvent, SourceWorkerHandle};
 pub use error::MetricSourceError;
 pub use reader::MetricReader;
@@ -28,58 +28,17 @@ pub use types::{MetricReaderErrorBound, MetricReaderTypeBound};
 /// This trait is used to erase the type of the metric source, to be able to have a
 /// convenient API for users while maintaining performance with monomorphization during hot paths.
 pub(crate) trait MetricSource: Send {
-    /// Spawn the source worker and return its handle, control channel and initialization channel.
-    fn run(
-        self: Box<Self>,
-        control_receiver: mpsc::Receiver<SourceEvent>,
-        init_receiver: oneshot::Receiver<i32>,
-        init_validation_sender: oneshot::Sender<Result<(), MetricSourceError>>,
-        init_timeout: Duration,
-    ) -> SourceWorkerHandle;
+    /// Initialize the source with the profiled program's pid.
+    ///
+    /// Must be awaited (and completed) before [`MetricSource::run`] is called.
+    fn init(
+        &mut self,
+        pid: i32,
+    ) -> Pin<Box<dyn Future<Output = Result<(), MetricSourceError>> + Send + '_>>;
+
+    /// Spawn the source worker and return its handle.
+    fn run(self: Box<Self>, control_receiver: mpsc::Receiver<SourceEvent>) -> SourceWorkerHandle;
 
     /// List sensors exposed by this source.
     fn list_sensors(&self) -> Result<Sensors, MetricSourceError>;
-}
-
-impl<R> MetricSource for MetricSourceRuntime<R>
-where
-    R: MetricReader,
-{
-    /// Runs the worker task and returns its handle and the sender, used to send events to manage the metric source.
-    ///
-    /// The metric source is consumed and transformed into a [`MetricSourceRuntime`] with the metric source as a reader.
-    /// This transformation allows to monomorphize the metric source and discover its type after its launch.
-    fn run(
-        self: Box<Self>,
-        control_receiver: mpsc::Receiver<SourceEvent>,
-        init_receiver: oneshot::Receiver<i32>,
-        init_validation_sender: oneshot::Sender<Result<(), MetricSourceError>>,
-        init_timeout: Duration,
-    ) -> SourceWorkerHandle {
-        tokio::spawn(async move {
-            self.run_worker(
-                control_receiver,
-                init_receiver,
-                init_validation_sender,
-                init_timeout,
-            )
-            .await
-        })
-    }
-
-    /// List the sensors of the metric source.
-    fn list_sensors(&self) -> Result<Sensors, MetricSourceError> {
-        self.get_source_sensors()
-    }
-}
-
-/// Converts a [`MetricReader`] into a boxed [`MetricSource`].
-impl<R> From<R> for Box<dyn MetricSource>
-where
-    R: MetricReader,
-{
-    fn from(reader: R) -> Self {
-        let source = MetricSourceRuntime::new(reader);
-        Box::new(source)
-    }
 }

--- a/core/src/source/mod.rs
+++ b/core/src/source/mod.rs
@@ -31,12 +31,11 @@ pub(crate) trait MetricSource: Send {
     /// Spawn the source worker and return its handle, control channel and initialization channel.
     fn run(
         self: Box<Self>,
+        control_receiver: mpsc::Receiver<SourceEvent>,
+        init_receiver: oneshot::Receiver<i32>,
+        init_validation_sender: oneshot::Sender<Result<(), MetricSourceError>>,
         init_timeout: Duration,
-    ) -> (
-        SourceWorkerHandle,
-        mpsc::Sender<SourceEvent>,
-        oneshot::Sender<i32>,
-    );
+    ) -> SourceWorkerHandle;
 
     /// List sensors exposed by this source.
     fn list_sensors(&self) -> Result<Sensors, MetricSourceError>;
@@ -52,19 +51,20 @@ where
     /// This transformation allows to monomorphize the metric source and discover its type after its launch.
     fn run(
         self: Box<Self>,
+        control_receiver: mpsc::Receiver<SourceEvent>,
+        init_receiver: oneshot::Receiver<i32>,
+        init_validation_sender: oneshot::Sender<Result<(), MetricSourceError>>,
         init_timeout: Duration,
-    ) -> (
-        SourceWorkerHandle,
-        mpsc::Sender<SourceEvent>,
-        oneshot::Sender<i32>,
-    ) {
-        let (control_sender, control_receiver) = mpsc::channel(4);
-        let (init_sender, init_receiver) = oneshot::channel();
-        let handle = tokio::spawn(async move {
-            self.run_worker(control_receiver, init_receiver, init_timeout)
-                .await
-        });
-        (handle, control_sender, init_sender)
+    ) -> SourceWorkerHandle {
+        tokio::spawn(async move {
+            self.run_worker(
+                control_receiver,
+                init_receiver,
+                init_validation_sender,
+                init_timeout,
+            )
+            .await
+        })
     }
 
     /// List the sensors of the metric source.

--- a/core/src/source/runtime.rs
+++ b/core/src/source/runtime.rs
@@ -39,6 +39,7 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
         mut self,
         mut receiver: mpsc::Receiver<SourceEvent>,
         init_receiver: oneshot::Receiver<i32>,
+        init_validation_sender: oneshot::Sender<Result<(), MetricSourceError>>,
         init_timeout: Duration,
     ) -> Result<(SensorResult, Box<dyn MetricSource>), MetricSourceError> {
         let pid = timeout(init_timeout, init_receiver)
@@ -46,7 +47,7 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
             .map_err(IntoMetricSourceError::into_metric_source_error)?
             .map_err(|_| MetricSourceError::InitTimeout(init_timeout))?;
 
-        self.init_source(pid).await?;
+        let _ = init_validation_sender.send(self.init_source(pid).await);
 
         loop {
             if let Some(event) = receiver.recv().await {
@@ -213,12 +214,13 @@ mod tests {
         let (reader, counts) = mock_reader_counted();
         let rt = MetricSourceRuntime::new(reader);
         let (tx, rx) = mpsc::channel(16);
+        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        rt.run_worker(rx, pid(0), Duration::from_secs(1))
+        rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
             .await
             .unwrap();
 
@@ -230,9 +232,10 @@ mod tests {
         let (reader, counts) = mock_reader_counted();
         let rt = MetricSourceRuntime::new(reader);
         let (tx, rx) = mpsc::channel(16);
+        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::JoinWorker).await.unwrap();
-        rt.run_worker(rx, pid(42), Duration::from_secs(1))
+        rt.run_worker(rx, pid(42), init_validation_sender, Duration::from_secs(1))
             .await
             .unwrap();
 
@@ -248,12 +251,13 @@ mod tests {
             .returning(|| Err(MockError("injected".into())));
         let rt = MetricSourceRuntime::new(reader);
         let (tx, rx) = mpsc::channel(16);
+        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
         assert!(
-            rt.run_worker(rx, pid(0), Duration::from_secs(1))
+            rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
                 .await
                 .is_err()
         );
@@ -264,11 +268,12 @@ mod tests {
         let (reader, counts) = mock_reader_counted();
         let rt = MetricSourceRuntime::new(reader);
         let (tx, rx) = mpsc::channel(16);
+        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::NewPhase).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        rt.run_worker(rx, pid(0), Duration::from_secs(1))
+        rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
             .await
             .unwrap();
 
@@ -280,9 +285,10 @@ mod tests {
         let (reader, counts) = mock_reader_counted();
         let rt = MetricSourceRuntime::new(reader);
         let (tx, rx) = mpsc::channel(16);
+        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::JoinWorker).await.unwrap();
-        rt.run_worker(rx, pid(0), Duration::from_secs(1))
+        rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
             .await
             .unwrap();
 
@@ -294,6 +300,7 @@ mod tests {
         let (reader, counts) = mock_reader_counted();
         let rt = MetricSourceRuntime::new(reader);
         let (tx, rx) = mpsc::channel(16);
+        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::Measure).await.unwrap();
@@ -301,7 +308,7 @@ mod tests {
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
         assert!(
-            rt.run_worker(rx, pid(0), Duration::from_secs(1))
+            rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
                 .await
                 .is_ok()
         );

--- a/core/src/source/runtime.rs
+++ b/core/src/source/runtime.rs
@@ -1,17 +1,16 @@
-use std::time::Duration;
+use std::pin::Pin;
 
 use log::debug;
-use tokio::{
-    sync::{mpsc, oneshot},
-    time::timeout,
-};
+use tokio::sync::mpsc;
 
 use crate::{
     aggregate::{phase::SensorPhase, sensor_result::SensorResult},
     sensor::Sensors,
     source::{
-        MetricReader, MetricSource, MetricSourceError, accumulator::MetricAccumulator,
-        error::IntoMetricSourceError, types::SourceEvent,
+        MetricReader, MetricSource, MetricSourceError,
+        accumulator::MetricAccumulator,
+        error::IntoMetricSourceError,
+        types::{SourceEvent, SourceWorkerHandle},
     },
 };
 
@@ -35,20 +34,11 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
     /// Runs the worker responsible for source and accumulator management.
     ///
     /// It listens for events through a channel and execute them.
-    pub async fn run_worker(
+    /// The source must already be initialized (see [`MetricSource::init`]).
+    pub(crate) async fn run_worker(
         mut self,
         mut receiver: mpsc::Receiver<SourceEvent>,
-        init_receiver: oneshot::Receiver<i32>,
-        init_validation_sender: oneshot::Sender<Result<(), MetricSourceError>>,
-        init_timeout: Duration,
     ) -> Result<(SensorResult, Box<dyn MetricSource>), MetricSourceError> {
-        let pid = timeout(init_timeout, init_receiver)
-            .await
-            .map_err(IntoMetricSourceError::into_metric_source_error)?
-            .map_err(|_| MetricSourceError::InitTimeout(init_timeout))?;
-
-        let _ = init_validation_sender.send(self.init_source(pid).await);
-
         loop {
             if let Some(event) = receiver.recv().await {
                 match event {
@@ -73,15 +63,6 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
     async fn measure_source(&mut self) -> Result<(), MetricSourceError> {
         self.source
             .measure()
-            .await
-            .map_err(IntoMetricSourceError::into_metric_source_error)
-    }
-
-    /// Init the source with the profiled program pid.
-    #[inline]
-    async fn init_source(&mut self, pid: i32) -> Result<(), MetricSourceError> {
-        self.source
-            .init(pid)
             .await
             .map_err(IntoMetricSourceError::into_metric_source_error)
     }
@@ -116,13 +97,49 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
             .collect::<Result<Vec<_>, MetricSourceError>>()?;
         Ok(SensorResult { phases: result })
     }
+}
 
-    /// Retrieve source sensors.
-    #[inline]
-    pub fn get_source_sensors(&self) -> Result<Sensors, MetricSourceError> {
+impl<R> MetricSource for MetricSourceRuntime<R>
+where
+    R: MetricReader,
+{
+    /// Initializes the source with the profiled program's pid.
+    fn init(
+        &mut self,
+        pid: i32,
+    ) -> Pin<Box<dyn Future<Output = Result<(), MetricSourceError>> + Send + '_>> {
+        Box::pin(async move {
+            self.source
+                .init(pid)
+                .await
+                .map_err(IntoMetricSourceError::into_metric_source_error)
+        })
+    }
+
+    /// Spawns the worker task and returns its handle, used to send events to manage the metric source.
+    ///
+    /// The metric source is consumed and transformed into a [`MetricSourceRuntime`] with the metric source as a reader.
+    /// This transformation allows to monomorphize the metric source and discover its type after its launch.
+    fn run(self: Box<Self>, control_receiver: mpsc::Receiver<SourceEvent>) -> SourceWorkerHandle {
+        tokio::spawn(async move { self.run_worker(control_receiver).await })
+    }
+
+    /// List the sensors of the metric source.
+    fn list_sensors(&self) -> Result<Sensors, MetricSourceError> {
         self.source
             .get_sensors()
             .map_err(IntoMetricSourceError::into_metric_source_error)
+    }
+}
+
+/// Converts a [`MetricReader`] into a boxed [`MetricSource`].
+impl<R> From<R> for Box<dyn MetricSource>
+where
+    R: MetricReader,
+{
+    fn from(reader: R) -> Self {
+        let source = MetricSourceRuntime::new(reader);
+        Box::new(source)
     }
 }
 
@@ -159,12 +176,6 @@ mod tests {
             fn to_metrics(&self, v: ()) -> Result<Metrics, MockError>;
             fn get_name() -> &'static str;
         }
-    }
-
-    fn pid(p: i32) -> oneshot::Receiver<i32> {
-        let (tx, rx) = oneshot::channel();
-        tx.send(p).unwrap();
-        rx
     }
 
     #[derive(Debug, Default)]
@@ -212,32 +223,25 @@ mod tests {
     #[tokio::test]
     async fn run_worker_measure_event_calls_measure() {
         let (reader, counts) = mock_reader_counted();
-        let rt = MetricSourceRuntime::new(reader);
+        let mut rt = MetricSourceRuntime::new(reader);
+        rt.init(0).await.unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
-            .await
-            .unwrap();
+        rt.run_worker(rx).await.unwrap();
 
         assert_eq!(counts.lock().unwrap().measure, 2);
     }
 
     #[tokio::test]
-    async fn run_worker_init_event_passes_pid() {
+    async fn init_source_passes_pid() {
         let (reader, counts) = mock_reader_counted();
-        let rt = MetricSourceRuntime::new(reader);
-        let (tx, rx) = mpsc::channel(16);
-        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
+        let mut rt = MetricSourceRuntime::new(reader);
 
-        tx.send(SourceEvent::JoinWorker).await.unwrap();
-        rt.run_worker(rx, pid(42), init_validation_sender, Duration::from_secs(1))
-            .await
-            .unwrap();
+        rt.init(42).await.unwrap();
 
         assert_eq!(counts.lock().unwrap().init, 1);
     }
@@ -249,33 +253,27 @@ mod tests {
         reader
             .expect_measure()
             .returning(|| Err(MockError("injected".into())));
-        let rt = MetricSourceRuntime::new(reader);
+        let mut rt = MetricSourceRuntime::new(reader);
+        rt.init(0).await.unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        assert!(
-            rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
-                .await
-                .is_err()
-        );
+        assert!(rt.run_worker(rx).await.is_err());
     }
 
     #[tokio::test]
     async fn run_worker_new_phase_calls_retrieve() {
         let (reader, counts) = mock_reader_counted();
-        let rt = MetricSourceRuntime::new(reader);
+        let mut rt = MetricSourceRuntime::new(reader);
+        rt.init(0).await.unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::NewPhase).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
-            .await
-            .unwrap();
+        rt.run_worker(rx).await.unwrap();
 
         assert_eq!(counts.lock().unwrap().retrieve, 1);
     }
@@ -283,14 +281,12 @@ mod tests {
     #[tokio::test]
     async fn run_worker_join_calls_join_on_source() {
         let (reader, counts) = mock_reader_counted();
-        let rt = MetricSourceRuntime::new(reader);
+        let mut rt = MetricSourceRuntime::new(reader);
+        rt.init(0).await.unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::JoinWorker).await.unwrap();
-        rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
-            .await
-            .unwrap();
+        rt.run_worker(rx).await.unwrap();
 
         assert_eq!(counts.lock().unwrap().join, 1);
     }
@@ -298,20 +294,16 @@ mod tests {
     #[tokio::test]
     async fn run_worker_full_lifecycle() {
         let (reader, counts) = mock_reader_counted();
-        let rt = MetricSourceRuntime::new(reader);
+        let mut rt = MetricSourceRuntime::new(reader);
+        rt.init(0).await.unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let (init_validation_sender, _init_validation_receiver) = oneshot::channel();
 
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::Measure).await.unwrap();
         tx.send(SourceEvent::NewPhase).await.unwrap();
         tx.send(SourceEvent::JoinWorker).await.unwrap();
 
-        assert!(
-            rt.run_worker(rx, pid(0), init_validation_sender, Duration::from_secs(1))
-                .await
-                .is_ok()
-        );
+        assert!(rt.run_worker(rx).await.is_ok());
 
         let c = counts.lock().unwrap();
         assert_eq!(c.measure, 2);


### PR DESCRIPTION
## Description

This pull request adds documentation to the measure method on the orchestrator. It is mandatory to document that the measure event does not ensure that the measurement is really made instantly.
After some benchmarks, the time taken between the sending of the event and the actual measurement is of around 50 microseconds, it can be less or more depending on the hardware and also the number of sources running. Also, the CPU frequency might be a factor of reactiveness like the stdout printing delay which depends on the workload.

For now the architecture is of a fire and forget type to have the lowest overhead. Later, with the refactoring of Joule Profiler and the constant export of metrics, having the timestamp of the measurement would fix entirely this bug by providing the delay between the moment the measurement should have been made and the moment it has been.

This pull request also adds an initialization validation mechanism that waits for each source to be initialized before resuming the process.

An option to return acks from events could be added but would introduce an overhead that is not valuable.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Improvement
* [x] Documentation

## Related Issues

The issue related is #45.

## Changes Made

* Documented orchestrator measure method to indicate that a measure event does not ensure measurement completion.
* Refactored orchestrator for more idiomatic code
* Added an initialization validation mechanism

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass
