### PR TITLE
Feat/22 AMD SMI source

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ joule-profiler-source-nvml = { path = "../sources/nvml", version = "1.0.2" }
 joule-profiler-source-perf_event = { path = "../sources/perf_event", version = "1.0.2" }
 joule-profiler-source-procfs = { path = "../sources/procfs", version = "0.1.0" }
 joule-profiler-source-cgroup = { path = "../sources/cgroup", version = "0.1.0" }
+joule-profiler-source-amdsmi = { path = "../sources/amdsmi", version = "0.1.0" }
 
 joule-profiler-core.workspace = true
 log.workspace = true

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -8,7 +8,7 @@ use joule_profiler_cli::{
 use joule_profiler_core::JouleProfiler;
 use joule_profiler_core::config::{Command, Config};
 use joule_profiler_source_cgroup::{CgroupConfig, CgroupSource};
-use joule_profiler_source_amdsmi::AmdSmiSource;
+use joule_profiler_source_amdsmi::AmdSmi;
 use joule_profiler_source_amdsmi::config::AmdSmiConfig;
 use joule_profiler_source_nvml::Nvml;
 use joule_profiler_source_nvml::config::NvmlConfig;
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
     }
 
     if cli.sources.contains(&Source::AmdSmi) {
-        match AmdSmiSource::new(AmdSmiConfig {
+        match AmdSmi::new(AmdSmiConfig {
             poll_interval: Some(Duration::from_millis(1)),
             ..Default::default()
         }) {

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -69,7 +69,10 @@ async fn main() -> Result<()> {
     }
 
     if cli.sources.contains(&Source::AmdSmi) {
-        match AmdSmiSource::new(AmdSmiConfig { poll_interval: Some(Duration::from_millis(1)) }) {
+        match AmdSmiSource::new(AmdSmiConfig {
+            poll_interval: Some(Duration::from_millis(1)),
+            ..Default::default()
+        }) {
             Ok(amdsmi) => {
                 trace!("Using AMD SMI for AMD GPU profiling");
                 profiler.add_source(amdsmi);

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use joule_profiler_cli::{
     CliArgs, ProfilerCommand, RaplBackend, Source, init_logging, output_format_to_displayer,
@@ -6,6 +8,8 @@ use joule_profiler_cli::{
 use joule_profiler_core::JouleProfiler;
 use joule_profiler_core::config::{Command, Config};
 use joule_profiler_source_cgroup::{CgroupConfig, CgroupSource};
+use joule_profiler_source_amdsmi::AmdSmiSource;
+use joule_profiler_source_amdsmi::config::AmdSmiConfig;
 use joule_profiler_source_nvml::Nvml;
 use joule_profiler_source_nvml::config::NvmlConfig;
 use joule_profiler_source_perf_event::PerfEvent;
@@ -59,6 +63,16 @@ async fn main() -> Result<()> {
             Ok(nvml) => {
                 trace!("Using NVML for Nvidia GPU profiling");
                 profiler.add_source(nvml);
+            }
+            Err(err) => warn!("{err}"),
+        }
+    }
+
+    if cli.sources.contains(&Source::AmdSmi) {
+        match AmdSmiSource::new(AmdSmiConfig { poll_interval: Some(Duration::from_millis(1)) }) {
+            Ok(amdsmi) => {
+                trace!("Using AMD SMI for AMD GPU profiling");
+                profiler.add_source(amdsmi);
             }
             Err(err) => warn!("{err}"),
         }

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::Result;
 use joule_profiler_cli::{
     CliArgs, ProfilerCommand, RaplBackend, Source, init_logging, output_format_to_displayer,
@@ -69,10 +67,7 @@ async fn main() -> Result<()> {
     }
 
     if cli.sources.contains(&Source::AmdSmi) {
-        match AmdSmi::new(AmdSmiConfig {
-            poll_interval: Some(Duration::from_millis(1)),
-            ..Default::default()
-        }) {
+        match AmdSmi::new(AmdSmiConfig::default()) {
             Ok(amdsmi) => {
                 trace!("Using AMD SMI for AMD GPU profiling");
                 profiler.add_source(amdsmi);

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -7,9 +7,9 @@ use joule_profiler_cli::{
 };
 use joule_profiler_core::JouleProfiler;
 use joule_profiler_core::config::{Command, Config};
-use joule_profiler_source_cgroup::{CgroupConfig, CgroupSource};
 use joule_profiler_source_amdsmi::AmdSmi;
 use joule_profiler_source_amdsmi::config::AmdSmiConfig;
+use joule_profiler_source_cgroup::{CgroupConfig, CgroupSource};
 use joule_profiler_source_nvml::Nvml;
 use joule_profiler_source_nvml::config::NvmlConfig;
 use joule_profiler_source_perf_event::PerfEvent;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -120,7 +120,7 @@ impl TryFrom<CliArgs> for Config {
 pub enum Source {
     Rapl,
     Nvml,
-    #[value(alias = "amdsmi")]
+    #[value(name = "amdsmi")]
     AmdSmi,
     #[value(alias = "perf_event")]
     Perf,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -133,7 +133,7 @@ impl std::fmt::Display for Source {
         let s = match self {
             Source::Rapl => "rapl",
             Source::Nvml => "nvml",
-            Self::AmdSmi => "amdsmi",
+            Source::AmdSmi => "amdsmi",
             Source::Perf => "perf | perf_event",
             Source::Procfs => "procfs",
             Source::Cgroup => "cgroup",

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -120,6 +120,8 @@ impl TryFrom<CliArgs> for Config {
 pub enum Source {
     Rapl,
     Nvml,
+    #[value(alias = "amdsmi")]
+    AmdSmi,
     #[value(alias = "perf_event")]
     Perf,
     Procfs,
@@ -131,6 +133,7 @@ impl std::fmt::Display for Source {
         let s = match self {
             Source::Rapl => "rapl",
             Source::Nvml => "nvml",
+            Self::AmdSmi => "amdsmi",
             Source::Perf => "perf | perf_event",
             Source::Procfs => "procfs",
             Source::Cgroup => "cgroup",

--- a/sources/amdsmi/Cargo.toml
+++ b/sources/amdsmi/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "joule-profiler-source-amdsmi"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "AMD AMI GPU energy measurement source for joule-profiler"
+keywords = ["energy", "amdsmi", "AMD", "GPU", "hardware"]
+readme = "README.md"
+
+[dependencies]
+joule-profiler-core.workspace = true
+log.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+futures.workspace = true
+amdsmi = { path = "../../../amdsmi-wrapper/amdsmi" }
+tokio-timerfd = "0.2.0"
+tokio-util = "0.7.18"
+bitflags = "2.11.1"
+
+[lints]
+workspace = true

--- a/sources/amdsmi/Cargo.toml
+++ b/sources/amdsmi/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "AMD AMI GPU energy measurement source for joule-profiler"
+description = "AMD GPU source for joule-profiler"
 keywords = ["energy", "amdsmi", "AMD", "GPU", "hardware"]
 readme = "README.md"
 

--- a/sources/amdsmi/Cargo.toml
+++ b/sources/amdsmi/Cargo.toml
@@ -15,7 +15,8 @@ log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 futures.workspace = true
-amdsmi = { path = "../../../amdsmi-wrapper/amdsmi" }
+
+amdsmi = { git = "https://github.com/joule-profiler/amd-smi-wrapper", version = "0.1.0" }
 tokio-timerfd = "0.2.0"
 tokio-util = "0.7.18"
 bitflags = "2.11.1"

--- a/sources/amdsmi/Cargo.toml
+++ b/sources/amdsmi/Cargo.toml
@@ -20,5 +20,9 @@ tokio-timerfd = "0.2.0"
 tokio-util = "0.7.18"
 bitflags = "2.11.1"
 
+[dev-dependencies]
+tokio.workspace = true
+mockall.workspace = true
+
 [lints]
 workspace = true

--- a/sources/amdsmi/README.md
+++ b/sources/amdsmi/README.md
@@ -1,0 +1,1 @@
+# Joule Profiler Source AMD SMI

--- a/sources/amdsmi/README.md
+++ b/sources/amdsmi/README.md
@@ -1,1 +1,36 @@
-# Joule Profiler Source AMD SMI
+# AMD SMI metric source
+
+AMD SMI metric source for [Joule Profiler](https://github.com/joule-profiler/joule-profiler).
+
+This crate implements `MetricSource` from `joule-profiler-core` and measures AMD GPU energy counters via the **AMD System Management Interface** library. It also tracks VRAM usage and GPU utilization at a fixed configurable polling interval.
+
+## What is AMD SMI?
+
+AMD SMI (System Management Interface) is the AMD library for monitoring and managing AMD GPU devices. It exposes some energy accumulation counters, instantaneous power draw, VRAM usage, and GPU utilization for the GPUs on the system.
+
+This source relies on the [amd-smi-wrapper](https://github.com/joule-profiler/amd-smi-wrapper) crate, a safe Rust wrapper around the AMD SMI C library with pre-generated bindings for the latest supported version.
+
+When a device supports direct energy accumulation registers, the source reads them directly. Otherwise it falls back to integrating instantaneous power samples using the trapezoidal rule.
+
+### Metrics
+
+| Metric | Unit | Description |
+|---|---|---|
+| `GPU-{uuid}-energy` | µJ | Energy consumed between two measurements |
+| `GPU-{uuid}-vram_min` | Bytes | Minimum VRAM usage observed during the interval |
+| `GPU-{uuid}-vram_max` | Bytes | Maximum VRAM usage observed during the interval |
+| `GPU-{uuid}-utilization_min` | % | Minimum GPU utilization observed during the interval |
+| `GPU-{uuid}-utilization_max` | % | Maximum GPU utilization observed during the interval |
+
+> Available metrics depend on device support. VRAM and utilization require a polling interval to be configured.
+
+## Requirements
+
+| | |
+|---|---|
+| Hardware | AMD GPU |
+| Library | `amd-smi-lib` |
+
+## Bindings
+
+The AMD SMI C library bindings are pre-generated for the latest supported version and distributed via [amd-smi-wrapper](https://github.com/joule-profiler/amd-smi-wrapper). If you need to target a different version of `amd-smi-lib`, you can regenerate them locally, see the wrapper repository for instructions.

--- a/sources/amdsmi/src/config.rs
+++ b/sources/amdsmi/src/config.rs
@@ -1,0 +1,7 @@
+use std::time::Duration;
+
+#[derive(Debug, Default)]
+pub struct AmdSmiConfig {
+    /// Optional background polling interval.
+    pub poll_interval: Option<Duration>,
+}

--- a/sources/amdsmi/src/config.rs
+++ b/sources/amdsmi/src/config.rs
@@ -1,7 +1,12 @@
 use std::time::Duration;
 
+use crate::UUID;
+
 #[derive(Debug, Default)]
 pub struct AmdSmiConfig {
     /// Optional background polling interval.
     pub poll_interval: Option<Duration>,
+
+    /// Optional gpus filter.
+    pub gpus_spec: Option<Vec<UUID>>,
 }

--- a/sources/amdsmi/src/config.rs
+++ b/sources/amdsmi/src/config.rs
@@ -1,12 +1,13 @@
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use crate::UUID;
 
+/// Configuration of the AMD SMI source.
 #[derive(Debug, Default)]
 pub struct AmdSmiConfig {
     /// Optional background polling interval.
     pub poll_interval: Option<Duration>,
 
     /// Optional gpus filter.
-    pub gpus_spec: Option<Vec<UUID>>,
+    pub gpus_spec: Option<HashSet<UUID>>,
 }

--- a/sources/amdsmi/src/config.rs
+++ b/sources/amdsmi/src/config.rs
@@ -3,11 +3,20 @@ use std::{collections::HashSet, time::Duration};
 use crate::UUID;
 
 /// Configuration of the AMD SMI source.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AmdSmiConfig {
     /// Optional background polling interval.
     pub poll_interval: Option<Duration>,
 
     /// Optional gpus filter.
     pub gpus_spec: Option<HashSet<UUID>>,
+}
+
+impl Default for AmdSmiConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Some(Duration::from_millis(20)),
+            gpus_spec: None,
+        }
+    }
 }

--- a/sources/amdsmi/src/counters.rs
+++ b/sources/amdsmi/src/counters.rs
@@ -1,0 +1,111 @@
+use amdsmi::types::EnergyCount;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EnergyCounter {
+    begin: Option<EnergyCount>,
+    end: Option<EnergyCount>,
+}
+
+impl EnergyCounter {
+    pub fn update(&mut self, value: EnergyCount) {
+        if self.begin.is_none() {
+            self.begin = Some(value);
+        } else {
+            self.end = Some(value);
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.begin = self.end;
+    }
+
+    pub fn diff(&self) -> Option<u64> {
+        if let Some(begin) = &self.begin
+            && let Some(end) = &self.end
+        {
+            let energy = ((end.energy_accumulator as f64 * f64::from(end.counter_resolution))
+                as u64)
+                .saturating_sub(
+                    (begin.energy_accumulator as f64 * f64::from(begin.counter_resolution)) as u64,
+                );
+            Some(energy)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<EnergyCount> for EnergyCounter {
+    fn from(value: EnergyCount) -> Self {
+        Self {
+            begin: Some(value),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct VramCounter {
+    pub min: Option<u64>,
+    pub max: Option<u64>,
+}
+
+impl VramCounter {
+    pub fn update(&mut self, value: u64) {
+        self.min = Some(if let Some(min) = self.min {
+            min.min(value)
+        } else {
+            value
+        });
+
+        self.max = Some(if let Some(max) = self.max {
+            max.max(value)
+        } else {
+            value
+        });
+    }
+
+    pub fn reset(&mut self) {
+        self.min = None;
+        self.max = None;
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct PowerMeasurement {
+    pub timestamp: u128,
+    pub power: u32,
+}
+
+#[derive(Default, Clone)]
+pub struct PowerCounter(Vec<PowerMeasurement>);
+
+impl PowerCounter {
+    pub fn update(&mut self, value: PowerMeasurement) {
+        self.0.push(value);
+    }
+
+    pub fn reset(&mut self) {
+        self.0 = Vec::new();
+    }
+
+    pub fn compute_energy(&self) -> u64 {
+        let mut energy: u64 = 0;
+        for power in self.0.windows(2) {
+            let p1 = power[0];
+            let p2 = power[1];
+            let duration_us = (p2.timestamp - p1.timestamp) as u64;
+
+            let avg_power = u64::from(p1.power.midpoint(p2.power));
+            energy += avg_power * duration_us;
+        }
+        energy
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct Counter {
+    pub energy: Option<EnergyCounter>,
+    pub vram: Option<VramCounter>,
+    pub power: Option<PowerCounter>,
+}

--- a/sources/amdsmi/src/counters.rs
+++ b/sources/amdsmi/src/counters.rs
@@ -31,7 +31,9 @@ impl EnergyCounter {
     /// Returns `None` if either measurement is missing.
     pub fn diff(&self) -> Option<u64> {
         match (self.begin, self.end) {
-            (Some(begin), Some(end)) => Some(energy(&end).saturating_sub(energy(&begin))),
+            (Some(begin), Some(end)) => {
+                Some(compute_energy(&end).saturating_sub(compute_energy(&begin)))
+            }
             _ => None,
         }
     }
@@ -176,6 +178,6 @@ pub struct Counter {
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
 )]
-fn energy(count: &EnergyCount) -> u64 {
+fn compute_energy(count: &EnergyCount) -> u64 {
     (count.energy_accumulator as f64 * f64::from(count.counter_resolution)) as u64
 }

--- a/sources/amdsmi/src/counters.rs
+++ b/sources/amdsmi/src/counters.rs
@@ -122,6 +122,39 @@ impl PowerCounter {
     }
 }
 
+/// Tracks the minimum and maximum GPU usage observed during a measurement interval.
+#[derive(Default, Clone, Copy)]
+pub struct UtilizationCounter {
+    /// Lowest GPU usage observed.
+    pub min: Option<u32>,
+
+    /// Highest GPU usage observed.
+    pub max: Option<u32>,
+}
+
+impl UtilizationCounter {
+    /// Updates the tracked minimum and maximum GPU usage values.
+    pub fn update(&mut self, value: u32) {
+        self.min = Some(if let Some(min) = self.min {
+            min.min(value)
+        } else {
+            value
+        });
+
+        self.max = Some(if let Some(max) = self.max {
+            max.max(value)
+        } else {
+            value
+        });
+    }
+
+    /// Resets the VRAM usage counters.
+    pub fn reset(&mut self) {
+        self.min = None;
+        self.max = None;
+    }
+}
+
 /// Available measurement counters for a device.
 #[derive(Default, Clone)]
 pub struct Counter {
@@ -133,6 +166,9 @@ pub struct Counter {
 
     /// Power draw samples.
     pub power: Option<PowerCounter>,
+
+    /// GPU usage counter.
+    pub utilization: Option<UtilizationCounter>,
 }
 
 #[allow(

--- a/sources/amdsmi/src/counters.rs
+++ b/sources/amdsmi/src/counters.rs
@@ -1,5 +1,6 @@
 use amdsmi::types::EnergyCount;
 
+/// Energy counter based on cumulative energy readings reported by AMD SMI.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct EnergyCounter {
     begin: Option<EnergyCount>,
@@ -7,6 +8,10 @@ pub struct EnergyCounter {
 }
 
 impl EnergyCounter {
+    /// Records an energy measurement.
+    ///
+    /// The first value becomes the starting measurement. Subsequent values
+    /// replace the ending measurement.
     pub fn update(&mut self, value: EnergyCount) {
         if self.begin.is_none() {
             self.begin = Some(value);
@@ -15,10 +20,15 @@ impl EnergyCounter {
         }
     }
 
+    /// Resets the counter by replacing begin by end.
     pub fn reset(&mut self) {
         self.begin = self.end;
     }
 
+    /// Returns the energy consumed between the starting and ending
+    /// measurements.
+    ///
+    /// Returns `None` if either measurement is missing.
     pub fn diff(&self) -> Option<u64> {
         if let Some(begin) = &self.begin
             && let Some(end) = &self.end
@@ -39,18 +49,23 @@ impl From<EnergyCount> for EnergyCounter {
     fn from(value: EnergyCount) -> Self {
         Self {
             begin: Some(value),
-            ..Default::default()
+            end: None,
         }
     }
 }
 
+/// Tracks the minimum and maximum VRAM usage observed during a measurement interval.
 #[derive(Default, Clone, Copy)]
 pub struct VramCounter {
+    /// Lowest VRAM usage observed.
     pub min: Option<u64>,
+
+    /// Highest VRAM usage observed.
     pub max: Option<u64>,
 }
 
 impl VramCounter {
+    /// Updates the tracked minimum and maximum VRAM usage values.
     pub fn update(&mut self, value: u64) {
         self.min = Some(if let Some(min) = self.min {
             min.min(value)
@@ -65,30 +80,42 @@ impl VramCounter {
         });
     }
 
+    /// Resets the VRAM usage counters.
     pub fn reset(&mut self) {
         self.min = None;
         self.max = None;
     }
 }
 
+/// Instantaneous power measurement.
 #[derive(Clone, Copy)]
 pub struct PowerMeasurement {
+    /// Timestamp in microseconds.
     pub timestamp: u128,
+
+    /// Power draw in Watts.
     pub power: u32,
 }
 
+/// Collection of power samples used to estimate energy consumption based on power draws.
 #[derive(Default, Clone)]
 pub struct PowerCounter(Vec<PowerMeasurement>);
 
 impl PowerCounter {
-    pub fn update(&mut self, value: PowerMeasurement) {
+    /// Appends a power measurement.
+    pub fn push(&mut self, value: PowerMeasurement) {
         self.0.push(value);
     }
 
+    /// Removes all stored samples.
     pub fn reset(&mut self) {
         self.0 = Vec::new();
     }
 
+    /// Estimates the consumed energy by integrating power samples using
+    /// the trapezoidal rule (average power over each interval).
+    ///
+    /// The returned value is expressed in microjoules (µJ)
     pub fn compute_energy(&self) -> u64 {
         let mut energy: u64 = 0;
         for power in self.0.windows(2) {
@@ -103,9 +130,15 @@ impl PowerCounter {
     }
 }
 
+/// Available measurement counters for a device.
 #[derive(Default, Clone)]
 pub struct Counter {
+    /// Energy counter based on hardware energy accumulation registers.
     pub energy: Option<EnergyCounter>,
+
+    /// VRAM usage statistics.
     pub vram: Option<VramCounter>,
+
+    /// Power draw samples.
     pub power: Option<PowerCounter>,
 }

--- a/sources/amdsmi/src/counters.rs
+++ b/sources/amdsmi/src/counters.rs
@@ -30,17 +30,9 @@ impl EnergyCounter {
     ///
     /// Returns `None` if either measurement is missing.
     pub fn diff(&self) -> Option<u64> {
-        if let Some(begin) = &self.begin
-            && let Some(end) = &self.end
-        {
-            let energy = ((end.energy_accumulator as f64 * f64::from(end.counter_resolution))
-                as u64)
-                .saturating_sub(
-                    (begin.energy_accumulator as f64 * f64::from(begin.counter_resolution)) as u64,
-                );
-            Some(energy)
-        } else {
-            None
+        match (self.begin, self.end) {
+            (Some(begin), Some(end)) => Some(energy(&end).saturating_sub(energy(&begin))),
+            _ => None,
         }
     }
 }
@@ -121,7 +113,7 @@ impl PowerCounter {
         for power in self.0.windows(2) {
             let p1 = power[0];
             let p2 = power[1];
-            let duration_us = (p2.timestamp - p1.timestamp) as u64;
+            let duration_us = u64::try_from(p2.timestamp - p1.timestamp).unwrap_or(u64::MAX);
 
             let avg_power = u64::from(p1.power.midpoint(p2.power));
             energy += avg_power * duration_us;
@@ -141,4 +133,13 @@ pub struct Counter {
 
     /// Power draw samples.
     pub power: Option<PowerCounter>,
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn energy(count: &EnergyCount) -> u64 {
+    (count.energy_accumulator as f64 * f64::from(count.counter_resolution)) as u64
 }

--- a/sources/amdsmi/src/error.rs
+++ b/sources/amdsmi/src/error.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+use tokio::task::JoinError;
+
+use crate::Processor;
+
+#[derive(Debug, Error)]
+pub enum AmdSmiError {
+    #[error("Device {0:?} not found.")]
+    NoSuchDevice(Processor),
+
+    #[error("Device with index {0} not found.")]
+    NoSuchDeviceFromIndex(usize),
+
+    /// Generic I/O error.
+    #[error("I/O error")]
+    Io(
+        #[from]
+        #[source]
+        std::io::Error,
+    ),
+
+    /// Tokio task join error (async execution failure).
+    #[error("Failed to join tokio task: {0}")]
+    JoinError(
+        #[from]
+        #[source]
+        JoinError,
+    ),
+
+    #[error("AMD SMI error: {0}")]
+    AmdSmiError(#[from] amdsmi::error::AmdSmiError),
+}

--- a/sources/amdsmi/src/error.rs
+++ b/sources/amdsmi/src/error.rs
@@ -5,9 +5,11 @@ use crate::Processor;
 
 #[derive(Debug, Error)]
 pub enum AmdSmiError {
+    /// Unknown device.
     #[error("Device {0:?} not found.")]
     NoSuchDevice(Processor),
 
+    /// No device with that index found in the devices list.
     #[error("Device with index {0} not found.")]
     NoSuchDeviceFromIndex(usize),
 

--- a/sources/amdsmi/src/error.rs
+++ b/sources/amdsmi/src/error.rs
@@ -5,6 +5,18 @@ use crate::Processor;
 
 #[derive(Debug, Error)]
 pub enum AmdSmiError {
+    /// AMD SMI could not find or load the driver.
+    #[error(
+        "No driver found or loaded to access AMD SMI, check whether you have an AMD GPU or not."
+    )]
+    NoDriverLoaded,
+
+    /// Unable to find the AMD SMI library.
+    #[error(
+        "AMD SMI library not found, check whether amd-smi-lib is installed and if you have an AMD GPU device."
+    )]
+    LibraryNotFound,
+
     /// Unknown device.
     #[error("Device {0:?} not found.")]
     NoSuchDevice(Processor),
@@ -22,7 +34,7 @@ pub enum AmdSmiError {
     ),
 
     /// Tokio task join error (async execution failure).
-    #[error("Failed to join tokio task: {0}")]
+    #[error("Failed to join tokio task: {0}.")]
     JoinError(
         #[from]
         #[source]
@@ -30,6 +42,6 @@ pub enum AmdSmiError {
     ),
 
     /// AMD SMI library error.
-    #[error("AMD SMI error: {0}")]
+    #[error("AMD SMI error: {0}.")]
     AmdSmiError(#[from] amdsmi::error::AmdSmiError),
 }

--- a/sources/amdsmi/src/error.rs
+++ b/sources/amdsmi/src/error.rs
@@ -29,6 +29,7 @@ pub enum AmdSmiError {
         JoinError,
     ),
 
+    /// AMD SMI library error.
     #[error("AMD SMI error: {0}")]
     AmdSmiError(#[from] amdsmi::error::AmdSmiError),
 }

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -76,12 +76,13 @@ impl Hardware for AmdSmi {
 
                 if support.is_empty() {
                     trace!("No support detected for device {uuid}, ignored.");
+                    None
+                } else {
+                    Some(Processor {
+                        uuid: uuid.clone(),
+                        support,
+                    })
                 }
-
-                Ok::<Processor, AmdSmiError>(Processor {
-                    uuid: uuid.clone(),
-                    support,
-                })
             })
             .collect())
     }

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+
+use amdsmi::types::EnergyCount;
+use joule_profiler_core::time::get_timestamp_micros;
+use log::{debug, info, trace};
+
+use crate::{
+    Processor, ProcessorSupport, Result, UUID, counters::PowerMeasurement, error::AmdSmiError,
+};
+
+pub trait Hardware: Send + Sync + 'static {
+    fn get_processors(&self) -> Result<Vec<Processor>>;
+    fn get_energy_count(&self, processor: &Processor) -> Result<EnergyCount>;
+    fn get_power(&self, processor: &Processor) -> Result<PowerMeasurement>;
+    fn get_vram_usage(&self, processor: &Processor) -> Result<u64>;
+}
+
+pub struct AmdSmi {
+    processor_handles: HashMap<UUID, amdsmi::Processor>,
+}
+
+impl AmdSmi {
+    pub fn new() -> Result<Self> {
+        let amdsmi = amdsmi::AmdSmi::init()?;
+        let (major, minor, patch) = amdsmi.get_lib_version()?;
+
+        info!("amdsmi driver detected, version v{major}.{minor}.{patch}");
+
+        let sockets = amdsmi.get_socket_handles()?;
+
+        let processor_handles: HashMap<_, _> = sockets
+            .into_iter()
+            .flat_map(|s| {
+                debug!("Socket {} detected.", s.get_socket_info()?);
+                s.get_processor_handles()
+            })
+            .flatten()
+            .flat_map(|p| {
+                let board_info = p.get_board_info()?;
+                let uuid = p.get_uuid()?;
+                debug!("Discovered GPU device {board_info}, UUID: {uuid}.");
+                Ok::<(UUID, amdsmi::Processor), AmdSmiError>((uuid, p))
+            })
+            .collect();
+
+        debug!("Discovered {} gpus.", processor_handles.len());
+
+        Ok(Self { processor_handles })
+    }
+
+    fn get_device_handle(&self, processor: &Processor) -> Result<&amdsmi::Processor> {
+        self.processor_handles
+            .get(&processor.uuid)
+            .ok_or(AmdSmiError::NoSuchDevice(processor.clone()))
+    }
+}
+
+impl Hardware for AmdSmi {
+    fn get_processors(&self) -> Result<Vec<Processor>> {
+        Ok(self
+            .processor_handles
+            .iter()
+            .flat_map(|(uuid, handle)| {
+                let mut support = ProcessorSupport::empty();
+
+                if handle.get_energy_count().is_ok() {
+                    support |= ProcessorSupport::Energy;
+                } else if handle.get_power().is_ok() {
+                    support |= ProcessorSupport::Power;
+                }
+                if handle.get_vram_usage().is_ok() {
+                    support |= ProcessorSupport::Vram;
+                }
+
+                debug!("Device {uuid} compatibility: {support:?}");
+
+                if support.is_empty() {
+                    trace!("No support detected for device {uuid}, ignored.");
+                }
+
+                Ok::<Processor, AmdSmiError>(Processor {
+                    uuid: uuid.clone(),
+                    support,
+                })
+            })
+            .collect())
+    }
+
+    fn get_energy_count(&self, processor: &Processor) -> Result<EnergyCount> {
+        Ok(self.get_device_handle(processor)?.get_energy_count()?)
+    }
+
+    fn get_power(&self, processor: &Processor) -> Result<PowerMeasurement> {
+        Ok(PowerMeasurement {
+            timestamp: get_timestamp_micros(),
+            power: self.get_device_handle(processor)?.get_power()?,
+        })
+    }
+
+    fn get_vram_usage(&self, processor: &Processor) -> Result<u64> {
+        Ok(self.get_device_handle(processor)?.get_vram_usage()?)
+    }
+}

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -60,7 +60,7 @@ impl Hardware for AmdSmi {
         Ok(self
             .processor_handles
             .iter()
-            .flat_map(|(uuid, handle)| {
+            .filter_map(|(uuid, handle)| {
                 let mut support = ProcessorSupport::empty();
 
                 if handle.get_energy_count().is_ok() {

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use amdsmi::types::EnergyCount;
 use joule_profiler_core::time::get_timestamp_micros;
@@ -9,7 +9,7 @@ use crate::{
 };
 
 pub trait Hardware: Send + Sync + 'static {
-    fn get_processors(&self) -> Result<Vec<Processor>>;
+    fn get_processors(&self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>>;
     fn get_energy_count(&self, processor: &Processor) -> Result<EnergyCount>;
     fn get_power(&self, processor: &Processor) -> Result<PowerMeasurement>;
     fn get_vram_usage(&self, processor: &Processor) -> Result<u64>;
@@ -56,11 +56,18 @@ impl AmdSmi {
 }
 
 impl Hardware for AmdSmi {
-    fn get_processors(&self) -> Result<Vec<Processor>> {
+    fn get_processors(&self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>> {
         Ok(self
             .processor_handles
             .iter()
             .filter_map(|(uuid, handle)| {
+                if let Some(spec) = &spec
+                    && !spec.contains(uuid)
+                {
+                    trace!("Ignoring device {uuid}.");
+                    return None;
+                }
+
                 let mut support = ProcessorSupport::empty();
 
                 if handle.get_energy_count().is_ok() {

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use amdsmi::types::EnergyCount;
 use joule_profiler_core::time::get_timestamp_micros;
-use log::{debug, info, trace};
+use log::{debug, trace};
 
 use crate::{
     Processor, ProcessorSupport, Result, UUID, counters::PowerMeasurement, error::AmdSmiError,
@@ -24,21 +24,21 @@ impl AmdSmi {
         let amdsmi = amdsmi::AmdSmi::init()?;
         let (major, minor, patch) = amdsmi.get_lib_version()?;
 
-        info!("amdsmi driver detected, version v{major}.{minor}.{patch}");
+        debug!("AMD SMI driver detected, version v{major}.{minor}.{patch}");
 
         let sockets = amdsmi.get_socket_handles()?;
 
         let processor_handles: HashMap<_, _> = sockets
             .into_iter()
             .flat_map(|s| {
-                debug!("Socket {} detected.", s.get_socket_info()?);
+                trace!("Socket {} detected.", s.get_socket_info()?);
                 s.get_processor_handles()
             })
             .flatten()
             .flat_map(|p| {
                 let board_info = p.get_board_info()?;
                 let uuid = p.get_uuid()?;
-                debug!("Discovered GPU device {board_info}, UUID: {uuid}.");
+                trace!("Discovered GPU device {board_info}, UUID: {uuid}.");
                 Ok::<(UUID, amdsmi::Processor), AmdSmiError>((uuid, p))
             })
             .collect();

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Trait for abstracting the backend of AMD SMI library. Used for testing.
-pub trait Hardware: Send + Sync + 'static {
+pub trait AmdSmiHardware: Send + Sync + 'static {
     /// Init all GPU devices specicied by the provided specification.
     fn init_processors(&mut self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>>;
 
@@ -27,7 +27,7 @@ pub trait Hardware: Send + Sync + 'static {
 }
 
 /// Backend for interacting with AMD SMI library.
-pub struct AmdSmi {
+pub struct AmdSmiWrapperHardware {
     /// Handle to the AMD SMI wrapper library.
     amdsmi: amdsmi::AmdSmi,
 
@@ -35,9 +35,14 @@ pub struct AmdSmi {
     processor_handles: HashMap<UUID, amdsmi::Processor>,
 }
 
-impl AmdSmi {
+impl AmdSmiWrapperHardware {
     pub fn new() -> Result<Self> {
-        let amdsmi = amdsmi::AmdSmi::init()?;
+        let amdsmi = amdsmi::AmdSmi::init().map_err(|err| match err {
+            amdsmi::error::AmdSmiError::DriverNotLoaded => AmdSmiError::NoDriverLoaded,
+            amdsmi::error::AmdSmiError::LibraryNotFound => AmdSmiError::LibraryNotFound,
+            _ => err.into(),
+        })?;
+
         let (major, minor, patch) = amdsmi.get_lib_version()?;
 
         debug!("AMD SMI driver detected, version v{major}.{minor}.{patch}");
@@ -55,7 +60,7 @@ impl AmdSmi {
     }
 }
 
-impl Hardware for AmdSmi {
+impl AmdSmiHardware for AmdSmiWrapperHardware {
     fn init_processors(&mut self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>> {
         let sockets = self.amdsmi.get_socket_handles()?;
 

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use amdsmi::types::EnergyCount;
+use amdsmi::types::{EnergyCount, GpuUsageInfo};
 use joule_profiler_core::time::get_timestamp_micros;
 use log::{debug, trace};
 
@@ -21,6 +21,9 @@ pub trait Hardware: Send + Sync + 'static {
 
     /// Retrieve the current vram usage of a device.
     fn get_vram_usage(&self, processor: &Processor) -> Result<u64>;
+
+    /// Retrieve the current GPU utilization info.
+    fn get_gpu_activity(&self, processor: &Processor) -> Result<GpuUsageInfo>;
 }
 
 /// Backend for interacting with AMD SMI library.
@@ -84,6 +87,9 @@ impl Hardware for AmdSmi {
                 if p.get_vram_usage().is_ok() {
                     support |= ProcessorSupport::Vram;
                 }
+                if p.get_gpu_activity().is_ok() {
+                    support |= ProcessorSupport::Utilization;
+                }
 
                 debug!("Device {uuid} compatibility: {support:?}");
 
@@ -119,5 +125,9 @@ impl Hardware for AmdSmi {
 
     fn get_vram_usage(&self, processor: &Processor) -> Result<u64> {
         Ok(self.get_device_handle(processor)?.get_vram_usage()?)
+    }
+
+    fn get_gpu_activity(&self, processor: &Processor) -> Result<GpuUsageInfo> {
+        Ok(self.get_device_handle(processor)?.get_gpu_activity()?)
     }
 }

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -9,9 +9,12 @@ use crate::{
 };
 
 /// Trait for abstracting the backend of AMD SMI library. Used for testing.
+#[cfg_attr(test, mockall::automock)]
 pub trait AmdSmiHardware: Send + Sync + 'static {
     /// Init all GPU devices specicied by the provided specification.
-    fn init_processors(&mut self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>>;
+    // Automock needs lifetime and clippy wants it erased.
+    #[allow(clippy::needless_lifetimes)]
+    fn init_processors<'a>(&mut self, spec: Option<&'a HashSet<UUID>>) -> Result<Vec<Processor>>;
 
     /// Retrieve the energy count of a device.
     fn get_energy_count(&self, processor: &Processor) -> Result<EnergyCount>;
@@ -36,7 +39,13 @@ pub struct AmdSmiWrapperHardware {
 }
 
 impl AmdSmiWrapperHardware {
+    /// Creates a new AMD SMI hardware instance.
+    ///
+    /// This function will return an error if:
+    /// - The AMD SMI library cannot be initialized (driver not installed, incompatible version, etc.)
+    /// - The permissions are insufficient to be able to query the AMD SMI driver.
     pub fn new() -> Result<Self> {
+        debug!("Attempting to initialize AMD SMI reader");
         let amdsmi = amdsmi::AmdSmi::init().map_err(|err| match err {
             amdsmi::error::AmdSmiError::DriverNotLoaded => AmdSmiError::NoDriverLoaded,
             amdsmi::error::AmdSmiError::LibraryNotFound => AmdSmiError::LibraryNotFound,
@@ -44,7 +53,6 @@ impl AmdSmiWrapperHardware {
         })?;
 
         let (major, minor, patch) = amdsmi.get_lib_version()?;
-
         debug!("AMD SMI driver detected, version v{major}.{minor}.{patch}");
 
         Ok(Self {
@@ -61,7 +69,10 @@ impl AmdSmiWrapperHardware {
 }
 
 impl AmdSmiHardware for AmdSmiWrapperHardware {
+    /// Initializes devices with the specified devices specification.
+    /// Check the compatibility of each device and determine which metrics can be queried.
     fn init_processors(&mut self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>> {
+        trace!("Discovering AMD GPU devices.");
         let sockets = self.amdsmi.get_socket_handles()?;
 
         let processors: Vec<_> = sockets
@@ -118,10 +129,12 @@ impl AmdSmiHardware for AmdSmiWrapperHardware {
     }
 
     fn get_energy_count(&self, processor: &Processor) -> Result<EnergyCount> {
+        trace!("Retrieving energy for GPU device {}.", processor.uuid);
         Ok(self.get_device_handle(processor)?.get_energy_count()?)
     }
 
     fn get_power(&self, processor: &Processor) -> Result<PowerMeasurement> {
+        trace!("Retrieving power for GPU device {}.", processor.uuid);
         Ok(PowerMeasurement {
             timestamp: get_timestamp_micros(),
             power: self.get_device_handle(processor)?.get_power()?,
@@ -129,10 +142,15 @@ impl AmdSmiHardware for AmdSmiWrapperHardware {
     }
 
     fn get_vram_usage(&self, processor: &Processor) -> Result<u64> {
+        trace!("Retrieving VRAM usage for GPU device {}.", processor.uuid);
         Ok(self.get_device_handle(processor)?.get_vram_usage()?)
     }
 
     fn get_gpu_activity(&self, processor: &Processor) -> Result<GpuUsageInfo> {
+        trace!(
+            "Retrieving GPU utilization for GPU device {}.",
+            processor.uuid
+        );
         Ok(self.get_device_handle(processor)?.get_gpu_activity()?)
     }
 }

--- a/sources/amdsmi/src/hardware.rs
+++ b/sources/amdsmi/src/hardware.rs
@@ -8,14 +8,27 @@ use crate::{
     Processor, ProcessorSupport, Result, UUID, counters::PowerMeasurement, error::AmdSmiError,
 };
 
+/// Trait for abstracting the backend of AMD SMI library. Used for testing.
 pub trait Hardware: Send + Sync + 'static {
-    fn get_processors(&self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>>;
+    /// Init all GPU devices specicied by the provided specification.
+    fn init_processors(&mut self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>>;
+
+    /// Retrieve the energy count of a device.
     fn get_energy_count(&self, processor: &Processor) -> Result<EnergyCount>;
+
+    /// Retrieve the instantaneous power of a device.
     fn get_power(&self, processor: &Processor) -> Result<PowerMeasurement>;
+
+    /// Retrieve the current vram usage of a device.
     fn get_vram_usage(&self, processor: &Processor) -> Result<u64>;
 }
 
+/// Backend for interacting with AMD SMI library.
 pub struct AmdSmi {
+    /// Handle to the AMD SMI wrapper library.
+    amdsmi: amdsmi::AmdSmi,
+
+    /// The handles to the GPU devices.
     processor_handles: HashMap<UUID, amdsmi::Processor>,
 }
 
@@ -26,26 +39,10 @@ impl AmdSmi {
 
         debug!("AMD SMI driver detected, version v{major}.{minor}.{patch}");
 
-        let sockets = amdsmi.get_socket_handles()?;
-
-        let processor_handles: HashMap<_, _> = sockets
-            .into_iter()
-            .flat_map(|s| {
-                trace!("Socket {} detected.", s.get_socket_info()?);
-                s.get_processor_handles()
-            })
-            .flatten()
-            .flat_map(|p| {
-                let board_info = p.get_board_info()?;
-                let uuid = p.get_uuid()?;
-                trace!("Discovered GPU device {board_info}, UUID: {uuid}.");
-                Ok::<(UUID, amdsmi::Processor), AmdSmiError>((uuid, p))
-            })
-            .collect();
-
-        debug!("Discovered {} gpus.", processor_handles.len());
-
-        Ok(Self { processor_handles })
+        Ok(Self {
+            amdsmi,
+            processor_handles: HashMap::new(),
+        })
     }
 
     fn get_device_handle(&self, processor: &Processor) -> Result<&amdsmi::Processor> {
@@ -56,26 +53,35 @@ impl AmdSmi {
 }
 
 impl Hardware for AmdSmi {
-    fn get_processors(&self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>> {
-        Ok(self
-            .processor_handles
-            .iter()
-            .filter_map(|(uuid, handle)| {
+    fn init_processors(&mut self, spec: Option<&HashSet<UUID>>) -> Result<Vec<Processor>> {
+        let sockets = self.amdsmi.get_socket_handles()?;
+
+        let processors: Vec<_> = sockets
+            .into_iter()
+            .flat_map(|s| {
+                trace!("Socket {} detected.", s.get_socket_info()?);
+                s.get_processor_handles()
+            })
+            .flatten()
+            .flat_map(|p| {
+                let uuid = p.get_uuid()?;
+                trace!("Discovered GPU device {uuid}.");
+
                 if let Some(spec) = &spec
-                    && !spec.contains(uuid)
+                    && !spec.contains(&uuid)
                 {
                     trace!("Ignoring device {uuid}.");
-                    return None;
+                    return Ok::<Option<Processor>, AmdSmiError>(None);
                 }
 
                 let mut support = ProcessorSupport::empty();
 
-                if handle.get_energy_count().is_ok() {
+                if p.get_energy_count().is_ok() {
                     support |= ProcessorSupport::Energy;
-                } else if handle.get_power().is_ok() {
+                } else if p.get_power().is_ok() {
                     support |= ProcessorSupport::Power;
                 }
-                if handle.get_vram_usage().is_ok() {
+                if p.get_vram_usage().is_ok() {
                     support |= ProcessorSupport::Vram;
                 }
 
@@ -83,15 +89,21 @@ impl Hardware for AmdSmi {
 
                 if support.is_empty() {
                     trace!("No support detected for device {uuid}, ignored.");
-                    None
+                    Ok(None)
                 } else {
-                    Some(Processor {
+                    self.processor_handles.insert(uuid.clone(), p);
+                    Ok(Some(Processor {
                         uuid: uuid.clone(),
                         support,
-                    })
+                    }))
                 }
             })
-            .collect())
+            .flatten()
+            .collect();
+
+        debug!("Discovered {} gpus.", processors.len());
+
+        Ok(processors)
     }
 
     fn get_energy_count(&self, processor: &Processor) -> Result<EnergyCount> {

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -1,0 +1,299 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use bitflags::bitflags;
+use futures::StreamExt;
+use joule_profiler_core::{
+    sensor::Sensors,
+    source::MetricReader,
+    types::{Metric, Metrics},
+    unit::{MetricUnit, Unit, UnitPrefix},
+};
+use log::{debug, trace};
+use tokio::{sync::Mutex, task::JoinHandle};
+use tokio_timerfd::Interval;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    config::AmdSmiConfig,
+    counters::{Counter, EnergyCounter, PowerCounter, VramCounter},
+    error::AmdSmiError::{self},
+    hardware::{AmdSmi, Hardware},
+};
+
+pub mod config;
+pub mod counters;
+pub mod error;
+mod hardware;
+
+pub type UUID = String;
+
+type Result<T> = std::result::Result<T, AmdSmiError>;
+pub(crate) type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
+
+bitflags! {
+    #[derive(Debug, Clone, Copy)]
+    struct ProcessorSupport: u8 {
+        const Energy = 1;
+        const Power = 1 << 1;
+        const Vram = 1 << 2;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Processor {
+    uuid: UUID,
+    support: ProcessorSupport,
+}
+
+pub struct AmdSmiSource<H: Hardware> {
+    config: AmdSmiConfig,
+    hardware: Arc<H>,
+    handle: Option<WorkerHandle>,
+    processors: Arc<HashMap<usize, Processor>>,
+    energy_counters: HashMap<usize, EnergyCounter>,
+    vram_counters: Arc<Mutex<HashMap<usize, VramCounter>>>,
+    power_counters: Arc<Mutex<HashMap<usize, PowerCounter>>>,
+}
+
+impl AmdSmiSource<AmdSmi> {
+    pub fn new(config: AmdSmiConfig) -> Result<Self> {
+        let amdsmi = AmdSmi::new()?;
+        let processors = amdsmi.get_processors()?.into_iter().enumerate().collect();
+
+        Ok(Self {
+            config,
+            hardware: Arc::new(amdsmi),
+            handle: None,
+            processors: Arc::new(processors),
+            energy_counters: HashMap::new(),
+            vram_counters: Arc::default(),
+            power_counters: Arc::default(),
+        })
+    }
+}
+
+impl<H: Hardware> AmdSmiSource<H> {
+    pub fn create_worker(
+        hardware: Arc<H>,
+        processors: Arc<HashMap<usize, Processor>>,
+        power_counters: Arc<Mutex<HashMap<usize, PowerCounter>>>,
+        vram_counters: Arc<Mutex<HashMap<usize, VramCounter>>>,
+        poll_interval: Duration,
+    ) -> Result<WorkerHandle> {
+        let mut ticker = Interval::new_interval(poll_interval)?;
+
+        let cancellation_token = CancellationToken::new();
+        let cancellation_token_clone = cancellation_token.clone();
+
+        let handle = tokio::spawn(async move {
+            debug!("Starting AMD SMI source polling.");
+
+            loop {
+                tokio::select! {
+                    _ = ticker.next() => {
+                        trace!("Polled AMD SMI source.");
+                        Self::read_polled_counters(&hardware, &processors, &power_counters, &vram_counters).await?;
+                    }
+
+                    () = cancellation_token.cancelled() => {
+                        debug!("AMD SMI worker stopped.");
+                        break;
+                    }
+                }
+            }
+
+            Ok(())
+        });
+
+        Ok((cancellation_token_clone, handle))
+    }
+
+    async fn read_polled_counters(
+        hardware: &Arc<H>,
+        processors: &Arc<HashMap<usize, Processor>>,
+        power_counters: &Arc<Mutex<HashMap<usize, PowerCounter>>>,
+        vram_counters: &Arc<Mutex<HashMap<usize, VramCounter>>>,
+    ) -> Result<()> {
+        for (index, processor) in processors.iter() {
+            if processor.support.contains(ProcessorSupport::Vram) {
+                let mut lock = vram_counters.lock().await;
+                let vram_usage = hardware.get_vram_usage(processor)?;
+                lock.entry(*index).and_modify(|c| c.update(vram_usage));
+            }
+
+            if processor.support.contains(ProcessorSupport::Vram) {
+                let mut lock = power_counters.lock().await;
+                let power = hardware.get_power(processor)?;
+                lock.entry(*index).and_modify(|c| c.update(power));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<H: Hardware> MetricReader for AmdSmiSource<H> {
+    type Type = HashMap<usize, Counter>;
+
+    type Error = AmdSmiError;
+
+    async fn measure(&mut self) -> Result<()> {
+        for (index, processor) in self.processors.iter() {
+            if processor.support.contains(ProcessorSupport::Energy) {
+                let energy = self.hardware.get_energy_count(processor)?;
+                self.energy_counters
+                    .entry(*index)
+                    .or_default()
+                    .update(energy);
+            } else if processor.support.contains(ProcessorSupport::Power) {
+                let mut lock = self.power_counters.lock().await;
+                let power = self.hardware.get_power(processor)?;
+                lock.entry(*index).or_default().update(power);
+            }
+
+            if processor.support.contains(ProcessorSupport::Vram) {
+                let mut lock = self.vram_counters.lock().await;
+                let vram_usage = self.hardware.get_vram_usage(processor)?;
+                lock.entry(*index).or_default().update(vram_usage);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn retrieve(&mut self) -> Result<Self::Type> {
+        let mut energy_counters = self.energy_counters.clone();
+        for counter in self.energy_counters.values_mut() {
+            counter.reset();
+        }
+
+        let mut lock = self.vram_counters.lock().await;
+        let mut vram_counters = lock.clone();
+        for counter in lock.values_mut() {
+            counter.reset();
+        }
+
+        let mut lock = self.power_counters.lock().await;
+        let mut power_counters = lock.clone();
+        for counter in lock.values_mut() {
+            counter.reset();
+        }
+
+        let map = self
+            .processors
+            .keys()
+            .map(|index| {
+                let energy = energy_counters.remove(index);
+                let vram = vram_counters.remove(index);
+                let power = power_counters.remove(index);
+                let counter = Counter {
+                    energy,
+                    vram,
+                    power,
+                };
+                (*index, counter)
+            })
+            .collect();
+
+        Ok(map)
+    }
+
+    async fn init(&mut self, _pid: i32) -> Result<()> {
+        if let Some(poll_interval) = self.config.poll_interval {
+            self.handle = Some(Self::create_worker(
+                self.hardware.clone(),
+                self.processors.clone(),
+                self.power_counters.clone(),
+                self.vram_counters.clone(),
+                poll_interval,
+            )?);
+        }
+
+        debug!("AMD SMI source initialized.");
+        Ok(())
+    }
+
+    async fn join(&mut self) -> Result<()> {
+        if let Some((cancellation_token, handle)) = self.handle.take() {
+            debug!("Joining AMD SMI source polling task.");
+            cancellation_token.cancel();
+            handle.await??;
+        }
+        Ok(())
+    }
+
+    fn get_sensors(&self) -> Result<Sensors> {
+        todo!()
+    }
+
+    fn to_metrics(&self, result: Self::Type) -> Result<Metrics> {
+        let metrics = result
+            .into_iter()
+            .flat_map(|(index, counter)| {
+                let uuid = &self
+                    .processors
+                    .get(&index)
+                    .ok_or(AmdSmiError::NoSuchDeviceFromIndex(index))?
+                    .uuid;
+
+                let mut processor_metrics = Vec::new();
+                if let Some(energy) = counter.energy
+                    && let Some(energy) = energy.diff()
+                {
+                    processor_metrics.push(Metric::new(
+                        format!("GPU-{uuid}-energy"),
+                        energy,
+                        MetricUnit {
+                            prefix: UnitPrefix::Micro,
+                            unit: Unit::Joule,
+                        },
+                        Self::get_name(),
+                    ));
+                } else if let Some(power) = counter.power {
+                    let energy = power.compute_energy();
+                    processor_metrics.push(Metric::new(
+                        format!("GPU-{uuid}-energy"),
+                        energy,
+                        MetricUnit {
+                            prefix: UnitPrefix::Micro,
+                            unit: Unit::Joule,
+                        },
+                        Self::get_name(),
+                    ));
+                }
+
+                if let Some(vram) = counter.vram
+                    && let Some(min) = vram.min
+                    && let Some(max) = vram.max
+                {
+                    processor_metrics.push(Metric::new(
+                        format!("GPU-{uuid}-vram_min"),
+                        min,
+                        MetricUnit {
+                            prefix: UnitPrefix::None,
+                            unit: Unit::Byte,
+                        },
+                        Self::get_name(),
+                    ));
+
+                    processor_metrics.push(Metric::new(
+                        format!("GPU-{uuid}-vram_max"),
+                        max,
+                        MetricUnit {
+                            prefix: UnitPrefix::None,
+                            unit: Unit::Byte,
+                        },
+                        Self::get_name(),
+                    ));
+                }
+
+                Ok::<Metrics, AmdSmiError>(processor_metrics)
+            })
+            .flatten()
+            .collect();
+        Ok(metrics)
+    }
+
+    fn get_name() -> &'static str {
+        "amdsmi"
+    }
+}

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use bitflags::bitflags;
 use futures::StreamExt;
 use joule_profiler_core::{
-    sensor::Sensors,
+    sensor::{Sensor, Sensors},
     source::MetricReader,
     types::{Metric, Metrics},
     unit::{MetricUnit, Unit, UnitPrefix},
@@ -29,6 +29,16 @@ pub type UUID = String;
 
 type Result<T> = std::result::Result<T, AmdSmiError>;
 pub(crate) type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
+
+const MICRO_JOULE_UNIT: MetricUnit = MetricUnit {
+    prefix: UnitPrefix::Micro,
+    unit: Unit::Joule,
+};
+
+const BYTE_UNIT: MetricUnit = MetricUnit {
+    prefix: UnitPrefix::None,
+    unit: Unit::Byte,
+};
 
 bitflags! {
     #[derive(Debug, Clone, Copy)]
@@ -114,19 +124,32 @@ impl<H: Hardware> AmdSmiSource<H> {
         power_counters: &Arc<Mutex<HashMap<usize, PowerCounter>>>,
         vram_counters: &Arc<Mutex<HashMap<usize, VramCounter>>>,
     ) -> Result<()> {
+        let mut vram_updates = Vec::new();
+        let mut power_updates = Vec::new();
+
         for (index, processor) in processors.iter() {
             if processor.support.contains(ProcessorSupport::Vram) {
-                let mut lock = vram_counters.lock().await;
-                let vram_usage = hardware.get_vram_usage(processor)?;
-                lock.entry(*index).and_modify(|c| c.update(vram_usage));
+                vram_updates.push((*index, hardware.get_vram_usage(processor)?));
             }
-
-            if processor.support.contains(ProcessorSupport::Vram) {
-                let mut lock = power_counters.lock().await;
-                let power = hardware.get_power(processor)?;
-                lock.entry(*index).and_modify(|c| c.update(power));
+            if processor.support.contains(ProcessorSupport::Power) {
+                power_updates.push((*index, hardware.get_power(processor)?));
             }
         }
+
+        {
+            let mut lock = vram_counters.lock().await;
+            for (index, vram_usage) in vram_updates {
+                lock.entry(index).and_modify(|c| c.update(vram_usage));
+            }
+        }
+
+        {
+            let mut lock = power_counters.lock().await;
+            for (index, power) in power_updates {
+                lock.entry(index).and_modify(|c| c.update(power));
+            }
+        }
+
         Ok(())
     }
 }
@@ -144,19 +167,15 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
                     .entry(*index)
                     .or_default()
                     .update(energy);
-            } else if processor.support.contains(ProcessorSupport::Power) {
-                let mut lock = self.power_counters.lock().await;
-                let power = self.hardware.get_power(processor)?;
-                lock.entry(*index).or_default().update(power);
-            }
-
-            if processor.support.contains(ProcessorSupport::Vram) {
-                let mut lock = self.vram_counters.lock().await;
-                let vram_usage = self.hardware.get_vram_usage(processor)?;
-                lock.entry(*index).or_default().update(vram_usage);
             }
         }
-
+        Self::read_polled_counters(
+            &self.hardware,
+            &self.processors,
+            &self.power_counters,
+            &self.vram_counters,
+        )
+        .await?;
         Ok(())
     }
 
@@ -222,7 +241,40 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
     }
 
     fn get_sensors(&self) -> Result<Sensors> {
-        todo!()
+        let sensors = self
+            .processors
+            .values()
+            .flat_map(|p| {
+                let mut processor_sensors = Vec::new();
+                let uuid = &p.uuid;
+
+                if p.support.contains(ProcessorSupport::Energy)
+                    || p.support.contains(ProcessorSupport::Power)
+                {
+                    processor_sensors.push(Sensor::new(
+                        format!("GPU-{uuid}-energy"),
+                        MICRO_JOULE_UNIT,
+                        Self::get_name(),
+                    ));
+                }
+
+                if p.support.contains(ProcessorSupport::Vram) {
+                    processor_sensors.push(Sensor::new(
+                        format!("GPU-{uuid}-vram_min"),
+                        BYTE_UNIT,
+                        Self::get_name(),
+                    ));
+                    processor_sensors.push(Sensor::new(
+                        format!("GPU-{uuid}-vram_max"),
+                        BYTE_UNIT,
+                        Self::get_name(),
+                    ));
+                }
+
+                processor_sensors
+            })
+            .collect();
+        Ok(sensors)
     }
 
     fn to_metrics(&self, result: Self::Type) -> Result<Metrics> {
@@ -236,27 +288,16 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
                     .uuid;
 
                 let mut processor_metrics = Vec::new();
-                if let Some(energy) = counter.energy
-                    && let Some(energy) = energy.diff()
-                {
+
+                let energy = counter
+                    .energy
+                    .map_or_else(|| counter.power.map(|c| c.compute_energy()), |c| c.diff());
+
+                if let Some(energy) = energy {
                     processor_metrics.push(Metric::new(
                         format!("GPU-{uuid}-energy"),
                         energy,
-                        MetricUnit {
-                            prefix: UnitPrefix::Micro,
-                            unit: Unit::Joule,
-                        },
-                        Self::get_name(),
-                    ));
-                } else if let Some(power) = counter.power {
-                    let energy = power.compute_energy();
-                    processor_metrics.push(Metric::new(
-                        format!("GPU-{uuid}-energy"),
-                        energy,
-                        MetricUnit {
-                            prefix: UnitPrefix::Micro,
-                            unit: Unit::Joule,
-                        },
+                        MICRO_JOULE_UNIT,
                         Self::get_name(),
                     ));
                 }
@@ -268,20 +309,14 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
                     processor_metrics.push(Metric::new(
                         format!("GPU-{uuid}-vram_min"),
                         min,
-                        MetricUnit {
-                            prefix: UnitPrefix::None,
-                            unit: Unit::Byte,
-                        },
+                        BYTE_UNIT,
                         Self::get_name(),
                     ));
 
                     processor_metrics.push(Metric::new(
                         format!("GPU-{uuid}-vram_max"),
                         max,
-                        MetricUnit {
-                            prefix: UnitPrefix::None,
-                            unit: Unit::Byte,
-                        },
+                        BYTE_UNIT,
                         Self::get_name(),
                     ));
                 }

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -1,3 +1,7 @@
+//! AMD SMI (AMD System Management Interface) energy profiling integration for Joule Profiler.
+//!
+//! This module provides energy consumption, VRAM usage and GPU utilization metrics for AMD GPUs using the AMD SMI library.
+
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use bitflags::bitflags;
@@ -428,5 +432,391 @@ impl<H: AmdSmiHardware> MetricReader for AmdSmi<H> {
 
     fn get_name() -> &'static str {
         AMDSMI_SOURCE_NAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc, time::Duration};
+
+    use amdsmi::types::{EnergyCount, GpuUsageInfo};
+    use joule_profiler_core::source::MetricReader;
+    use mockall::predicate::function;
+    use tokio::time::sleep;
+
+    use crate::{
+        AmdSmi, Processor, ProcessorSupport,
+        config::AmdSmiConfig,
+        counters::{Counter, PowerMeasurement},
+        error::AmdSmiError,
+        hardware::MockAmdSmiHardware,
+    };
+
+    fn make_processor(uuid: &str, support: ProcessorSupport) -> Processor {
+        Processor {
+            uuid: uuid.to_owned(),
+            support,
+        }
+    }
+
+    fn processors_map(list: Vec<Processor>) -> Arc<HashMap<usize, Processor>> {
+        Arc::new(list.into_iter().enumerate().collect())
+    }
+
+    fn build_amdsmi(
+        hardware: MockAmdSmiHardware,
+        processors: Arc<HashMap<usize, Processor>>,
+        poll_interval: Option<Duration>,
+    ) -> AmdSmi<MockAmdSmiHardware> {
+        AmdSmi {
+            config: AmdSmiConfig {
+                poll_interval,
+                gpus_spec: None,
+            },
+            hardware: Arc::new(hardware),
+            handle: None,
+            processors,
+            energy_counters: HashMap::default(),
+            vram_counters: Arc::default(),
+            power_counters: Arc::default(),
+            utilization_counters: Arc::default(),
+        }
+    }
+
+    fn energy_count(value: u64) -> EnergyCount {
+        EnergyCount {
+            energy_accumulator: value,
+            counter_resolution: 1.0,
+            timestamp: 0,
+        }
+    }
+
+    fn gpu_usage(gpu_usage: u32) -> GpuUsageInfo {
+        GpuUsageInfo {
+            gpu_usage,
+            mem_usage: 0,
+        }
+    }
+
+    fn power_measurement(power: u32) -> PowerMeasurement {
+        PowerMeasurement {
+            timestamp: 0,
+            power,
+        }
+    }
+
+    fn by_uuid(uuid: &'static str) -> impl mockall::Predicate<Processor> {
+        function(move |p: &Processor| p.uuid == uuid)
+    }
+
+    #[test]
+    fn get_sensors_energy_support_emits_energy_sensor() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Energy)]);
+        let amdsmi = build_amdsmi(MockAmdSmiHardware::new(), processors, None);
+
+        let sensors = amdsmi.get_sensors().unwrap();
+        assert!(sensors.iter().any(|s| s.name == "GPU-UUID_0-energy"));
+    }
+
+    #[test]
+    fn get_sensors_power_support_emits_energy_sensor() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Power)]);
+        let amdsmi = build_amdsmi(MockAmdSmiHardware::new(), processors, None);
+
+        let sensors = amdsmi.get_sensors().unwrap();
+        assert!(sensors.iter().any(|s| s.name == "GPU-UUID_0-energy"));
+    }
+
+    #[test]
+    fn get_sensors_vram_support_emits_vram_sensors() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Vram)]);
+        let amdsmi = build_amdsmi(MockAmdSmiHardware::new(), processors, None);
+
+        let sensors = amdsmi.get_sensors().unwrap();
+        assert!(sensors.iter().any(|s| s.name == "GPU-UUID_0-vram_min"));
+        assert!(sensors.iter().any(|s| s.name == "GPU-UUID_0-vram_max"));
+    }
+
+    #[test]
+    fn get_sensors_utilization_support_emits_utilization_sensors() {
+        let processors = processors_map(vec![make_processor(
+            "UUID_0",
+            ProcessorSupport::Utilization,
+        )]);
+        let amdsmi = build_amdsmi(MockAmdSmiHardware::new(), processors, None);
+
+        let sensors = amdsmi.get_sensors().unwrap();
+        assert!(
+            sensors
+                .iter()
+                .any(|s| s.name == "GPU-UUID_0-utilization_min")
+        );
+        assert!(
+            sensors
+                .iter()
+                .any(|s| s.name == "GPU-UUID_0-utilization_max")
+        );
+    }
+
+    #[test]
+    fn get_sensors_empty_when_no_processors() {
+        let amdsmi = build_amdsmi(MockAmdSmiHardware::new(), Arc::new(HashMap::new()), None);
+        assert!(amdsmi.get_sensors().unwrap().is_empty());
+    }
+
+    #[test]
+    fn get_sensors_counts_all_sensors_for_full_support() {
+        let processors = processors_map(vec![make_processor(
+            "UUID_0",
+            ProcessorSupport::Energy | ProcessorSupport::Vram | ProcessorSupport::Utilization,
+        )]);
+        let amdsmi = build_amdsmi(MockAmdSmiHardware::new(), processors, None);
+        assert_eq!(amdsmi.get_sensors().unwrap().len(), 5);
+    }
+
+    #[tokio::test]
+    async fn measure_reads_energy_for_energy_capable_processor() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Energy)]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_energy_count()
+            .with(by_uuid("UUID_0"))
+            .once()
+            .returning(|_| Ok(energy_count(1_000_000)));
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        amdsmi.measure().await.unwrap();
+
+        assert!(amdsmi.energy_counters.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn measure_reads_power_for_power_capable_processor() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Power)]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_power()
+            .with(by_uuid("UUID_0"))
+            .once()
+            .returning(|_| Ok(power_measurement(150_000)));
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        amdsmi.measure().await.unwrap();
+
+        assert!(amdsmi.power_counters.lock().await.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn measure_reads_vram_for_vram_capable_processor() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Vram)]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_vram_usage()
+            .with(by_uuid("UUID_0"))
+            .once()
+            .returning(|_| Ok(8_000_000_000));
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        amdsmi.measure().await.unwrap();
+
+        assert!(amdsmi.vram_counters.lock().await.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn measure_reads_utilization_for_utilization_capable_processor() {
+        let processors = processors_map(vec![make_processor(
+            "UUID_0",
+            ProcessorSupport::Utilization,
+        )]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_gpu_activity()
+            .with(by_uuid("UUID_0"))
+            .once()
+            .returning(|_| Ok(gpu_usage(75)));
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        amdsmi.measure().await.unwrap();
+
+        assert!(amdsmi.utilization_counters.lock().await.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn measure_skips_energy_and_power_for_vram_only_processor() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Vram)]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_energy_count().never();
+        hw.expect_get_power().never();
+        hw.expect_get_vram_usage()
+            .once()
+            .returning(|_| Ok(1_000_000));
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        amdsmi.measure().await.unwrap();
+
+        assert!(amdsmi.energy_counters.is_empty());
+        assert!(amdsmi.power_counters.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn measure_propagates_energy_error() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Energy)]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_energy_count().once().returning(|_| {
+            Err(AmdSmiError::AmdSmiError(
+                amdsmi::error::AmdSmiError::NotSupported,
+            ))
+        });
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        assert!(amdsmi.measure().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn measure_propagates_power_error() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Power)]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_power().once().returning(|_| {
+            Err(AmdSmiError::AmdSmiError(
+                amdsmi::error::AmdSmiError::NotSupported,
+            ))
+        });
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        assert!(amdsmi.measure().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn measure_propagates_vram_error() {
+        let processors = processors_map(vec![make_processor("UUID_0", ProcessorSupport::Vram)]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_vram_usage().once().returning(|_| {
+            Err(AmdSmiError::AmdSmiError(
+                amdsmi::error::AmdSmiError::NotSupported,
+            ))
+        });
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        assert!(amdsmi.measure().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn measure_propagates_utilization_error() {
+        let processors = processors_map(vec![make_processor(
+            "UUID_0",
+            ProcessorSupport::Utilization,
+        )]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_gpu_activity().once().returning(|_| {
+            Err(AmdSmiError::AmdSmiError(
+                amdsmi::error::AmdSmiError::NotSupported,
+            ))
+        });
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        assert!(amdsmi.measure().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn retrieve_returns_counters_and_resets_them() {
+        let processors = processors_map(vec![make_processor(
+            "UUID_0",
+            ProcessorSupport::Energy | ProcessorSupport::Vram,
+        )]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_energy_count()
+            .returning(|_| Ok(energy_count(10_000)));
+        hw.expect_get_vram_usage().returning(|_| Ok(1_000_000));
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        amdsmi.measure().await.unwrap();
+        amdsmi.measure().await.unwrap();
+
+        let result = amdsmi.retrieve().await.unwrap();
+        assert!(result.contains_key(&0));
+
+        let result2 = amdsmi.retrieve().await.unwrap();
+        let counter: &Counter = result2.get(&0).unwrap();
+        assert!(
+            counter
+                .energy
+                .as_ref()
+                .and_then(|e| e.diff())
+                .is_none_or(|v| v == 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn retrieve_includes_entry_for_every_processor() {
+        let processors = processors_map(vec![
+            make_processor("UUID_0", ProcessorSupport::Energy),
+            make_processor("UUID_1", ProcessorSupport::Power),
+            make_processor("UUID_2", ProcessorSupport::Vram),
+        ]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_energy_count()
+            .returning(|_| Ok(energy_count(1_000)));
+        hw.expect_get_power()
+            .returning(|_| Ok(power_measurement(5_000)));
+        hw.expect_get_vram_usage().returning(|_| Ok(1_000_000));
+
+        let mut amdsmi = build_amdsmi(hw, processors, None);
+        amdsmi.measure().await.unwrap();
+
+        let result = amdsmi.retrieve().await.unwrap();
+        assert_eq!(result.len(), 3);
+        for index in [0, 1, 2] {
+            assert!(result.contains_key(&index));
+        }
+    }
+
+    #[tokio::test]
+    async fn init_does_not_spawn_worker_without_poll_interval() {
+        let mut amdsmi = build_amdsmi(MockAmdSmiHardware::new(), Arc::new(HashMap::new()), None);
+        amdsmi.init(1234).await.unwrap();
+        assert!(amdsmi.handle.is_none());
+    }
+
+    #[tokio::test]
+    async fn init_spawns_worker_with_poll_interval() {
+        let mut amdsmi = build_amdsmi(
+            MockAmdSmiHardware::new(),
+            Arc::new(HashMap::new()),
+            Some(Duration::from_millis(50)),
+        );
+        amdsmi.init(1234).await.unwrap();
+        assert!(amdsmi.handle.is_some());
+        amdsmi.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn worker_polls_counters_and_can_be_cancelled() {
+        let processors = processors_map(vec![make_processor(
+            "UUID_0",
+            ProcessorSupport::Power | ProcessorSupport::Vram | ProcessorSupport::Utilization,
+        )]);
+
+        let mut hw = MockAmdSmiHardware::new();
+        hw.expect_get_power()
+            .returning(|_| Ok(power_measurement(5_000)));
+        hw.expect_get_vram_usage().returning(|_| Ok(1_000_000));
+        hw.expect_get_gpu_activity()
+            .returning(|_| Ok(gpu_usage(42)));
+
+        let mut amdsmi = build_amdsmi(hw, processors, Some(Duration::from_millis(20)));
+        amdsmi.init(0).await.unwrap();
+
+        sleep(Duration::from_millis(80)).await;
+
+        amdsmi.join().await.unwrap();
+
+        assert!(amdsmi.power_counters.lock().await.contains_key(&0));
     }
 }

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -28,7 +28,9 @@ mod hardware;
 pub type UUID = String;
 
 type Result<T> = std::result::Result<T, AmdSmiError>;
-pub(crate) type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
+
+/// Polling task handle and its cancellation token.
+type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 
 const MICRO_JOULE_UNIT: MetricUnit = MetricUnit {
     prefix: UnitPrefix::Micro,
@@ -41,6 +43,7 @@ const BYTE_UNIT: MetricUnit = MetricUnit {
 };
 
 bitflags! {
+    /// The supports of a device.
     #[derive(Debug, Clone, Copy)]
     struct ProcessorSupport: u8 {
         const Energy = 1;
@@ -51,25 +54,42 @@ bitflags! {
 
 #[derive(Debug, Clone)]
 pub struct Processor {
+    /// The UUID of the device.
     uuid: UUID,
+
+    /// The supports of the device (e.g., Energy, Power, VRAM).
     support: ProcessorSupport,
 }
 
 pub struct AmdSmiSource<H: Hardware> {
+    /// Source configuration.
     config: AmdSmiConfig,
+
+    /// The hardware used for querying AMD SMI lib. Used for testing.
     hardware: Arc<H>,
+
+    /// The handle to the polling task and its cancellation token.
     handle: Option<WorkerHandle>,
+
+    /// Map of GPU devices, the key is an index to avoid cloning the devices UUID.
     processors: Arc<HashMap<usize, Processor>>,
+
+    /// The current energy counters.
     energy_counters: HashMap<usize, EnergyCounter>,
+
+    /// The current vram counters.
     vram_counters: Arc<Mutex<HashMap<usize, VramCounter>>>,
+
+    /// The current power counters.
     power_counters: Arc<Mutex<HashMap<usize, PowerCounter>>>,
 }
 
 impl AmdSmiSource<AmdSmi> {
+    /// Initializes the AMD SMI source and retrieve the GPU devices.
     pub fn new(config: AmdSmiConfig) -> Result<Self> {
-        let amdsmi = AmdSmi::new()?;
+        let mut amdsmi = AmdSmi::new()?;
         let processors = amdsmi
-            .get_processors(config.gpus_spec.as_ref())?
+            .init_processors(config.gpus_spec.as_ref())?
             .into_iter()
             .enumerate()
             .collect();
@@ -87,6 +107,7 @@ impl AmdSmiSource<AmdSmi> {
 }
 
 impl<H: Hardware> AmdSmiSource<H> {
+    /// Creates the worker task for power and vram polling at the specified polling interval.
     pub fn create_worker(
         hardware: Arc<H>,
         processors: Arc<HashMap<usize, Processor>>,
@@ -122,6 +143,7 @@ impl<H: Hardware> AmdSmiSource<H> {
         Ok((cancellation_token_clone, handle))
     }
 
+    /// Reads the power and vram counters for each processors and updates the current counters.
     async fn read_polled_counters(
         hardware: &Arc<H>,
         processors: &Arc<HashMap<usize, Processor>>,
@@ -150,7 +172,7 @@ impl<H: Hardware> AmdSmiSource<H> {
         {
             let mut lock = power_counters.lock().await;
             for (index, power) in power_updates {
-                lock.entry(index).and_modify(|c| c.update(power));
+                lock.entry(index).and_modify(|c| c.push(power));
             }
         }
 
@@ -163,6 +185,7 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
 
     type Error = AmdSmiError;
 
+    /// Makes a measurement for every devices.
     async fn measure(&mut self) -> Result<()> {
         for (index, processor) in self.processors.iter() {
             if processor.support.contains(ProcessorSupport::Energy) {
@@ -183,6 +206,7 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
         Ok(())
     }
 
+    /// Retrieve the current counters and reset them for the next phase.
     async fn retrieve(&mut self) -> Result<Self::Type> {
         let mut energy_counters = self.energy_counters.clone();
         for counter in self.energy_counters.values_mut() {
@@ -220,6 +244,7 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
         Ok(map)
     }
 
+    /// Creates the polling task if a polling interval has been configured.
     async fn init(&mut self, _pid: i32) -> Result<()> {
         if let Some(poll_interval) = self.config.poll_interval {
             self.handle = Some(Self::create_worker(
@@ -235,6 +260,7 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
         Ok(())
     }
 
+    /// Joins the polling task if it exists.
     async fn join(&mut self) -> Result<()> {
         if let Some((cancellation_token, handle)) = self.handle.take() {
             debug!("Joining AMD SMI source polling task.");

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use bitflags::bitflags;
-use futures::StreamExt;
+use futures::{StreamExt, future::try_join_all};
 use joule_profiler_core::{
     sensor::{Sensor, Sensors},
     source::MetricReader,
@@ -13,7 +13,10 @@ use joule_profiler_core::{
     unit::{MetricUnit, Unit, UnitPrefix},
 };
 use log::{debug, trace};
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::{
+    sync::Mutex,
+    task::{JoinHandle, spawn_blocking},
+};
 use tokio_timerfd::Interval;
 use tokio_util::sync::CancellationToken;
 
@@ -162,6 +165,9 @@ impl<H: AmdSmiHardware> AmdSmi<H> {
     }
 
     /// Reads the power and vram counters for each processors and updates the current counters.
+    ///
+    /// Spawn every blocking read upfront so they run concurrently on the
+    /// blocking thread pool, instead of awaiting them one by one.
     async fn read_polled_counters(
         hardware: &Arc<H>,
         processors: &Arc<HashMap<usize, Processor>>,
@@ -169,39 +175,64 @@ impl<H: AmdSmiHardware> AmdSmi<H> {
         vram_counters: &Arc<Mutex<HashMap<usize, VramCounter>>>,
         utilization_counters: &Arc<Mutex<HashMap<usize, UtilizationCounter>>>,
     ) -> Result<()> {
-        let mut vram_updates = Vec::new();
-        let mut power_updates = Vec::new();
-        let mut utilization_updates = Vec::new();
+        let mut vram_tasks = Vec::new();
+        let mut power_tasks = Vec::new();
+        let mut utilization_tasks = Vec::new();
 
         for (index, processor) in processors.iter() {
+            let index = *index;
+
             if processor.support.contains(ProcessorSupport::Vram) {
-                vram_updates.push((*index, hardware.get_vram_usage(processor)?));
+                let hardware = hardware.clone();
+                let processor = processor.clone();
+                vram_tasks.push(spawn_blocking(move || {
+                    hardware
+                        .get_vram_usage(&processor)
+                        .map(|vram| (index, vram))
+                }));
             }
             if processor.support.contains(ProcessorSupport::Power) {
-                power_updates.push((*index, hardware.get_power(processor)?));
+                let hardware = hardware.clone();
+                let processor = processor.clone();
+                power_tasks.push(spawn_blocking(move || {
+                    hardware.get_power(&processor).map(|power| (index, power))
+                }));
             }
             if processor.support.contains(ProcessorSupport::Utilization) {
-                utilization_updates.push((*index, hardware.get_gpu_activity(processor)?.gpu_usage));
+                let hardware = hardware.clone();
+                let processor = processor.clone();
+                utilization_tasks.push(spawn_blocking(move || {
+                    hardware
+                        .get_gpu_activity(&processor)
+                        .map(|usage| (index, usage.gpu_usage))
+                }));
             }
         }
 
+        let vram_updates = try_join_all(vram_tasks).await?;
+        let power_updates = try_join_all(power_tasks).await?;
+        let utilization_updates = try_join_all(utilization_tasks).await?;
+
         {
             let mut lock = vram_counters.lock().await;
-            for (index, vram_usage) in vram_updates {
+            for (index, vram_usage) in vram_updates.into_iter().collect::<Result<Vec<_>>>()? {
                 lock.entry(index).or_default().update(vram_usage);
             }
         }
 
         {
             let mut lock = power_counters.lock().await;
-            for (index, power) in power_updates {
+            for (index, power) in power_updates.into_iter().collect::<Result<Vec<_>>>()? {
                 lock.entry(index).or_default().push(power);
             }
         }
 
         {
             let mut lock = utilization_counters.lock().await;
-            for (index, utilization) in utilization_updates {
+            for (index, utilization) in utilization_updates
+                .into_iter()
+                .collect::<Result<Vec<_>>>()?
+            {
                 lock.entry(index).or_default().update(utilization);
             }
         }
@@ -216,16 +247,24 @@ impl<H: AmdSmiHardware> MetricReader for AmdSmi<H> {
     type Error = AmdSmiError;
 
     /// Makes a measurement for every devices.
+    ///
+    /// Spawns the different measures in the blocking thread pool to execute
+    /// them in parallel without blocking the async pool.
     async fn measure(&mut self) -> Result<()> {
+        let mut energy_tasks = Vec::new();
         for (index, processor) in self.processors.iter() {
             if processor.support.contains(ProcessorSupport::Energy) {
-                let energy = self.hardware.get_energy_count(processor)?;
-                self.energy_counters
-                    .entry(*index)
-                    .or_default()
-                    .update(energy);
+                let hardware = self.hardware.clone();
+                let processor = processor.clone();
+                let index = *index;
+                energy_tasks.push(spawn_blocking(move || {
+                    hardware
+                        .get_energy_count(&processor)
+                        .map(|energy| (index, energy))
+                }));
             }
         }
+
         Self::read_polled_counters(
             &self.hardware,
             &self.processors,
@@ -234,6 +273,18 @@ impl<H: AmdSmiHardware> MetricReader for AmdSmi<H> {
             &self.utilization_counters,
         )
         .await?;
+
+        for (index, energy) in try_join_all(energy_tasks)
+            .await?
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?
+        {
+            self.energy_counters
+                .entry(index)
+                .or_default()
+                .update(energy);
+        }
+
         Ok(())
     }
 

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -32,6 +32,8 @@ type Result<T> = std::result::Result<T, AmdSmiError>;
 /// Polling task handle and its cancellation token.
 type WorkerHandle = (CancellationToken, JoinHandle<Result<()>>);
 
+const AMDSMI_SOURCE_NAME: &str = "amdsmi";
+
 const MICRO_JOULE_UNIT: MetricUnit = MetricUnit {
     prefix: UnitPrefix::Micro,
     unit: Unit::Joule,
@@ -425,6 +427,6 @@ impl<H: AmdSmiHardware> MetricReader for AmdSmi<H> {
     }
 
     fn get_name() -> &'static str {
-        "amdsmi"
+        AMDSMI_SOURCE_NAME
     }
 }

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -15,7 +15,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     config::AmdSmiConfig,
-    counters::{Counter, EnergyCounter, PowerCounter, VramCounter},
+    counters::{Counter, EnergyCounter, PowerCounter, UtilizationCounter, VramCounter},
     error::AmdSmiError::{self},
     hardware::{AmdSmi, Hardware},
 };
@@ -42,6 +42,11 @@ const BYTE_UNIT: MetricUnit = MetricUnit {
     unit: Unit::Byte,
 };
 
+const PERCENT_UNIT: MetricUnit = MetricUnit {
+    prefix: UnitPrefix::None,
+    unit: Unit::Percent,
+};
+
 bitflags! {
     /// The supports of a device.
     #[derive(Debug, Clone, Copy)]
@@ -49,6 +54,7 @@ bitflags! {
         const Energy = 1;
         const Power = 1 << 1;
         const Vram = 1 << 2;
+        const Utilization = 1 << 3;
     }
 }
 
@@ -82,6 +88,9 @@ pub struct AmdSmiSource<H: Hardware> {
 
     /// The current power counters.
     power_counters: Arc<Mutex<HashMap<usize, PowerCounter>>>,
+
+    /// The current GPU utilization counters.
+    utilization_counters: Arc<Mutex<HashMap<usize, UtilizationCounter>>>,
 }
 
 impl AmdSmiSource<AmdSmi> {
@@ -102,6 +111,7 @@ impl AmdSmiSource<AmdSmi> {
             energy_counters: HashMap::new(),
             vram_counters: Arc::default(),
             power_counters: Arc::default(),
+            utilization_counters: Arc::default(),
         })
     }
 }
@@ -113,6 +123,7 @@ impl<H: Hardware> AmdSmiSource<H> {
         processors: Arc<HashMap<usize, Processor>>,
         power_counters: Arc<Mutex<HashMap<usize, PowerCounter>>>,
         vram_counters: Arc<Mutex<HashMap<usize, VramCounter>>>,
+        usage_counters: Arc<Mutex<HashMap<usize, UtilizationCounter>>>,
         poll_interval: Duration,
     ) -> Result<WorkerHandle> {
         let mut ticker = Interval::new_interval(poll_interval)?;
@@ -127,7 +138,7 @@ impl<H: Hardware> AmdSmiSource<H> {
                 tokio::select! {
                     _ = ticker.next() => {
                         trace!("Polled AMD SMI source.");
-                        Self::read_polled_counters(&hardware, &processors, &power_counters, &vram_counters).await?;
+                        Self::read_polled_counters(&hardware, &processors, &power_counters, &vram_counters, &usage_counters).await?;
                     }
 
                     () = cancellation_token.cancelled() => {
@@ -149,9 +160,11 @@ impl<H: Hardware> AmdSmiSource<H> {
         processors: &Arc<HashMap<usize, Processor>>,
         power_counters: &Arc<Mutex<HashMap<usize, PowerCounter>>>,
         vram_counters: &Arc<Mutex<HashMap<usize, VramCounter>>>,
+        utilization_counters: &Arc<Mutex<HashMap<usize, UtilizationCounter>>>,
     ) -> Result<()> {
         let mut vram_updates = Vec::new();
         let mut power_updates = Vec::new();
+        let mut utilization_updates = Vec::new();
 
         for (index, processor) in processors.iter() {
             if processor.support.contains(ProcessorSupport::Vram) {
@@ -160,19 +173,29 @@ impl<H: Hardware> AmdSmiSource<H> {
             if processor.support.contains(ProcessorSupport::Power) {
                 power_updates.push((*index, hardware.get_power(processor)?));
             }
+            if processor.support.contains(ProcessorSupport::Utilization) {
+                utilization_updates.push((*index, hardware.get_gpu_activity(processor)?.gpu_usage));
+            }
         }
 
         {
             let mut lock = vram_counters.lock().await;
             for (index, vram_usage) in vram_updates {
-                lock.entry(index).and_modify(|c| c.update(vram_usage));
+                lock.entry(index).or_default().update(vram_usage);
             }
         }
 
         {
             let mut lock = power_counters.lock().await;
             for (index, power) in power_updates {
-                lock.entry(index).and_modify(|c| c.push(power));
+                lock.entry(index).or_default().push(power);
+            }
+        }
+
+        {
+            let mut lock = utilization_counters.lock().await;
+            for (index, utilization) in utilization_updates {
+                lock.entry(index).or_default().update(utilization);
             }
         }
 
@@ -201,6 +224,7 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
             &self.processors,
             &self.power_counters,
             &self.vram_counters,
+            &self.utilization_counters,
         )
         .await?;
         Ok(())
@@ -225,6 +249,12 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
             counter.reset();
         }
 
+        let mut lock = self.utilization_counters.lock().await;
+        let mut utilization_counters = lock.clone();
+        for counter in lock.values_mut() {
+            counter.reset();
+        }
+
         let map = self
             .processors
             .keys()
@@ -232,10 +262,12 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
                 let energy = energy_counters.remove(index);
                 let vram = vram_counters.remove(index);
                 let power = power_counters.remove(index);
+                let utilization = utilization_counters.remove(index);
                 let counter = Counter {
                     energy,
                     vram,
                     power,
+                    utilization,
                 };
                 (*index, counter)
             })
@@ -252,6 +284,7 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
                 self.processors.clone(),
                 self.power_counters.clone(),
                 self.vram_counters.clone(),
+                self.utilization_counters.clone(),
                 poll_interval,
             )?);
         }
@@ -297,6 +330,19 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
                     processor_sensors.push(Sensor::new(
                         format!("GPU-{uuid}-vram_max"),
                         BYTE_UNIT,
+                        Self::get_name(),
+                    ));
+                }
+
+                if p.support.contains(ProcessorSupport::Utilization) {
+                    processor_sensors.push(Sensor::new(
+                        format!("GPU-{uuid}-utilization_min"),
+                        PERCENT_UNIT,
+                        Self::get_name(),
+                    ));
+                    processor_sensors.push(Sensor::new(
+                        format!("GPU-{uuid}-utilization_max"),
+                        PERCENT_UNIT,
                         Self::get_name(),
                     ));
                 }
@@ -347,6 +393,25 @@ impl<H: Hardware> MetricReader for AmdSmiSource<H> {
                         format!("GPU-{uuid}-vram_max"),
                         max,
                         BYTE_UNIT,
+                        Self::get_name(),
+                    ));
+                }
+
+                if let Some(utilization) = counter.utilization
+                    && let Some(min) = utilization.min
+                    && let Some(max) = utilization.max
+                {
+                    processor_metrics.push(Metric::new(
+                        format!("GPU-{uuid}-utilization_min"),
+                        u64::from(min),
+                        PERCENT_UNIT,
+                        Self::get_name(),
+                    ));
+
+                    processor_metrics.push(Metric::new(
+                        format!("GPU-{uuid}-utilization_max"),
+                        u64::from(max),
+                        PERCENT_UNIT,
                         Self::get_name(),
                     ));
                 }

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -17,7 +17,7 @@ use crate::{
     config::AmdSmiConfig,
     counters::{Counter, EnergyCounter, PowerCounter, UtilizationCounter, VramCounter},
     error::AmdSmiError::{self},
-    hardware::{AmdSmi, Hardware},
+    hardware::{AmdSmiHardware, AmdSmiWrapperHardware},
 };
 
 pub mod config;
@@ -67,7 +67,7 @@ pub struct Processor {
     support: ProcessorSupport,
 }
 
-pub struct AmdSmiSource<H: Hardware> {
+pub struct AmdSmi<H: AmdSmiHardware> {
     /// Source configuration.
     config: AmdSmiConfig,
 
@@ -93,10 +93,11 @@ pub struct AmdSmiSource<H: Hardware> {
     utilization_counters: Arc<Mutex<HashMap<usize, UtilizationCounter>>>,
 }
 
-impl AmdSmiSource<AmdSmi> {
+impl AmdSmi<AmdSmiWrapperHardware> {
     /// Initializes the AMD SMI source and retrieve the GPU devices.
     pub fn new(config: AmdSmiConfig) -> Result<Self> {
-        let mut amdsmi = AmdSmi::new()?;
+        let mut amdsmi = AmdSmiWrapperHardware::new()?;
+
         let processors = amdsmi
             .init_processors(config.gpus_spec.as_ref())?
             .into_iter()
@@ -116,7 +117,7 @@ impl AmdSmiSource<AmdSmi> {
     }
 }
 
-impl<H: Hardware> AmdSmiSource<H> {
+impl<H: AmdSmiHardware> AmdSmi<H> {
     /// Creates the worker task for power and vram polling at the specified polling interval.
     pub fn create_worker(
         hardware: Arc<H>,
@@ -203,7 +204,7 @@ impl<H: Hardware> AmdSmiSource<H> {
     }
 }
 
-impl<H: Hardware> MetricReader for AmdSmiSource<H> {
+impl<H: AmdSmiHardware> MetricReader for AmdSmi<H> {
     type Type = HashMap<usize, Counter>;
 
     type Error = AmdSmiError;

--- a/sources/amdsmi/src/lib.rs
+++ b/sources/amdsmi/src/lib.rs
@@ -68,7 +68,11 @@ pub struct AmdSmiSource<H: Hardware> {
 impl AmdSmiSource<AmdSmi> {
     pub fn new(config: AmdSmiConfig) -> Result<Self> {
         let amdsmi = AmdSmi::new()?;
-        let processors = amdsmi.get_processors()?.into_iter().enumerate().collect();
+        let processors = amdsmi
+            .get_processors(config.gpus_spec.as_ref())?
+            .into_iter()
+            .enumerate()
+            .collect();
 
         Ok(Self {
             config,


### PR DESCRIPTION
## Description

This pull request adds a new metric source for AMD GPU using the [AMD SMI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/) library.

The AMD SMI library is  a C library, therefore we had to generate bindings and a safe wrapper to use it in rust. The generated bindings are available [here](https://github.com/joule-profiler/amd-smi-wrapper).

This source allows to retrieve the energy consumption, GPU usage and VRAM usage of AMD GPU devices.
If a device is of an old architecture, than it uses the instantaneous power to estimate the energy consumption.
On recent devices, a monotonous energy counter is available. 

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Improvement
* [ ] Documentation

## Related Issues

The related issue is #22.

## Changes Made

* AMD SMI source integration.
* Documentation, testing...

## Checklist

* [x] My code follows the project style
* [x] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass

## Additional Notes

The generated bindings are updated to the current latest version, however, we should maintain it and regenerate them when a new version is available. Moreover, the user can generate the bindings itself but it requires more setup.