### PR TITLE
feat(perf): added cpu specification to not open counters on each core…

### DIFF
--- a/sources/perf_event/src/config.rs
+++ b/sources/perf_event/src/config.rs
@@ -22,4 +22,10 @@ pub struct PerfConfig {
 
     /// The root path of the cgroup if cgroup name is provided.
     pub cgroup_root: Option<PathBuf>,
+
+    /// If the source uses the cgroup, then you can specify on
+    /// which CPU cores you want to open the counters.
+    /// It can be useful if your program has a configured CPU affinity (e.g., taskset)
+    /// Not opening counters on all cores can improve the performance of the source.
+    pub cpu_spec: Option<HashSet<u32>>,
 }

--- a/sources/perf_event/src/error.rs
+++ b/sources/perf_event/src/error.rs
@@ -36,4 +36,7 @@ pub enum PerfEventError {
         #[source]
         tokio::task::JoinError,
     ),
+
+    #[error("CPU specification invalid, the provided CPU core {0} is not an online CPU.")]
+    InvalidCpuCore(u32),
 }

--- a/sources/perf_event/src/hardware.rs
+++ b/sources/perf_event/src/hardware.rs
@@ -18,8 +18,9 @@ pub enum Target {
     /// it runs on (via `inherit`).
     Pid(i32),
     /// Track every process inside a cgroup. Cgroup-scoped events don't
-    /// support `inherit`, so this is monitored with one group per online CPU.
-    Cgroup(File),
+    /// support `inherit`, so this is monitored with one group per online CPU
+    /// or per CPU in the specification if provided.
+    Cgroup(File, Option<HashSet<u32>>),
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -65,7 +66,9 @@ impl PerfEventHardware for PerfEventCounters {
     async fn init_counters(&mut self, events: &[Event], target: Target) -> Result<()> {
         match target {
             Target::Pid(pid) => self.init_pid_counters(events, pid).await,
-            Target::Cgroup(cgroup_fd) => self.init_cgroup_counters(events, cgroup_fd).await,
+            Target::Cgroup(cgroup_fd, cpu_spec) => {
+                self.init_cgroup_counters(events, cpu_spec, cgroup_fd).await
+            }
         }
     }
 
@@ -144,11 +147,30 @@ impl PerfEventCounters {
     /// event later, in `PerfEvent::to_metrics`. Each group is opened on its
     /// own blocking thread, in parallel, since building it and adding its
     /// events are all blocking `perf_event_open`/ioctl calls.
-    async fn init_cgroup_counters(&mut self, events: &[Event], cgroup_fd: File) -> Result<()> {
-        let cpus = list_online_cpus()?;
+    async fn init_cgroup_counters(
+        &mut self,
+        events: &[Event],
+        cpu_spec: Option<HashSet<u32>>,
+        cgroup_fd: File,
+    ) -> Result<()> {
+        let online_cpus = list_online_cpus()?;
+        let cpus = if let Some(cpu_spec) = cpu_spec {
+            for cpu in &cpu_spec {
+                if !online_cpus.contains(cpu) {
+                    return Err(PerfEventError::InvalidCpuCore(*cpu));
+                }
+            }
+            cpu_spec
+        } else {
+            online_cpus
+        };
+
+        debug!("Initializing perf_event counters with cgroup for cores: {cpus:?}");
+
         let cgroup_fd = Arc::new(cgroup_fd);
 
         let tasks = cpus.into_iter().map(|cpu| {
+            let cpu = cpu as usize;
             let cgroup_fd = cgroup_fd.clone();
             let events = events.to_vec();
             spawn_blocking(move || -> Result<(usize, Group, HashMap<Event, Counter>)> {
@@ -194,7 +216,7 @@ impl PerfEventCounters {
 }
 
 /// Reads the set of online CPU ids from sysfs (e.g. `0-2,4`).
-fn list_online_cpus() -> Result<HashSet<usize>> {
+fn list_online_cpus() -> Result<HashSet<u32>> {
     let content = fs::read_to_string("/sys/devices/system/cpu/online")?;
 
     let mut cpus = HashSet::new();
@@ -203,8 +225,8 @@ fn list_online_cpus() -> Result<HashSet<usize>> {
             continue;
         }
         if let Some((start, end)) = part.split_once('-') {
-            let start: usize = start.parse()?;
-            let end: usize = end.parse()?;
+            let start: u32 = start.parse()?;
+            let end: u32 = end.parse()?;
             cpus.extend(start..=end);
         } else {
             cpus.insert(part.parse()?);

--- a/sources/perf_event/src/lib.rs
+++ b/sources/perf_event/src/lib.rs
@@ -7,6 +7,7 @@
 //! `inherit(true)` is incompatible with `perf_event` groups on Linux.
 
 use std::{
+    collections::HashSet,
     fs::File,
     path::{Path, PathBuf},
 };
@@ -47,6 +48,7 @@ const CGROUP_ROOT: &str = "/sys/fs/cgroup";
 struct CgroupConfig {
     name: PathBuf,
     root: PathBuf,
+    cpu_spec: Option<HashSet<u32>>,
 }
 
 /// Hardware performance counter source using `perf_event`.
@@ -75,6 +77,7 @@ impl<H: PerfEventHardware + 'static> MetricReader for PerfEvent<H> {
             Some(CgroupConfig {
                 name: cgroup_name,
                 root: config.cgroup_root.take().unwrap_or(CGROUP_ROOT.into()),
+                cpu_spec: config.cpu_spec,
             })
         } else {
             None
@@ -92,13 +95,13 @@ impl<H: PerfEventHardware + 'static> MetricReader for PerfEvent<H> {
     }
 
     async fn pre_init(&mut self) -> Result<()> {
-        if let Some(cgroup_config) = &self.cgroup_config {
+        if let Some(cgroup_config) = &mut self.cgroup_config {
             let path = Path::new(&cgroup_config.root).join(&cgroup_config.name);
             info!(
                 "Initializing perf_event source for cgroup {}",
                 path.display()
             );
-            let target = Target::Cgroup(File::open(path)?);
+            let target = Target::Cgroup(File::open(path)?, cgroup_config.cpu_spec.take());
             self.hardware.init_counters(&self.events, target).await?;
         }
         Ok(())


### PR DESCRIPTION
… when using cgroup

## Description

This pull request adds a way to configure on which cores to open the perf_event counters when using the cgroups.
It allows the user to configure a specification.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Improvement
* [ ] Documentation

## Related Issues

The issue related is #58.

## Changes Made

* Added cpu_spec config option in the perf_event config
* Open counters only on the cores configured by the cpu spec if provided

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass