### PR TITLE
Perf/60 spawn phase detection in separate thread

### DIFF
--- a/core/src/orchestrator/mod.rs
+++ b/core/src/orchestrator/mod.rs
@@ -121,20 +121,32 @@ impl Orchestrator {
             .collect();
     }
 
-    /// Send a measure event to each metrics source.
+    /// Sends a measure event to each metric source, blocking.
     ///
-    /// This function ensure event submission, but is does not ensure
-    /// measurement completion and that the measure will be taken directly after it.
-    /// At high concurrency and with many running sources, the measurement can be made lately.
+    /// This function ensures event submission, not measurement completion.
+    /// Must be called from outside the async runtime (e.g. the reader thread).
     #[inline]
-    pub async fn measure(&mut self) -> Result<(), OrchestratorError> {
-        self.send_event(SourceEvent::Measure).await
+    pub fn measure_blocking(&mut self) -> Result<(), OrchestratorError> {
+        self.send_event_blocking(SourceEvent::Measure)
     }
 
-    /// Initializes a new phase for each metric source.
+    /// Initializes a new phase for each metric source, blocking.
+    ///
+    /// Must be called from outside the async runtime (e.g. the reader thread).
     #[inline]
-    pub async fn new_phase(&mut self) -> Result<(), OrchestratorError> {
-        self.send_event(SourceEvent::NewPhase).await
+    pub fn new_phase_blocking(&mut self) -> Result<(), OrchestratorError> {
+        self.send_event_blocking(SourceEvent::NewPhase)
+    }
+
+    /// Sends the provided event to all the metric sources, blocking.
+    ///
+    /// A send only fails when a source worker died: the source error is
+    /// surfaced later, when joining the workers.
+    fn send_event_blocking(&mut self, event: SourceEvent) -> Result<(), OrchestratorError> {
+        for handle in &self.handles {
+            handle.control_sender.blocking_send(event)?;
+        }
+        Ok(())
     }
 
     /// Retrieves and merge results from all sources.
@@ -323,7 +335,13 @@ mod tests {
         orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
         orchestrator.run();
 
-        let _ = orchestrator.measure().await;
+        // blocking_send must run off the async runtime.
+        let mut orchestrator = tokio::task::spawn_blocking(move || {
+            let _ = orchestrator.measure_blocking();
+            orchestrator
+        })
+        .await
+        .unwrap();
         let _ = orchestrator.join().await;
 
         tokio::task::yield_now().await;
@@ -378,7 +396,13 @@ mod tests {
 
         orchestrator.init(0, Duration::from_secs(1)).await.unwrap();
         orchestrator.run();
-        orchestrator.measure().await.unwrap();
+        // blocking_send must run off the async runtime.
+        let mut orchestrator = tokio::task::spawn_blocking(move || {
+            orchestrator.measure_blocking().unwrap();
+            orchestrator
+        })
+        .await
+        .unwrap();
         let result = orchestrator.finalize().await;
 
         assert!(result.is_err());

--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -65,6 +65,14 @@ pub enum JouleProfilerError {
     #[error("Process control failed: {0}")]
     ProcessControlFailed(String),
 
+    /// Failed to spawn the stdout reader thread.
+    #[error("Failed to spawn stdout reader thread: {0}")]
+    ReaderThreadSpawnFailed(String),
+
+    /// The stdout reader thread panicked before completing.
+    #[error("Stdout reader thread panicked")]
+    ReaderThreadPanicked,
+
     /// Error propagated from a metric source.
     #[error("Metric source error.")]
     MetricSourceError(#[from] MetricSourceError),

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -9,11 +9,11 @@ use regex::Regex;
 use std::io::BufWriter;
 use std::os::unix::process::CommandExt;
 use std::process::{Child, ChildStdout, Command};
-use std::thread::JoinHandle;
 use std::{
     io::{BufRead, BufReader, ErrorKind, Write},
     process::{self, Stdio},
 };
+use tokio::sync::oneshot;
 
 pub mod error;
 
@@ -37,8 +37,9 @@ struct MeasureData {
     end_timestamp: u128,
 }
 
-/// Reader thread handle: gives the orchestrator back with the collected data.
-type ReaderThreadHandle = JoinHandle<(Orchestrator, Result<MeasureData>)>;
+/// What the reader thread sends back once done: the orchestrator (to reuse
+/// its sources) alongside the measurement outcome.
+type ReaderResult = (Orchestrator, Result<MeasureData>);
 
 /// Orchestrates program profiling and metric collection.
 ///
@@ -138,16 +139,16 @@ impl JouleProfiler {
 
         pause_process(pid)?;
 
+        orchestrator.init(pid, config.init_timeout).await?;
+        orchestrator.run();
+
         let child_stdout = child
             .stdout
             .take()
             .ok_or(JouleProfilerError::StdOutCaptureFail)?;
 
-        orchestrator.init(pid, config.init_timeout).await?;
-        orchestrator.run();
-
         info!("Starting measurements");
-        let reader_thread = spawn_reader_thread(
+        let reader_result_rx = spawn_reader_thread(
             orchestrator,
             child_stdout,
             regex,
@@ -155,10 +156,9 @@ impl JouleProfiler {
             pid,
         )?;
 
-        let (mut orchestrator, measure_result) =
-            tokio::task::spawn_blocking(move || join_reader_thread(reader_thread))
-                .await
-                .map_err(|_| JouleProfilerError::ReaderThreadPanicked)??;
+        let (mut orchestrator, measure_result) = reader_result_rx
+            .await
+            .map_err(|_| JouleProfilerError::ReaderThreadPanicked)?;
 
         let MeasureData {
             phases: detected_phases,
@@ -176,6 +176,7 @@ impl JouleProfiler {
 
         let command_duration_ms = (end_timestamp - begin_timestamp) / 1000;
         let timestamp = begin_timestamp;
+
         let exit_code = tokio::task::spawn_blocking(move || wait_for_child_exit(&mut child))
             .await
             .map_err(|_| {
@@ -270,15 +271,17 @@ fn measure_phases_blocking(
     })
 }
 
-/// Spawns the reader thread, which owns the orchestrator during the run and
-/// gives it back on join.
+/// Spawns the dedicated reader thread, which owns the orchestrator during the
+/// run and sends it back with the measurement outcome once done.
 fn spawn_reader_thread(
     mut orchestrator: Orchestrator,
     child_stdout: ChildStdout,
     regex: Regex,
     stdout_file: Option<String>,
     pid: i32,
-) -> Result<ReaderThreadHandle> {
+) -> Result<oneshot::Receiver<ReaderResult>> {
+    let (tx, rx) = oneshot::channel();
+
     std::thread::Builder::new()
         .name("phase-reader".to_string())
         .spawn(move || {
@@ -289,15 +292,11 @@ fn spawn_reader_thread(
                 stdout_file.as_ref(),
                 pid,
             );
-            (orchestrator, result)
+            let _ = tx.send((orchestrator, result));
         })
-        .map_err(|err| JouleProfilerError::ReaderThreadSpawnFailed(err.to_string()))
-}
+        .map_err(|err| JouleProfilerError::ReaderThreadSpawnFailed(err.to_string()))?;
 
-fn join_reader_thread<T>(handle: JoinHandle<T>) -> Result<T> {
-    handle
-        .join()
-        .map_err(|_| JouleProfilerError::ReaderThreadPanicked)
+    Ok(rx)
 }
 
 /// Reads the child's stdout line by line; every line matching the regex
@@ -475,8 +474,8 @@ mod tests {
     use crate::orchestrator::Orchestrator;
     use crate::phase::{PhaseInfo, PhaseToken};
     use crate::profiler::{
-        create_output_sink, join_reader_thread, phase_token_in_line, read_and_detect_phases,
-        spawn_profiled_command, wait_for_child_exit,
+        create_output_sink, phase_token_in_line, read_and_detect_phases, spawn_profiled_command,
+        wait_for_child_exit,
     };
     use crate::sensor::Sensors;
     use crate::source::MetricReader;
@@ -654,31 +653,18 @@ mod tests {
         assert_eq!(phases.len(), 1);
     }
 
-    #[test]
-    fn join_reader_thread_propagates_panic_as_error() {
-        let handle = std::thread::spawn(|| -> crate::profiler::types::Result<()> {
-            panic!("boom");
-        });
+    #[tokio::test]
+    async fn reader_channel_dropped_without_send_maps_to_reader_thread_panicked() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        drop(tx);
 
-        let result = join_reader_thread(handle);
+        let result: crate::profiler::types::Result<()> = rx
+            .await
+            .map_err(|_| JouleProfilerError::ReaderThreadPanicked);
 
         assert!(matches!(
             result,
             Err(JouleProfilerError::ReaderThreadPanicked)
-        ));
-    }
-
-    #[test]
-    fn join_reader_thread_returns_thread_result() {
-        let handle = std::thread::spawn(|| -> crate::profiler::types::Result<()> {
-            Err(JouleProfilerError::StdOutCaptureFail)
-        });
-
-        let result = join_reader_thread(handle);
-
-        assert!(matches!(
-            result,
-            Ok(Err(JouleProfilerError::StdOutCaptureFail))
         ));
     }
 

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -31,7 +31,11 @@ pub use error::JouleProfilerError;
 pub mod types;
 
 /// Phases and begin/end timestamps collected by the reader thread.
-type MeasureData = (Vec<PhaseInfo>, u128, u128);
+struct MeasureData {
+    phases: Vec<PhaseInfo>,
+    begin_timestamp: u128,
+    end_timestamp: u128,
+}
 
 /// Reader thread handle: gives the orchestrator back with the collected data.
 type ReaderThreadHandle = JoinHandle<(Orchestrator, Result<MeasureData>)>;
@@ -132,7 +136,7 @@ impl JouleProfiler {
         let mut child = spawn_profiled_command(config)?;
         let pid = child.id().cast_signed();
 
-        pause_prosess(pid)?;
+        pause_process(pid)?;
 
         let child_stdout = child
             .stdout
@@ -156,19 +160,27 @@ impl JouleProfiler {
                 .await
                 .map_err(|_| JouleProfilerError::ReaderThreadPanicked)??;
 
-        let (detected_phases, begin_timestamp, end_timestamp) = match measure_result {
+        let MeasureData {
+            phases: detected_phases,
+            begin_timestamp,
+            end_timestamp,
+        } = match measure_result {
             Ok(data) => data,
             Err(err) => {
                 return Err(match orchestrator.finalize().await {
                     Err(source_err) => source_err.into(),
                     Ok(_) => err,
-                })?;
+                });
             }
         };
 
         let command_duration_ms = (end_timestamp - begin_timestamp) / 1000;
         let timestamp = begin_timestamp;
-        let exit_code = wait_for_child_exit(&mut child)?;
+        let exit_code = tokio::task::spawn_blocking(move || wait_for_child_exit(&mut child))
+            .await
+            .map_err(|_| {
+                JouleProfilerError::ProcessControlFailed("wait thread panicked".to_string())
+            })??;
         info!("Command finished: duration={command_duration_ms} ms exit_code={exit_code}");
 
         let (sources_results, sources) = orchestrator.finalize().await?;
@@ -251,7 +263,11 @@ fn measure_phases_blocking(
     orchestrator.new_phase_blocking()?;
     detected_phases.push(PhaseInfo::end(end_timestamp));
 
-    Ok((detected_phases, begin_timestamp, end_timestamp))
+    Ok(MeasureData {
+        phases: detected_phases,
+        begin_timestamp,
+        end_timestamp,
+    })
 }
 
 /// Spawns the reader thread, which owns the orchestrator during the run and
@@ -427,7 +443,7 @@ fn create_output_sink(path: Option<&String>) -> Result<Box<dyn Write>> {
 
 /// Sends `SIGSTOP` to a child process to pause its execution.
 ///
-/// SAFETY
+/// # Preconditions
 ///
 /// - 'pid' must refer to a valid process identifier obtained from
 ///   '`std::process::Child::id()`' immediately after spawning.
@@ -436,13 +452,13 @@ fn create_output_sink(path: Option<&String>) -> Result<Box<dyn Write>> {
 ///
 /// Returns [`JouleProfilerError::ProcessControlFailed`] if the
 /// signal delivery fails.
-fn pause_prosess(pid: i32) -> Result<()> {
+fn pause_process(pid: i32) -> Result<()> {
     signal(pid, libc::SIGSTOP)
 }
 
 /// Sends `SIGCONT` to resume a previously paused process.
 ///
-/// SAFETY
+/// # Preconditions
 ///
 /// - `pid` must refer to a valid, running or stopped child process.
 /// - The process must still exist when the signal is sent.

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -8,11 +8,13 @@ use log::{debug, info, trace};
 use regex::Regex;
 use std::io::BufWriter;
 use std::os::unix::process::CommandExt;
-use std::process::{Child, Command};
+use std::process::{Child, ChildStdout, Command};
+use std::thread::JoinHandle;
 use std::{
     io::{BufRead, BufReader, ErrorKind, Write},
     process::{self, Stdio},
 };
+use tokio::sync::mpsc::{Receiver, Sender};
 
 pub mod error;
 
@@ -28,6 +30,8 @@ use crate::util::time::get_timestamp_micros;
 pub use error::JouleProfilerError;
 
 pub mod types;
+
+const PHASE_CHANNEL_SIZE: usize = 2;
 
 /// Orchestrates program profiling and metric collection.
 ///
@@ -118,6 +122,9 @@ impl JouleProfiler {
             return Err(JouleProfilerError::NoSourceConfigured);
         }
         let mut orchestrator = Orchestrator::new(sources);
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<PhaseInfo>(PHASE_CHANNEL_SIZE);
+
         orchestrator.pre_init().await?;
 
         debug!("Spawning command: {:?}", config.cmd);
@@ -125,15 +132,24 @@ impl JouleProfiler {
         let pid = child.id().cast_signed();
 
         pause_prosess(pid)?;
+
+        let child_stdout = child
+            .stdout
+            .take()
+            .ok_or(JouleProfilerError::StdOutCaptureFail)?;
+        let reader_thread =
+            spawn_reader_thread(child_stdout, regex, config.stdout_file.clone(), tx)?;
+
         orchestrator.init(pid, config.init_timeout).await?;
         orchestrator.run();
 
         info!("Starting measurements");
         let (command_duration_ms, timestamp, exit_code, detected_phases) = self
-            .measure_phases(&mut orchestrator, config, &regex, &mut child, pid)
+            .measure_phases(&mut orchestrator, &mut child, rx, pid)
             .await?;
 
         let (sources_results, sources) = orchestrator.finalize().await?;
+        join_reader_thread(reader_thread)?;
         self.sources = sources;
 
         let mut phases: Vec<_> = detected_phases
@@ -160,7 +176,7 @@ impl JouleProfiler {
         if phases.is_empty()
             && let Some(end_phase) = sources_results.phases.into_iter().last()
         {
-            let phase = Phase {
+            phases.push(Phase {
                 index: 0,
                 metrics: end_phase.metrics,
                 start_token: PhaseToken::Start,
@@ -169,8 +185,7 @@ impl JouleProfiler {
                 duration_ms: command_duration_ms,
                 start_token_line: None,
                 end_token_line: None,
-            };
-            phases.push(phase);
+            });
         }
 
         debug!("Collected {} sensor phase(s)", phases.len());
@@ -197,40 +212,24 @@ impl JouleProfiler {
     async fn measure_phases(
         &mut self,
         orchestrator: &mut Orchestrator,
-        config: &ProfileConfig,
-        regex: &Regex,
         child: &mut Child,
+        mut rx: Receiver<PhaseInfo>,
         pid: i32,
     ) -> Result<MeasurePhasesReturnType> {
-        let mut sink = create_output_sink(config.stdout_file.as_ref())?;
-
-        let child_stdout = child
-            .stdout
-            .take()
-            .ok_or(JouleProfilerError::StdOutCaptureFail)?;
-
-        let reader = BufReader::new(child_stdout);
         let mut detected_phases = Vec::with_capacity(2);
 
         let begin_timestamp = get_timestamp_micros();
         trace!("Begin timestamp: {begin_timestamp}");
 
         orchestrator.measure().await?;
-
         resume_process(pid)?;
-
         detected_phases.push(PhaseInfo::start(begin_timestamp));
 
-        self.detect_and_handle_phases_from_program_output(
-            orchestrator,
-            &mut detected_phases,
-            reader,
-            regex,
-            &mut sink,
-        )
-        .await?;
-
-        sink.flush()?;
+        while let Some(phase_info) = rx.recv().await {
+            orchestrator.measure().await?;
+            orchestrator.new_phase().await?;
+            detected_phases.push(phase_info);
+        }
 
         let end_timestamp = get_timestamp_micros();
         trace!("End timestamp: {end_timestamp}");
@@ -239,83 +238,97 @@ impl JouleProfiler {
         orchestrator.new_phase().await?;
 
         let duration_ms = (end_timestamp - begin_timestamp) / 1000;
-
         detected_phases.push(PhaseInfo::end(end_timestamp));
 
         let exit_code = wait_for_child_exit(child)?;
-
         info!("Command finished: duration={duration_ms} ms exit_code={exit_code}");
 
         Ok((duration_ms, begin_timestamp, exit_code, detected_phases))
     }
+}
 
-    /// Detects and measures the phases from the profiled program standard output.
-    ///
-    /// When a token in the standard output matches the specified regular expression,
-    /// a measure is made and a new phase begins.
-    async fn detect_and_handle_phases_from_program_output<R, W>(
-        &mut self,
-        orchestrator: &mut Orchestrator,
-        phases: &mut Vec<PhaseInfo>,
-        mut reader: R,
-        regex: &Regex,
-        sink: &mut W,
-    ) -> Result<()>
-    where
-        R: BufRead,
-        W: Write + ?Sized,
-    {
-        let mut line = String::new();
-        let mut line_number: usize = 0;
+fn spawn_reader_thread(
+    child_stdout: ChildStdout,
+    regex: Regex,
+    stdout_file: Option<String>,
+    tx: Sender<PhaseInfo>,
+) -> Result<JoinHandle<Result<()>>> {
+    let reader = BufReader::new(child_stdout);
 
-        loop {
-            line.clear();
+    std::thread::Builder::new()
+        .name("phase-reader".to_string())
+        .spawn(move || {
+            let sink = create_output_sink(stdout_file.as_ref())?;
+            read_and_detect_phases(reader, &regex, sink, &tx)
+        })
+        .map_err(|err| JouleProfilerError::ReaderThreadSpawnFailed(err.to_string()))
+}
 
-            let n = match reader.read_line(&mut line) {
-                Ok(n) => n,
-                Err(e) if e.kind() == ErrorKind::InvalidData => {
-                    trace!("Skipping invalid UTF-8 output at line {line_number}");
-                    line_number += 1;
-                    continue;
-                }
-                Err(e) => return Err(e.into()),
-            };
+fn join_reader_thread(handle: JoinHandle<Result<()>>) -> Result<()> {
+    match handle.join() {
+        Ok(inner) => inner,
+        Err(_) => Err(JouleProfilerError::ReaderThreadPanicked),
+    }
+}
 
-            if n == 0 {
-                break;
+/// Reads the child's stdout line by line, and emits a [`PhaseInfo`]
+/// in the channel for every line whose content matches the regex pattern.
+fn read_and_detect_phases<R, W>(
+    mut reader: R,
+    regex: &Regex,
+    mut sink: W,
+    tx: &Sender<PhaseInfo>,
+) -> Result<()>
+where
+    R: BufRead,
+    W: Write,
+{
+    let mut line = String::new();
+    let mut line_number: usize = 0;
+
+    loop {
+        line.clear();
+
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(e) if e.kind() == ErrorKind::InvalidData => {
+                trace!("Skipping invalid UTF-8 output at line {line_number}");
+                line_number += 1;
+                continue;
             }
-
-            if line.ends_with('\n') {
-                line.pop();
-                if line.ends_with('\r') {
-                    line.pop();
-                }
-            }
-
-            writeln!(sink, "{line}")?;
-
-            if let Some(token) = phase_token_in_line(regex, &line) {
-                let phase_timestamp = get_timestamp_micros();
-
-                debug!("Detected phase at line {line_number}, token '{token}'");
-
-                orchestrator.measure().await?;
-                orchestrator.new_phase().await?;
-
-                let phase_info = PhaseInfo {
-                    token: PhaseToken::Token(token.to_owned()),
-                    timestamp: phase_timestamp,
-                    line_number: Some(line_number),
-                };
-
-                phases.push(phase_info);
-            }
-
-            line_number += 1;
+            Err(e) => return Err(e.into()),
         }
 
-        Ok(())
+        if line.ends_with('\n') {
+            line.pop();
+            if line.ends_with('\r') {
+                line.pop();
+            }
+        }
+
+        writeln!(sink, "{line}")?;
+
+        if let Some(token) = phase_token_in_line(regex, &line) {
+            let phase_timestamp = get_timestamp_micros();
+            debug!("Detected phase at line {line_number}, token '{token}'");
+
+            let phase_info = PhaseInfo {
+                token: PhaseToken::Token(token.to_owned()),
+                timestamp: phase_timestamp,
+                line_number: Some(line_number),
+            };
+
+            if tx.blocking_send(phase_info).is_err() {
+                break;
+            }
+        }
+
+        line_number += 1;
     }
+
+    sink.flush()?;
+    Ok(())
 }
 
 /// Checks whether a line matches the specified regular expression.
@@ -430,10 +443,10 @@ fn resume_process(pid: i32) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::config::ProfileConfig;
-    use crate::orchestrator::Orchestrator;
-    use crate::phase::PhaseToken;
+    use crate::phase::{PhaseInfo, PhaseToken};
     use crate::profiler::{
-        create_output_sink, phase_token_in_line, spawn_profiled_command, wait_for_child_exit,
+        create_output_sink, join_reader_thread, phase_token_in_line, read_and_detect_phases,
+        spawn_profiled_command, wait_for_child_exit,
     };
     use crate::sensor::Sensors;
     use crate::source::MetricReader;
@@ -442,7 +455,7 @@ mod tests {
     use mockall::mock;
     use regex::Regex;
     use std::fs;
-    use std::io::{BufReader, Cursor, Read};
+    use std::io::{BufReader, Cursor, Read, Write};
     use std::time::Duration;
     use tempfile::TempDir;
 
@@ -452,8 +465,25 @@ mod tests {
         }
     }
 
-    fn orchestrator() -> Orchestrator {
-        Orchestrator::new(Vec::new())
+    /// Drives [`read_and_detect_phases`] to completion over an in-memory reader and
+    /// collects every [`PhaseInfo`] it emitted through the channel.
+    fn collect_phases<R, W>(
+        reader: R,
+        regex: &Regex,
+        sink: W,
+    ) -> crate::profiler::types::Result<Vec<PhaseInfo>>
+    where
+        R: std::io::BufRead,
+        W: Write,
+    {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<PhaseInfo>(16);
+        read_and_detect_phases(reader, regex, sink, &tx)?;
+
+        let mut phases = Vec::new();
+        while let Ok(phase) = rx.try_recv() {
+            phases.push(phase);
+        }
+        Ok(phases)
     }
 
     fn create_test_config(cmd: Vec<String>) -> ProfileConfig {
@@ -496,26 +526,14 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn detect_multiple_phases() {
-        let mut profiler = joule_profiler();
-        let mut orchestrator = orchestrator();
+    #[test]
+    fn detect_multiple_phases() {
         let regex = Regex::new("__[A-Z0-9_]+__").unwrap();
         let cursor = Cursor::new("__PHASE1__\n__PHASE2__\n__PHASE3__");
         let reader = BufReader::new(cursor);
-        let mut phases = Vec::new();
-        let mut sink: Vec<u8> = Vec::new();
+        let sink: Vec<u8> = Vec::new();
 
-        profiler
-            .detect_and_handle_phases_from_program_output(
-                &mut orchestrator,
-                &mut phases,
-                reader,
-                &regex,
-                &mut sink,
-            )
-            .await
-            .unwrap();
+        let phases = collect_phases(reader, &regex, sink).unwrap();
 
         assert_eq!(3, phases.len());
         assert_eq!(PhaseToken::Token("__PHASE1__".to_string()), phases[0].token);
@@ -523,129 +541,70 @@ mod tests {
         assert_eq!(PhaseToken::Token("__PHASE3__".to_string()), phases[2].token);
     }
 
-    #[tokio::test]
-    async fn detect_no_phases() {
-        let mut profiler = joule_profiler();
-        let mut orchestrator = orchestrator();
+    #[test]
+    fn detect_no_phases() {
         let regex = Regex::new("__[A-Z0-9_]+__").unwrap();
         let cursor = Cursor::new("hello\nworld\nno phases here");
         let reader = BufReader::new(cursor);
-        let mut phases = Vec::new();
-        let mut sink: Vec<u8> = Vec::new();
-        profiler
-            .detect_and_handle_phases_from_program_output(
-                &mut orchestrator,
-                &mut phases,
-                reader,
-                &regex,
-                &mut sink,
-            )
-            .await
-            .unwrap();
+        let sink: Vec<u8> = Vec::new();
+
+        let phases = collect_phases(reader, &regex, sink).unwrap();
 
         assert!(phases.is_empty());
     }
 
-    #[tokio::test]
-    async fn detect_empty_output() {
-        let mut profiler = joule_profiler();
-        let mut orchestrator = orchestrator();
+    #[test]
+    fn detect_empty_output() {
         let regex = Regex::new("__PHASE__").unwrap();
         let cursor = Cursor::new("");
         let reader = BufReader::new(cursor);
-        let mut phases = Vec::new();
-        let mut sink: Vec<u8> = Vec::new();
+        let sink: Vec<u8> = Vec::new();
 
-        profiler
-            .detect_and_handle_phases_from_program_output(
-                &mut orchestrator,
-                &mut phases,
-                reader,
-                &regex,
-                &mut sink,
-            )
-            .await
-            .unwrap();
+        let phases = collect_phases(reader, &regex, sink).unwrap();
 
         assert_eq!(phases.len(), 0);
     }
 
-    #[tokio::test]
-    async fn detect_phase_in_middle_of_line() {
-        let mut profiler = joule_profiler();
-        let mut orchestrator = orchestrator();
+    #[test]
+    fn detect_phase_in_middle_of_line() {
         let regex = Regex::new("__PHASE[0-9]+__").unwrap();
         let cursor = Cursor::new("start __PHASE1__ end");
         let reader = BufReader::new(cursor);
-        let mut phases = Vec::new();
-        let mut sink: Vec<u8> = Vec::new();
+        let sink: Vec<u8> = Vec::new();
 
-        profiler
-            .detect_and_handle_phases_from_program_output(
-                &mut orchestrator,
-                &mut phases,
-                reader,
-                &regex,
-                &mut sink,
-            )
-            .await
-            .unwrap();
+        let phases = collect_phases(reader, &regex, sink).unwrap();
 
         assert_eq!(phases.len(), 1);
         assert_eq!(phases[0].token, PhaseToken::Token("__PHASE1__".to_string()));
         assert_eq!(phases[0].line_number, Some(0));
     }
 
-    #[tokio::test]
-    async fn detect_correct_line_numbers() {
-        let mut profiler = joule_profiler();
-        let mut orchestrator = Orchestrator::new(Vec::new());
+    #[test]
+    fn detect_correct_line_numbers() {
         let regex = Regex::new("__PHASE[0-9]+__").unwrap();
         let cursor = Cursor::new("a\nb\n__PHASE1__\nc\n__PHASE2__");
         let reader = BufReader::new(cursor);
-        let mut phases = Vec::new();
-        let mut sink: Vec<u8> = Vec::new();
+        let sink: Vec<u8> = Vec::new();
 
-        profiler
-            .detect_and_handle_phases_from_program_output(
-                &mut orchestrator,
-                &mut phases,
-                reader,
-                &regex,
-                &mut sink,
-            )
-            .await
-            .unwrap();
+        let phases = collect_phases(reader, &regex, sink).unwrap();
 
         assert_eq!(phases.len(), 2);
         assert_eq!(phases[0].line_number, Some(2));
         assert_eq!(phases[1].line_number, Some(4));
     }
 
-    #[tokio::test]
-    async fn writes_stdout_to_file() {
+    #[test]
+    fn writes_stdout_to_file() {
         use std::fs;
         use tempfile::NamedTempFile;
 
-        let mut profiler = joule_profiler();
-        let mut orchestrator = orchestrator();
         let regex = Regex::new("__PHASE__").unwrap();
         let cursor = Cursor::new("hello\n__PHASE__\nworld");
         let reader = BufReader::new(cursor);
 
         let mut temp_file = NamedTempFile::new().unwrap();
-        let mut phases = Vec::new();
 
-        profiler
-            .detect_and_handle_phases_from_program_output(
-                &mut orchestrator,
-                &mut phases,
-                reader,
-                &regex,
-                temp_file.as_file_mut(),
-            )
-            .await
-            .unwrap();
+        collect_phases(reader, &regex, temp_file.as_file_mut()).unwrap();
 
         let content = fs::read_to_string(temp_file.path()).unwrap();
         assert!(content.contains("hello"));
@@ -653,10 +612,8 @@ mod tests {
         assert!(content.contains("world"));
     }
 
-    #[tokio::test]
-    async fn skips_invalid_utf8_lines() {
-        let mut profiler = joule_profiler();
-        let mut orchestrator = orchestrator();
+    #[test]
+    fn skips_invalid_utf8_lines() {
         let regex = Regex::new("__PHASE__").unwrap();
 
         let bytes = vec![
@@ -664,21 +621,51 @@ mod tests {
         ];
         let cursor = Cursor::new(bytes);
         let reader = BufReader::new(cursor);
-        let mut phases = Vec::new();
-        let mut sink: Vec<u8> = Vec::new();
+        let sink: Vec<u8> = Vec::new();
 
-        profiler
-            .detect_and_handle_phases_from_program_output(
-                &mut orchestrator,
-                &mut phases,
-                reader,
-                &regex,
-                &mut sink,
-            )
-            .await
-            .unwrap();
+        let phases = collect_phases(reader, &regex, sink).unwrap();
 
         assert_eq!(phases.len(), 1);
+    }
+
+    #[test]
+    fn read_and_detect_phases_stops_when_receiver_dropped() {
+        let regex = Regex::new("__PHASE__").unwrap();
+        let cursor = Cursor::new("__PHASE__\n__PHASE__\n__PHASE__");
+        let reader = BufReader::new(cursor);
+        let sink: Vec<u8> = Vec::new();
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<PhaseInfo>(1);
+        drop(rx);
+
+        let result = read_and_detect_phases(reader, &regex, sink, &tx);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn join_reader_thread_propagates_panic_as_error() {
+        let handle = std::thread::spawn(|| -> crate::profiler::types::Result<()> {
+            panic!("boom");
+        });
+
+        let result = join_reader_thread(handle);
+
+        assert!(matches!(
+            result,
+            Err(JouleProfilerError::ReaderThreadPanicked)
+        ));
+    }
+
+    #[test]
+    fn join_reader_thread_propagates_inner_error() {
+        let handle = std::thread::spawn(|| -> crate::profiler::types::Result<()> {
+            Err(JouleProfilerError::StdOutCaptureFail)
+        });
+
+        let result = join_reader_thread(handle);
+
+        assert!(matches!(result, Err(JouleProfilerError::StdOutCaptureFail)));
     }
 
     #[test]

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -14,14 +14,13 @@ use std::{
     io::{BufRead, BufReader, ErrorKind, Write},
     process::{self, Stdio},
 };
-use tokio::sync::mpsc::{Receiver, Sender};
 
 pub mod error;
 
 use crate::config::ProfileConfig;
 use crate::orchestrator::Orchestrator;
 use crate::phase::{PhaseInfo, PhaseToken};
-use crate::profiler::types::{MeasurePhasesReturnType, Phase, ProfilerResults, Result};
+use crate::profiler::types::{Phase, ProfilerResults, Result};
 use crate::sensor::{Sensor, Sensors};
 use crate::source::{MetricReader, MetricSource, MetricSourceError};
 use crate::util::fs::create_file_with_user_permissions;
@@ -31,7 +30,11 @@ pub use error::JouleProfilerError;
 
 pub mod types;
 
-const PHASE_CHANNEL_SIZE: usize = 2;
+/// Phases and begin/end timestamps collected by the reader thread.
+type MeasureData = (Vec<PhaseInfo>, u128, u128);
+
+/// Reader thread handle: gives the orchestrator back with the collected data.
+type ReaderThreadHandle = JoinHandle<(Orchestrator, Result<MeasureData>)>;
 
 /// Orchestrates program profiling and metric collection.
 ///
@@ -123,8 +126,6 @@ impl JouleProfiler {
         }
         let mut orchestrator = Orchestrator::new(sources);
 
-        let (tx, rx) = tokio::sync::mpsc::channel::<PhaseInfo>(PHASE_CHANNEL_SIZE);
-
         orchestrator.pre_init().await?;
 
         debug!("Spawning command: {:?}", config.cmd);
@@ -137,19 +138,40 @@ impl JouleProfiler {
             .stdout
             .take()
             .ok_or(JouleProfilerError::StdOutCaptureFail)?;
-        let reader_thread =
-            spawn_reader_thread(child_stdout, regex, config.stdout_file.clone(), tx)?;
 
         orchestrator.init(pid, config.init_timeout).await?;
         orchestrator.run();
 
         info!("Starting measurements");
-        let (command_duration_ms, timestamp, exit_code, detected_phases) = self
-            .measure_phases(&mut orchestrator, &mut child, rx, pid)
-            .await?;
+        let reader_thread = spawn_reader_thread(
+            orchestrator,
+            child_stdout,
+            regex,
+            config.stdout_file.clone(),
+            pid,
+        )?;
+
+        let (mut orchestrator, measure_result) =
+            tokio::task::spawn_blocking(move || join_reader_thread(reader_thread))
+                .await
+                .map_err(|_| JouleProfilerError::ReaderThreadPanicked)??;
+
+        let (detected_phases, begin_timestamp, end_timestamp) = match measure_result {
+            Ok(data) => data,
+            Err(err) => {
+                return Err(match orchestrator.finalize().await {
+                    Err(source_err) => source_err.into(),
+                    Ok(_) => err,
+                })?;
+            }
+        };
+
+        let command_duration_ms = (end_timestamp - begin_timestamp) / 1000;
+        let timestamp = begin_timestamp;
+        let exit_code = wait_for_child_exit(&mut child)?;
+        info!("Command finished: duration={command_duration_ms} ms exit_code={exit_code}");
 
         let (sources_results, sources) = orchestrator.finalize().await?;
-        join_reader_thread(reader_thread)?;
         self.sources = sources;
 
         let mut phases: Vec<_> = detected_phases
@@ -196,88 +218,80 @@ impl JouleProfiler {
             phases,
         })
     }
-
-    /// Profile the already spawned and paused command, separating its execution into phases
-    /// through tokens matching a configured regular expression.
-    ///
-    /// The profiling is composed of several steps:
-    ///
-    /// - The metric sources have already been initialized with the profiled program's pid and the process paused
-    ///   (see [`JouleProfiler::profile`]), to configure the sources without introducing a significant overhead.
-    /// - The first measure is made and the process is then resumed.
-    /// - The profiler listens for phase token in the standard output of the profiled process and make a measure for every token detected.
-    /// - When the program exited, the profiler makes a last measure to compute the last phase metrics.
-    ///
-    /// After the profiling, results are aggregated into a common structure.
-    async fn measure_phases(
-        &mut self,
-        orchestrator: &mut Orchestrator,
-        child: &mut Child,
-        mut rx: Receiver<PhaseInfo>,
-        pid: i32,
-    ) -> Result<MeasurePhasesReturnType> {
-        let mut detected_phases = Vec::with_capacity(2);
-
-        let begin_timestamp = get_timestamp_micros();
-        trace!("Begin timestamp: {begin_timestamp}");
-
-        orchestrator.measure().await?;
-        resume_process(pid)?;
-        detected_phases.push(PhaseInfo::start(begin_timestamp));
-
-        while let Some(phase_info) = rx.recv().await {
-            orchestrator.measure().await?;
-            orchestrator.new_phase().await?;
-            detected_phases.push(phase_info);
-        }
-
-        let end_timestamp = get_timestamp_micros();
-        trace!("End timestamp: {end_timestamp}");
-
-        orchestrator.measure().await?;
-        orchestrator.new_phase().await?;
-
-        let duration_ms = (end_timestamp - begin_timestamp) / 1000;
-        detected_phases.push(PhaseInfo::end(end_timestamp));
-
-        let exit_code = wait_for_child_exit(child)?;
-        info!("Command finished: duration={duration_ms} ms exit_code={exit_code}");
-
-        Ok((duration_ms, begin_timestamp, exit_code, detected_phases))
-    }
 }
 
+/// Profiles the already spawned and paused command, on the reader thread:
+/// first measure, resume the process, then a blocking measure and new phase
+/// for each detected token, until the stdout closes.
+fn measure_phases_blocking(
+    orchestrator: &mut Orchestrator,
+    child_stdout: ChildStdout,
+    regex: &Regex,
+    stdout_file: Option<&String>,
+    pid: i32,
+) -> Result<MeasureData> {
+    let sink = create_output_sink(stdout_file)?;
+    let reader = BufReader::new(child_stdout);
+
+    let mut detected_phases = Vec::with_capacity(2);
+
+    let begin_timestamp = get_timestamp_micros();
+    trace!("Begin timestamp: {begin_timestamp}");
+
+    orchestrator.measure_blocking()?;
+    resume_process(pid)?;
+    detected_phases.push(PhaseInfo::start(begin_timestamp));
+
+    read_and_detect_phases(orchestrator, &mut detected_phases, reader, regex, sink)?;
+
+    let end_timestamp = get_timestamp_micros();
+    trace!("End timestamp: {end_timestamp}");
+
+    orchestrator.measure_blocking()?;
+    orchestrator.new_phase_blocking()?;
+    detected_phases.push(PhaseInfo::end(end_timestamp));
+
+    Ok((detected_phases, begin_timestamp, end_timestamp))
+}
+
+/// Spawns the reader thread, which owns the orchestrator during the run and
+/// gives it back on join.
 fn spawn_reader_thread(
+    mut orchestrator: Orchestrator,
     child_stdout: ChildStdout,
     regex: Regex,
     stdout_file: Option<String>,
-    tx: Sender<PhaseInfo>,
-) -> Result<JoinHandle<Result<()>>> {
-    let reader = BufReader::new(child_stdout);
-
+    pid: i32,
+) -> Result<ReaderThreadHandle> {
     std::thread::Builder::new()
         .name("phase-reader".to_string())
         .spawn(move || {
-            let sink = create_output_sink(stdout_file.as_ref())?;
-            read_and_detect_phases(reader, &regex, sink, &tx)
+            let result = measure_phases_blocking(
+                &mut orchestrator,
+                child_stdout,
+                &regex,
+                stdout_file.as_ref(),
+                pid,
+            );
+            (orchestrator, result)
         })
         .map_err(|err| JouleProfilerError::ReaderThreadSpawnFailed(err.to_string()))
 }
 
-fn join_reader_thread(handle: JoinHandle<Result<()>>) -> Result<()> {
-    match handle.join() {
-        Ok(inner) => inner,
-        Err(_) => Err(JouleProfilerError::ReaderThreadPanicked),
-    }
+fn join_reader_thread<T>(handle: JoinHandle<T>) -> Result<T> {
+    handle
+        .join()
+        .map_err(|_| JouleProfilerError::ReaderThreadPanicked)
 }
 
-/// Reads the child's stdout line by line, and emits a [`PhaseInfo`]
-/// in the channel for every line whose content matches the regex pattern.
+/// Reads the child's stdout line by line; every line matching the regex
+/// triggers a blocking measure and new phase, and records a [`PhaseInfo`].
 fn read_and_detect_phases<R, W>(
+    orchestrator: &mut Orchestrator,
+    phases: &mut Vec<PhaseInfo>,
     mut reader: R,
     regex: &Regex,
     mut sink: W,
-    tx: &Sender<PhaseInfo>,
 ) -> Result<()>
 where
     R: BufRead,
@@ -313,15 +327,14 @@ where
             let phase_timestamp = get_timestamp_micros();
             debug!("Detected phase at line {line_number}, token '{token}'");
 
-            let phase_info = PhaseInfo {
+            orchestrator.measure_blocking()?;
+            orchestrator.new_phase_blocking()?;
+
+            phases.push(PhaseInfo {
                 token: PhaseToken::Token(token.to_owned()),
                 timestamp: phase_timestamp,
                 line_number: Some(line_number),
-            };
-
-            if tx.blocking_send(phase_info).is_err() {
-                break;
-            }
+            });
         }
 
         line_number += 1;
@@ -443,6 +456,7 @@ fn resume_process(pid: i32) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::config::ProfileConfig;
+    use crate::orchestrator::Orchestrator;
     use crate::phase::{PhaseInfo, PhaseToken};
     use crate::profiler::{
         create_output_sink, join_reader_thread, phase_token_in_line, read_and_detect_phases,
@@ -465,8 +479,8 @@ mod tests {
         }
     }
 
-    /// Drives [`read_and_detect_phases`] to completion over an in-memory reader and
-    /// collects every [`PhaseInfo`] it emitted through the channel.
+    /// Drives [`read_and_detect_phases`] to completion over an in-memory reader
+    /// with a sourceless orchestrator, and collects the recorded [`PhaseInfo`]s.
     fn collect_phases<R, W>(
         reader: R,
         regex: &Regex,
@@ -476,13 +490,9 @@ mod tests {
         R: std::io::BufRead,
         W: Write,
     {
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<PhaseInfo>(16);
-        read_and_detect_phases(reader, regex, sink, &tx)?;
-
+        let mut orchestrator = Orchestrator::new(Vec::new());
         let mut phases = Vec::new();
-        while let Ok(phase) = rx.try_recv() {
-            phases.push(phase);
-        }
+        read_and_detect_phases(&mut orchestrator, &mut phases, reader, regex, sink)?;
         Ok(phases)
     }
 
@@ -629,21 +639,6 @@ mod tests {
     }
 
     #[test]
-    fn read_and_detect_phases_stops_when_receiver_dropped() {
-        let regex = Regex::new("__PHASE__").unwrap();
-        let cursor = Cursor::new("__PHASE__\n__PHASE__\n__PHASE__");
-        let reader = BufReader::new(cursor);
-        let sink: Vec<u8> = Vec::new();
-
-        let (tx, rx) = tokio::sync::mpsc::channel::<PhaseInfo>(1);
-        drop(rx);
-
-        let result = read_and_detect_phases(reader, &regex, sink, &tx);
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
     fn join_reader_thread_propagates_panic_as_error() {
         let handle = std::thread::spawn(|| -> crate::profiler::types::Result<()> {
             panic!("boom");
@@ -658,14 +653,17 @@ mod tests {
     }
 
     #[test]
-    fn join_reader_thread_propagates_inner_error() {
+    fn join_reader_thread_returns_thread_result() {
         let handle = std::thread::spawn(|| -> crate::profiler::types::Result<()> {
             Err(JouleProfilerError::StdOutCaptureFail)
         });
 
         let result = join_reader_thread(handle);
 
-        assert!(matches!(result, Err(JouleProfilerError::StdOutCaptureFail)));
+        assert!(matches!(
+            result,
+            Ok(Err(JouleProfilerError::StdOutCaptureFail))
+        ));
     }
 
     #[test]

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -20,7 +20,7 @@ pub mod error;
 use crate::config::ProfileConfig;
 use crate::orchestrator::Orchestrator;
 use crate::phase::{PhaseInfo, PhaseToken};
-use crate::profiler::types::{Phase, ProfilerResults, Result};
+use crate::profiler::types::{MeasureData, Phase, ProfilerResults, ReaderResult, Result};
 use crate::sensor::{Sensor, Sensors};
 use crate::source::{MetricReader, MetricSource, MetricSourceError};
 use crate::util::fs::create_file_with_user_permissions;
@@ -29,17 +29,6 @@ use crate::util::time::get_timestamp_micros;
 pub use error::JouleProfilerError;
 
 pub mod types;
-
-/// Phases and begin/end timestamps collected by the reader thread.
-struct MeasureData {
-    phases: Vec<PhaseInfo>,
-    begin_timestamp: u128,
-    end_timestamp: u128,
-}
-
-/// What the reader thread sends back once done: the orchestrator (to reuse
-/// its sources) alongside the measurement outcome.
-type ReaderResult = (Orchestrator, Result<MeasureData>);
 
 /// Orchestrates program profiling and metric collection.
 ///

--- a/core/src/profiler/types.rs
+++ b/core/src/profiler/types.rs
@@ -1,12 +1,10 @@
 use crate::JouleProfilerError;
 use crate::aggregate::Metrics;
-use crate::phase::{PhaseInfo, PhaseToken};
+use crate::phase::PhaseToken;
 use serde::Serialize;
 
 /// Result type for profiler operations.
 pub type Result<T> = std::result::Result<T, JouleProfilerError>;
-
-pub type MeasurePhasesReturnType = (u128, u128, i32, Vec<PhaseInfo>);
 
 /// Represents a profiling phase with metrics and timing.
 #[derive(Debug, Serialize)]

--- a/core/src/profiler/types.rs
+++ b/core/src/profiler/types.rs
@@ -1,6 +1,7 @@
 use crate::JouleProfilerError;
 use crate::aggregate::Metrics;
-use crate::phase::PhaseToken;
+use crate::orchestrator::Orchestrator;
+use crate::phase::{PhaseInfo, PhaseToken};
 use serde::Serialize;
 
 /// Result type for profiler operations.
@@ -59,3 +60,14 @@ pub struct ProfilerResults {
     /// Phases detected in the program's standard output.
     pub phases: Phases,
 }
+
+/// Phases and begin/end timestamps collected by the reader thread.
+pub(crate) struct MeasureData {
+    pub phases: Vec<PhaseInfo>,
+    pub begin_timestamp: u128,
+    pub end_timestamp: u128,
+}
+
+/// What the reader thread sends back once done: the orchestrator (to reuse
+/// its sources) alongside the measurement outcome.
+pub(crate) type ReaderResult = (Orchestrator, Result<MeasureData>);

--- a/core/src/source/runtime.rs
+++ b/core/src/source/runtime.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use log::debug;
+use log::{debug, warn};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
         accumulator::MetricAccumulator,
         error::IntoMetricSourceError,
         types::{SourceEvent, SourceWorkerHandle},
-    },
+    }, time::get_timestamp_micros,
 };
 
 /// Orchestrate a metric source and handle the conversion between raw source results to metrics.
@@ -59,6 +59,7 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
     /// Make a measurement.
     #[inline]
     async fn measure_source(&mut self) -> Result<(), MetricSourceError> {
+        warn!("{}", get_timestamp_micros());
         self.source
             .measure()
             .await

--- a/core/src/source/runtime.rs
+++ b/core/src/source/runtime.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use log::{debug, warn};
+use log::debug;
 use tokio::sync::mpsc;
 
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
         accumulator::MetricAccumulator,
         error::IntoMetricSourceError,
         types::{SourceEvent, SourceWorkerHandle},
-    }, time::get_timestamp_micros,
+    },
 };
 
 /// Orchestrate a metric source and handle the conversion between raw source results to metrics.
@@ -59,7 +59,6 @@ impl<R: MetricReader> MetricSourceRuntime<R> {
     /// Make a measurement.
     #[inline]
     async fn measure_source(&mut self) -> Result<(), MetricSourceError> {
-        warn!("{}", get_timestamp_micros());
         self.source
             .measure()
             .await


### PR DESCRIPTION
## Description

This pull request optimizes the reading of stdout for phases detection.
The problem was that the former implementation was blocking the tokio asynchronous runtime in case of a single worker runtime.  The CLI was not impacted but for library users it would have delayed the measurements by blocking the runtime.
This pull requests puts the reading into its own std thread to not be scheduled by tokio and reduce jitter.
However, it comes with the cost of the thread spawn latency which can be a hundred microseconds long.
When profiling programs that does not attach the right pid to the workload we want to profile (e.g. containers) it will introduce a delay at the start of the profiling. One way to address this issue is to use add a way to configure a cgroup and freeze the cgroup instead of pausing the wrong process using the wrong pid.

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] Improvement
* [ ] Documentation
* [ ] Other (please specify):

## Related Issues

The issue related is #60.

## Changes Made

* Spawns the phase detection task into its own std thread instead of blocking the runtime.
* Made measure and new_phase function blocking in orchestrator. (measure_blocking and new_phase_blocking now)
*

## Checklist

* [x] My code follows the project style
* [ ] I have tested my changes
* [ ] I have added/updated documentation if needed
* [x] All tests pass