### PR TITLE
Fix perf_event uncounting in virtualized environments and improved Cgroup source

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,22 @@ sudo cp target/release/joule-profiler /usr/local/bin/
 
 ```bash
 # Phase-based profiling
-sudo joule-profiler profile -- python workload.py
+joule-profiler profile -- <COMMAND>
 
 # JSON output
-sudo joule-profiler --output-format json profile -- ./benchmark
+joule-profiler --output-format json profile -- <COMMAND>
 
 # GPU profiling (NVIDIA)
-sudo joule-profiler --sources rapl,nvml profile -- ./gpu-workload
+joule-profiler --sources rapl,nvml profile -- <COMMAND>
 ```
+
+For the RAPL source with the perf_event backend, you might be asked to run Joule Profiler with the root privileges, you can configure the perf_event_paranoid level to allow using the source without them:
+```bash
+sudo sysctl kernel.perf_event_paranoid=0
+```
+
+See the [perf_event_paranoid](https://joule-profiler.github.io/sources/perf_event/perf_event_paranoid.html) documentation for further information.
+Some sources like Cgroup or RAPL with the powercap backend can also require root privileges.
 
 ## Documentation
 
@@ -71,7 +79,7 @@ print("__CLEANUP__")
 ```
 
 ```bash
-sudo joule-profiler profile -- python example.py
+joule-profiler profile -- python example.py
 ```
 
 ### Multiple Metric Sources
@@ -81,7 +89,7 @@ sudo joule-profiler profile -- python example.py
 | **RAPL** (powercap) | RAPL domains energy | Intel CPU, kernel 3.13+ |
 | **RAPL** (perf) | RAPL domains energy | Intel CPU, perf_event support |
 | **perf_event** | Performance counters | Linux perf support |
-| **cgroup** | CPU/memory/IO usage | cgroup v2, root if cgroup creation |
+| **cgroup** | CPU/memory/IO usage | cgroup v2, root if cgroup creation or attach pid |
 | **procfs** | Memory/IO usage | Linux, `/proc` access |
 | **NVML** | NVIDIA GPU energy | NVIDIA GPU |
 | **AMD SMI** | AMD GPU energy | AMD GPU, `amd-smi-lib` |

--- a/examples/programs/mandelbrot_nvidia.cu
+++ b/examples/programs/mandelbrot_nvidia.cu
@@ -1,7 +1,7 @@
 /*
   Source: https://github.com/canonizer/mandelbrot-dyn
 
-  Compile: nvcc -O3 -Xcompiler -fopenmp mandelbrot_nvidia.cu -o mandelbrot_nvidia
+  Compile: nvcc -O3 -Xcompiler -fopenmp examples/programs/mandelbrot_nvidia.cu -o mandelbrot_nvidia
   Usage: joule-profiler --gpu profile -- ./mandelbrot_nvidia {n}
 */
 

--- a/examples/programs/nbody.c
+++ b/examples/programs/nbody.c
@@ -1,7 +1,7 @@
 /*
  * CPU intensive program.
  * Compile with:
- *      gcc -pipe -Wall -O3 -fomit-frame-pointer -march=ivybridge  examples/programs/nbody.c -o examples/programs/nbody
+ *      gcc -pipe -Wall -O3 -fomit-frame-pointer -march=ivybridge  examples/programs/nbody.c -o nbody
  * 
  * Usage:
  *      joule-profiler profile -- ./nbody {n}

--- a/examples/programs/nbody.py
+++ b/examples/programs/nbody.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+"""
+CPU intensive program.
+ Usage:
+    joule-profiler profile -- python3 ./examples/programs/nbody.py {n}
+    with n = 1000000 < 1s
+         n = 10000000 < 3s
+         n = 100000000 < 30s 
+"""
 # The Computer Language Benchmarks Game
 # https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 #

--- a/examples/programs/workload.py
+++ b/examples/programs/workload.py
@@ -3,7 +3,7 @@
 Simple workload for testing joule-profiler phase detection.
 
 Usage:
-    joule-profiler profile -- python3 workload.py
+    joule-profiler profile -- python3 examples/programs/workload.py
 """
 
 import argparse

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -97,9 +97,7 @@ impl CgroupBackend for SysFsBackend {
             ErrorKind::PermissionDenied => CgroupError::PermissionDenied(
                 "attaching a process to this cgroup requires root privileges.",
             ),
-            // The kernel reports a missing `cgroup.procs` and a process that
-            // died before being attached the same way, so only the file tells
-            // them apart.
+
             ErrorKind::NotFound if !procs_path.exists() => {
                 CgroupError::NotFound(path.to_path_buf())
             }

--- a/sources/cgroup/src/cgroup.rs
+++ b/sources/cgroup/src/cgroup.rs
@@ -1,9 +1,4 @@
-//! cgroup v2 management utilities.
-//!
-//! This module provides:
-//! - child cgroup creation and cleanup;
-//! - process attachment to cgroups;
-//! - CPU, memory, and I/O statistics collection.
+//! Cgroup v2 management utilities.
 
 use std::{
     fs,
@@ -17,15 +12,17 @@ use crate::{
     Result,
     error::CgroupError,
     snapshot::{CpuSnapshot, IoSnapshot, MemorySnapshot},
-    util::{read_flat_keyed_file, read_io_stat, read_u64_opt},
+    util::{is_cgroup_dir, read_flat_keyed_file, read_io_stat, read_u64_opt},
 };
 
 /// Interface for reading cgroup statistics.
-///
-/// `Default` and `Clone` let [`RootCgroup::build`] construct a backend from
-/// scratch and share that same instance with its child cgroup, for any
-/// implementation of this trait (not just [`SysFsBackend`]).
 pub trait CgroupBackend: Send + Sync + Clone + Default + 'static {
+    /// Checks that `path` is a cgroup the backend can read, `root` being the
+    /// hierarchy it belongs to.
+    fn verify(&self, _path: &Path, _root: &Path) -> Result<()> {
+        Ok(())
+    }
+
     /// Initializes the backend.
     fn create(&self, path: &Path) -> Result<()>;
 
@@ -54,7 +51,11 @@ impl SysFsBackend {
     fn pids(path: &Path) -> Result<Vec<i32>> {
         debug!("Retrieving cgroup `{}` PIDs.", path.display());
         let path = path.join("cgroup.procs");
-        let content = fs::read_to_string(&path)?;
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(CgroupError::io(&path, err)),
+        };
         Ok(content
             .lines()
             .filter_map(|l| l.trim().parse::<i32>().ok())
@@ -63,6 +64,20 @@ impl SysFsBackend {
 }
 
 impl CgroupBackend for SysFsBackend {
+    /// Checks that the hierarchy is mounted and that the cgroup exists in it.
+    fn verify(&self, path: &Path, root: &Path) -> Result<()> {
+        if !is_cgroup_dir(root) {
+            return Err(CgroupError::NotAvailable(root.to_path_buf()));
+        }
+        if !path.exists() {
+            return Err(CgroupError::NotFound(path.to_path_buf()));
+        }
+        if !is_cgroup_dir(path) {
+            return Err(CgroupError::NotAvailable(path.to_path_buf()));
+        }
+        Ok(())
+    }
+
     /// Creates the cgroup directory.
     fn create(&self, path: &Path) -> Result<()> {
         debug!("Initializing cgroup at \"{}\"", path.display());
@@ -70,7 +85,7 @@ impl CgroupBackend for SysFsBackend {
             ErrorKind::PermissionDenied => {
                 CgroupError::PermissionDenied("creating a cgroup requires root privileges.")
             }
-            _ => err.into(),
+            _ => CgroupError::io(path, err),
         })?;
         Ok(())
     }
@@ -82,6 +97,12 @@ impl CgroupBackend for SysFsBackend {
             ErrorKind::PermissionDenied => CgroupError::PermissionDenied(
                 "attaching a process to this cgroup requires root privileges.",
             ),
+            // The kernel reports a missing `cgroup.procs` and a process that
+            // died before being attached the same way, so only the file tells
+            // them apart.
+            ErrorKind::NotFound if !procs_path.exists() => {
+                CgroupError::NotFound(path.to_path_buf())
+            }
             _ => CgroupError::FailedToAttachPid {
                 pid,
                 path: procs_path,
@@ -94,6 +115,14 @@ impl CgroupBackend for SysFsBackend {
 
     /// Moves processes back to the root cgroup and removes the directory.
     fn cleanup(&self, path: &Path, root: &Path) -> Result<()> {
+        if !path.exists() {
+            debug!(
+                "Cgroup `{}` is already gone, nothing to clean.",
+                path.display()
+            );
+            return Ok(());
+        }
+
         debug!("Cleaning cgroup `{}`.", path.display());
 
         let root_procs = root.join("cgroup.procs");
@@ -102,15 +131,13 @@ impl CgroupBackend for SysFsBackend {
                 warn!("Could not move PID {pid} back to root cgroup: {e}");
             }
         }
-        if path.exists() {
-            if let Err(e) = fs::remove_dir(path) {
-                warn!(
-                    "Could not remove cgroup {} (may still have live tasks): {e}",
-                    path.display()
-                );
-            } else {
-                debug!("Removed cgroup {}", path.display());
-            }
+        match fs::remove_dir(path) {
+            Ok(()) => debug!("Removed cgroup {}", path.display()),
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
+            Err(e) => warn!(
+                "Could not remove cgroup {} (may still have live tasks): {e}",
+                path.display()
+            ),
         }
         Ok(())
     }
@@ -221,6 +248,11 @@ impl<B: CgroupBackend> RootCgroup<B> {
     pub fn io(&self) -> Result<IoSnapshot> {
         self.backend.io(&self.path)
     }
+
+    /// Checks that the cgroup v2 hierarchy is mounted at this path.
+    pub fn verify(&self) -> Result<()> {
+        self.backend.verify(&self.path, &self.path)
+    }
 }
 
 const DEFAULT_CGROUP_ROOT: &str = "/sys/fs/cgroup";
@@ -265,6 +297,11 @@ impl<B: CgroupBackend> ChildCgroup<B> {
     /// Get I/O stats.
     pub fn io(&self) -> Result<IoSnapshot> {
         self.backend.io(&self.path)
+    }
+
+    /// Checks that the cgroup exists in a mounted cgroup v2 hierarchy.
+    pub fn verify(&self) -> Result<()> {
+        self.backend.verify(&self.path, &self.root)
     }
 
     /// Initializes the cgroup backend.
@@ -327,6 +364,78 @@ mod tests {
             root: path,
             backend,
         }
+    }
+
+    /// Builds a directory that looks like a cgroup v2 one.
+    fn cgroup_dir(path: &Path) {
+        fs::create_dir_all(path).unwrap();
+        fs::write(path.join("cgroup.controllers"), "cpu io memory").unwrap();
+    }
+
+    #[test]
+    fn verify_rejects_a_root_that_is_not_a_cgroup_hierarchy() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("child");
+        cgroup_dir(&cgroup);
+
+        let err = SysFsBackend.verify(&cgroup, dir.path()).unwrap_err();
+
+        assert!(matches!(err, CgroupError::NotAvailable(path) if path == dir.path()));
+    }
+
+    #[test]
+    fn verify_rejects_a_missing_cgroup() {
+        let dir = tempfile::tempdir().unwrap();
+        cgroup_dir(dir.path());
+        let cgroup = dir.path().join("child");
+
+        let err = SysFsBackend.verify(&cgroup, dir.path()).unwrap_err();
+
+        assert!(matches!(err, CgroupError::NotFound(path) if path == cgroup));
+    }
+
+    #[test]
+    fn verify_rejects_a_plain_directory_inside_a_hierarchy() {
+        let dir = tempfile::tempdir().unwrap();
+        cgroup_dir(dir.path());
+        let cgroup = dir.path().join("child");
+        fs::create_dir(&cgroup).unwrap();
+
+        let err = SysFsBackend.verify(&cgroup, dir.path()).unwrap_err();
+
+        assert!(matches!(err, CgroupError::NotAvailable(path) if path == cgroup));
+    }
+
+    #[test]
+    fn verify_accepts_a_cgroup_of_the_hierarchy() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("child");
+        cgroup_dir(dir.path());
+        cgroup_dir(&cgroup);
+
+        SysFsBackend.verify(&cgroup, dir.path()).unwrap();
+    }
+
+    /// Cleaning up a cgroup that the kernel already removed, or that was never
+    /// created because the run failed earlier, is not a failure.
+    #[test]
+    fn cleanup_of_a_missing_cgroup_is_a_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        cgroup_dir(dir.path());
+
+        SysFsBackend
+            .cleanup(&dir.path().join("gone"), dir.path())
+            .unwrap();
+    }
+
+    #[test]
+    fn attach_pid_reports_a_missing_cgroup() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("gone");
+
+        let err = SysFsBackend.attach_pid(&cgroup, 1).unwrap_err();
+
+        assert!(matches!(err, CgroupError::NotFound(path) if path == cgroup));
     }
 
     #[test]

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -7,12 +7,24 @@ use std::{
 use thiserror::Error;
 use tokio::task::JoinError;
 
+use crate::util::{is_cgroup_dir, read_controllers};
+
 /// Main error type for all cgroup-related operations.
 #[derive(Debug, Error)]
 pub enum CgroupError {
     /// cgroup v2 is not available or not mounted as a unified hierarchy.
-    #[error("Cgroup v2 not available at `{0}`. Check if the unified hierarchy is mounted.")]
-    NotAvailable(String),
+    #[error(
+        "`{0}` is not a cgroup v2 directory. Check that the unified hierarchy is mounted \
+        (`mount -t cgroup2`) and that `cgroup_root` points to it."
+    )]
+    NotAvailable(PathBuf),
+
+    /// The cgroup directory does not exist.
+    #[error(
+        "Cgroup `{0}` does not exist. Create it beforehand or let the source do it \
+        with `create_cgroup = true`."
+    )]
+    NotFound(PathBuf),
 
     /// Attempted to create a cgroup that already exists.
     #[error("Cgroup with name \"{0}\" already created.")]
@@ -37,17 +49,19 @@ pub enum CgroupError {
         path: PathBuf,
     },
 
+    /// A cgroup controller is not available in the hierarchy at all.
+    #[error(
+        "Cgroup controller `{controller}` is not available in `{path}`. \
+        The kernel was built without it or it is not delegated to this hierarchy."
+    )]
+    ControllerNotAvailable {
+        controller: &'static str,
+        path: PathBuf,
+    },
+
     /// A metric expected to always exist in kernel stats was missing.
     #[error("Missing always present metric `{0}`")]
     MissingAlwaysPresentMetric(&'static str),
-
-    /// Generic I/O error.
-    #[error("I/O error")]
-    Io(
-        #[from]
-        #[source]
-        std::io::Error,
-    ),
 
     /// I/O error tied to a specific file path.
     #[error("I/O error on `{path}`: {source}")]
@@ -56,6 +70,13 @@ pub enum CgroupError {
         #[source]
         source: std::io::Error,
     },
+
+    /// Failed to create the timer driving the background memory polling.
+    ///
+    /// Not built from [`From`] on purpose: every I/O error of the source must
+    /// name the file or the operation it comes from.
+    #[error("Failed to create the cgroup polling timer: {0}")]
+    Timer(#[source] std::io::Error),
 
     /// Failed to parse a numeric value from a cgroup file.
     #[error("Failed to parse `{path}`: {source}")]
@@ -81,16 +102,179 @@ pub enum CgroupError {
 }
 
 impl CgroupError {
+    /// Builds an [`CgroupError::IoPath`] carrying the file the operation failed on.
+    pub(crate) fn io(path: &Path, source: std::io::Error) -> Self {
+        CgroupError::IoPath {
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+
+    /// Refines a missing controller interface file into its actual cause.
+    ///
+    /// A `memory.stat` (or `cpu.stat`, `io.stat`) that cannot be found has
+    /// several plausible causes, which are checked from the most general to the
+    /// most specific so the reported one is always the first thing to fix:
+    /// the cgroup does not exist, it is not part of a cgroup v2 hierarchy, the
+    /// controller is unknown to that hierarchy, or the parent cgroup does not
+    /// delegate it through `cgroup.subtree_control`.
+    ///
+    /// Any error that is not a missing file, and any cause that cannot be
+    /// established, is returned untouched.
     pub(crate) fn into_controller_error(self, controller: &'static str, cgroup: &Path) -> Self {
-        if let CgroupError::IoPath { ref source, .. } = self
-            && source.kind() == ErrorKind::NotFound
-            && let Some(parent) = cgroup.parent()
-        {
-            return CgroupError::ControllerNotEnabled {
+        let CgroupError::IoPath { ref source, .. } = self else {
+            return self;
+        };
+
+        if source.kind() != ErrorKind::NotFound {
+            return self;
+        }
+
+        if !cgroup.exists() {
+            return CgroupError::NotFound(cgroup.to_path_buf());
+        }
+
+        if !is_cgroup_dir(cgroup) {
+            return CgroupError::NotAvailable(cgroup.to_path_buf());
+        }
+
+        // A controller only exposes its interface files in a cgroup once the
+        // *parent* enables it for its children. The hierarchy root has no such
+        // parent, so only the controller availability can be checked there.
+        let parent = cgroup.parent().filter(|parent| is_cgroup_dir(parent));
+        let scope = parent.unwrap_or(cgroup);
+
+        let Ok(available) = read_controllers(&scope.join("cgroup.controllers")) else {
+            return self;
+        };
+
+        if !available.iter().any(|name| name == controller) {
+            return CgroupError::ControllerNotAvailable {
                 controller,
-                path: parent.to_path_buf(),
+                path: scope.to_path_buf(),
             };
         }
-        self
+
+        let Some(parent) = parent else {
+            return self;
+        };
+
+        let Ok(enabled) = read_controllers(&parent.join("cgroup.subtree_control")) else {
+            return self;
+        };
+
+        if enabled.iter().any(|name| name == controller) {
+            return self;
+        }
+
+        CgroupError::ControllerNotEnabled {
+            controller,
+            path: parent.to_path_buf(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    /// Builds a directory that looks like a cgroup v2 one.
+    fn cgroup_dir(path: &Path, available: &str, enabled: &str) {
+        fs::create_dir_all(path).unwrap();
+        fs::write(path.join("cgroup.controllers"), available).unwrap();
+        fs::write(path.join("cgroup.subtree_control"), enabled).unwrap();
+    }
+
+    fn not_found(path: &Path) -> CgroupError {
+        CgroupError::io(path, ErrorKind::NotFound.into())
+    }
+
+    #[test]
+    fn keeps_errors_that_are_not_a_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = CgroupError::io(dir.path(), ErrorKind::PermissionDenied.into());
+
+        let err = err.into_controller_error("memory", dir.path());
+
+        assert!(matches!(err, CgroupError::IoPath { .. }));
+    }
+
+    #[test]
+    fn reports_a_missing_cgroup() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("gone");
+
+        let err = not_found(&cgroup.join("memory.stat")).into_controller_error("memory", &cgroup);
+
+        assert!(matches!(err, CgroupError::NotFound(path) if path == cgroup));
+    }
+
+    #[test]
+    fn reports_a_directory_that_is_not_a_cgroup() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let err =
+            not_found(&dir.path().join("memory.stat")).into_controller_error("memory", dir.path());
+
+        assert!(matches!(err, CgroupError::NotAvailable(path) if path == dir.path()));
+    }
+
+    #[test]
+    fn reports_a_controller_missing_from_the_hierarchy() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("child");
+        cgroup_dir(dir.path(), "cpu io", "cpu io");
+        cgroup_dir(&cgroup, "cpu io", "");
+
+        let err = not_found(&cgroup.join("memory.stat")).into_controller_error("memory", &cgroup);
+
+        assert!(
+            matches!(err, CgroupError::ControllerNotAvailable { controller, path }
+                if controller == "memory" && path == dir.path())
+        );
+    }
+
+    #[test]
+    fn reports_a_controller_the_parent_does_not_delegate() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("child");
+        cgroup_dir(dir.path(), "cpu io memory", "cpu");
+        cgroup_dir(&cgroup, "cpu", "");
+
+        let err = not_found(&cgroup.join("memory.stat")).into_controller_error("memory", &cgroup);
+
+        assert!(
+            matches!(err, CgroupError::ControllerNotEnabled { controller, path }
+                if controller == "memory" && path == dir.path())
+        );
+    }
+
+    /// The root of a hierarchy has no parent to enable controllers for it, so
+    /// nothing more precise than the failing read can be reported.
+    #[test]
+    fn keeps_the_io_error_at_the_hierarchy_root() {
+        let dir = tempfile::tempdir().unwrap();
+        cgroup_dir(dir.path(), "cpu io memory", "cpu io memory");
+
+        let err =
+            not_found(&dir.path().join("memory.stat")).into_controller_error("memory", dir.path());
+
+        assert!(matches!(err, CgroupError::IoPath { .. }));
+    }
+
+    /// A controller enabled by the parent but whose file is still missing is
+    /// not something the source can explain: the original error is kept.
+    #[test]
+    fn keeps_the_io_error_when_nothing_explains_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let cgroup = dir.path().join("child");
+        cgroup_dir(dir.path(), "cpu io memory", "cpu io memory");
+        cgroup_dir(&cgroup, "cpu io memory", "");
+
+        let err = not_found(&cgroup.join("memory.stat")).into_controller_error("memory", &cgroup);
+
+        assert!(matches!(err, CgroupError::IoPath { .. }));
     }
 }

--- a/sources/cgroup/src/error.rs
+++ b/sources/cgroup/src/error.rs
@@ -102,7 +102,6 @@ pub enum CgroupError {
 }
 
 impl CgroupError {
-    /// Builds an [`CgroupError::IoPath`] carrying the file the operation failed on.
     pub(crate) fn io(path: &Path, source: std::io::Error) -> Self {
         CgroupError::IoPath {
             path: path.to_path_buf(),
@@ -110,17 +109,6 @@ impl CgroupError {
         }
     }
 
-    /// Refines a missing controller interface file into its actual cause.
-    ///
-    /// A `memory.stat` (or `cpu.stat`, `io.stat`) that cannot be found has
-    /// several plausible causes, which are checked from the most general to the
-    /// most specific so the reported one is always the first thing to fix:
-    /// the cgroup does not exist, it is not part of a cgroup v2 hierarchy, the
-    /// controller is unknown to that hierarchy, or the parent cgroup does not
-    /// delegate it through `cgroup.subtree_control`.
-    ///
-    /// Any error that is not a missing file, and any cause that cannot be
-    /// established, is returned untouched.
     pub(crate) fn into_controller_error(self, controller: &'static str, cgroup: &Path) -> Self {
         let CgroupError::IoPath { ref source, .. } = self else {
             return self;
@@ -138,9 +126,6 @@ impl CgroupError {
             return CgroupError::NotAvailable(cgroup.to_path_buf());
         }
 
-        // A controller only exposes its interface files in a cgroup once the
-        // *parent* enables it for its children. The hierarchy root has no such
-        // parent, so only the controller availability can be checked there.
         let parent = cgroup.parent().filter(|parent| is_cgroup_dir(parent));
         let scope = parent.unwrap_or(cgroup);
 

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -85,7 +85,7 @@ impl<B: CgroupBackend> Cgroup<B> {
         global_memory_counters: Arc<Mutex<MemoryCounters>>,
         poll_interval: Duration,
     ) -> Result<WorkerHandle> {
-        let mut ticker = Interval::new_interval(poll_interval)?;
+        let mut ticker = Interval::new_interval(poll_interval).map_err(CgroupError::Timer)?;
 
         let cancellation_token = CancellationToken::new();
         let cancellation_token_clone = cancellation_token.clone();
@@ -153,15 +153,16 @@ impl<B: CgroupBackend> MetricReader for Cgroup<B> {
         })
     }
 
-    /// Creates the cgroup if configured.
-    ///
-    /// Creating the directory or attaching a pid fails with `CgroupError::PermissionDenied`
-    /// if the caller lacks access, which also lets delegated (non-root-owned) cgroup
-    /// subtrees work.
+    /// Creates the cgroup if configured, then checks that it is usable.
     async fn pre_init(&mut self) -> Result<()> {
+        self.root_cgroup.verify()?;
+
         if self.config.create_cgroup {
             self.proc_cgroup.create()?;
         }
+
+        self.proc_cgroup.verify()?;
+
         Ok(())
     }
 

--- a/sources/cgroup/src/lib.rs
+++ b/sources/cgroup/src/lib.rs
@@ -11,7 +11,7 @@ use joule_profiler_core::source::MetricReader;
 use joule_profiler_core::time::get_timestamp_micros;
 use joule_profiler_core::types::{Metric, MetricValue, Metrics};
 use joule_profiler_core::unit::{MetricUnit, Unit, UnitPrefix};
-use log::{debug, trace};
+use log::{debug, trace, warn};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -158,6 +158,12 @@ impl<B: CgroupBackend> MetricReader for Cgroup<B> {
         self.root_cgroup.verify()?;
 
         if self.config.create_cgroup {
+            if self.proc_cgroup.verify().is_ok() {
+                warn!(
+                    "Cgroup {} already mounted, if a process has already been spawned inside the cgroup, then the peak metrics might be wrong.",
+                    self.config.cgroup_name
+                );
+            }
             self.proc_cgroup.create()?;
         }
 

--- a/sources/cgroup/src/util.rs
+++ b/sources/cgroup/src/util.rs
@@ -1,15 +1,28 @@
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, fs, io::ErrorKind, path::Path};
 
 use crate::{Result, error::CgroupError};
 
+/// Reads a cgroup file, tagging any I/O failure with the file it happened on.
+pub fn read_file(path: &Path) -> Result<String> {
+    fs::read_to_string(path).map_err(|err| CgroupError::io(path, err))
+}
+
+/// Reads a cgroup file, returning `None` when it does not exist.
+///
+/// Many interface files are only exposed by some kernel versions or some
+/// controller configurations, so a missing file is a valid answer here while
+/// any other I/O failure stays an error.
+fn read_file_opt(path: &Path) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(CgroupError::io(path, err)),
+    }
+}
+
 /// Reads a `u64` value from a file, returns an error if unable to parse.
-fn read_u64(path: &Path) -> Result<u64> {
-    let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
-        path: path.to_path_buf(),
-        source: e,
-    })?;
-    let trimmed = raw.trim();
-    trimmed.parse::<u64>().map_err(|err| CgroupError::Parse {
+fn parse_u64(path: &Path, raw: &str) -> Result<u64> {
+    raw.trim().parse::<u64>().map_err(|err| CgroupError::Parse {
         path: path.to_path_buf(),
         source: err,
     })
@@ -19,11 +32,28 @@ fn read_u64(path: &Path) -> Result<u64> {
 ///
 /// Return None if the file does not exist, else try to parse the file.
 pub fn read_u64_opt(path: &Path) -> Result<Option<u64>> {
-    if fs::exists(path)? {
-        Ok(Some(read_u64(path)?))
-    } else {
-        Ok(None)
-    }
+    read_file_opt(path)?
+        .map(|raw| parse_u64(path, &raw))
+        .transpose()
+}
+
+/// Returns whether `path` is a directory of a cgroup v2 hierarchy.
+///
+/// Every cgroup v2 directory, root or not, exposes a read-only
+/// `cgroup.controllers` file, which a plain directory never has.
+pub fn is_cgroup_dir(path: &Path) -> bool {
+    path.join("cgroup.controllers").is_file()
+}
+
+/// Reads a space separated list of controller names.
+///
+/// Used for `cgroup.controllers` (controllers the hierarchy knows about) and
+/// `cgroup.subtree_control` (controllers a cgroup enables for its children).
+pub fn read_controllers(path: &Path) -> Result<Vec<String>> {
+    Ok(read_file(path)?
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect())
 }
 
 /// Reads a flat key-value file.
@@ -37,10 +67,7 @@ pub fn read_u64_opt(path: &Path) -> Result<Option<u64>> {
 /// Returns a map of parsed metrics.
 /// Lines that fail to parse are ignored.
 pub fn read_flat_keyed_file(path: &Path) -> Result<HashMap<String, u64>> {
-    let raw = fs::read_to_string(path).map_err(|err| CgroupError::IoPath {
-        path: path.to_owned(),
-        source: err,
-    })?;
+    let raw = read_file(path)?;
 
     let map = raw
         .lines()
@@ -67,10 +94,7 @@ pub fn read_flat_keyed_file(path: &Path) -> Result<HashMap<String, u64>> {
 ///
 /// Returns `(read_bytes, write_bytes)` if present.
 pub fn read_io_stat(path: &Path) -> Result<(Option<u64>, Option<u64>)> {
-    let raw = fs::read_to_string(path).map_err(|e| CgroupError::IoPath {
-        path: path.to_path_buf(),
-        source: e,
-    })?;
+    let raw = read_file(path)?;
 
     let mut rbytes = 0;
     let mut wbytes = 0;
@@ -116,8 +140,8 @@ mod tests {
     fn test_read_u64_ok() {
         let path = temp_file("valid_u64", "42");
 
-        let v = read_u64(&path).unwrap();
-        assert_eq!(v, 42);
+        let v = read_u64_opt(&path).unwrap();
+        assert_eq!(v, Some(42));
 
         let _ = std::fs::remove_file(path);
     }
@@ -126,7 +150,7 @@ mod tests {
     fn test_read_u64_invalid() {
         let path = temp_file("invalid_u64", "NaN");
 
-        let err = read_u64(&path).unwrap_err();
+        let err = read_u64_opt(&path).unwrap_err();
         assert!(matches!(err, CgroupError::Parse { .. }));
         let _ = std::fs::remove_file(path);
     }
@@ -138,6 +162,39 @@ mod tests {
 
         let v = read_u64_opt(&path).unwrap();
         assert_eq!(v, None);
+    }
+
+    #[test]
+    fn test_read_file_reports_the_faulty_path() {
+        let mut path = std::env::temp_dir();
+        path.push("missing_cgroup_file");
+
+        let err = read_file(&path).unwrap_err();
+
+        assert!(matches!(&err, CgroupError::IoPath { path: p, .. } if *p == path));
+        assert!(err.to_string().contains("missing_cgroup_file"));
+    }
+
+    #[test]
+    fn test_read_controllers() {
+        let path = temp_file("test_controllers", "cpuset cpu io memory pids\n");
+
+        let controllers = read_controllers(&path).unwrap();
+
+        assert_eq!(controllers, ["cpuset", "cpu", "io", "memory", "pids"]);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_is_cgroup_dir() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert!(!is_cgroup_dir(dir.path()));
+
+        File::create(dir.path().join("cgroup.controllers")).unwrap();
+
+        assert!(is_cgroup_dir(dir.path()));
     }
 
     #[test]

--- a/sources/perf_event/src/hardware.rs
+++ b/sources/perf_event/src/hardware.rs
@@ -126,6 +126,8 @@ impl PerfEventCounters {
                     .observe_pid(pid)
                     .include_hv()
                     .include_kernel()
+                    .exclude_guest(false)
+                    .exclude_host(false)
                     .enabled(true)
                     .build()?;
                 counters.insert(event, counter);
@@ -179,6 +181,10 @@ impl PerfEventCounters {
                 let mut group = new_group_builder()
                     .one_cpu(cpu)
                     .observe_cgroup(&cgroup_fd)
+                    .include_hv()
+                    .include_kernel()
+                    .exclude_guest(false)
+                    .exclude_host(false)
                     .build_group()?;
 
                 let mut cpu_counters = HashMap::with_capacity(events.len());
@@ -186,8 +192,12 @@ impl PerfEventCounters {
                     trace!("Adding event {event:?} on cpu {cpu}");
                     let counter = group.add(
                         Builder::new(Hardware::from(event))
+                            .one_cpu(cpu)
                             .observe_cgroup(&cgroup_fd)
-                            .one_cpu(cpu),
+                            .include_hv()
+                            .include_kernel()
+                            .exclude_guest(false)
+                            .exclude_host(false),
                     )?;
                     cpu_counters.insert(event, counter);
                 }


### PR DESCRIPTION
## Description

This pull requests fixes the uncounting of perf_event counters in virtualized environments, include_hv is not sufficient to count all virtualized environments counters. We need to add exclude_guest and exclude_host(false) when opening the counters.
It also improves the error handling and logging of the Cgroup source, and adds tests to it.
Also, the examples in the readme and some usage section in the examples programs files has been updated to improve the documentation. 

## Type of Change

* [x] Bug fix
* [ ] New feature
* [x] Improvement
* [x] Documentation

## Related Issues

The related issues are #65.

## Changes Made

* perf_event uncounting in virtualized environments fix
* cgroup tests and documentation update, improved error handling
* update readme examples and example programs usage section

## Checklist

* [x] My code follows the project style
* [x] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass
