### PR TITLE
feat(cli): override configuration with -D flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ Any key of the configuration file can be set from the command line with `-D KEY=
 
 ```bash
 # Switch the RAPL backend and restrict it to the first socket
-joule-profiler -D profiler.rapl_backend=powercap -D 'sources.rapl.sockets_spec=[0]' profile -- <COMMAND>
+joule-profiler -D profiler.rapl_backend=powercap -D "sources.rapl.sockets_spec=[0]" profile -- <COMMAND>
 ```
+
+> [!IMPORTANT]
+> If a config option is not in string format, then you must add brackets.
 
 For the RAPL source with the perf_event backend, you might be asked to run Joule Profiler with the root privileges, you can configure the perf_event_paranoid level to allow using the source without them:
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ joule-profiler --output-format json profile -- <COMMAND>
 joule-profiler --sources rapl,nvml profile -- <COMMAND>
 ```
 
+A configuration file can be used to configure the tool using the CLI flag `--config`, see [configuration file](examples/example_config.toml). The CLI arguments will ALWAYS override the configuration arguments.
+
+Any key of the configuration file can be set from the command line with `-D KEY=VALUE`, where `KEY` is the toml key. This works with or without a `--config` file, and can be repeated:
+
+```bash
+# Switch the RAPL backend and restrict it to the first socket
+joule-profiler -D profiler.rapl_backend=powercap -D 'sources.rapl.sockets_spec=[0]' profile -- <COMMAND>
+```
+
 For the RAPL source with the perf_event backend, you might be asked to run Joule Profiler with the root privileges, you can configure the perf_event_paranoid level to allow using the source without them:
 ```bash
 sudo sysctl kernel.perf_event_paranoid=0

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,10 +1,9 @@
-use anyhow::{Result, anyhow};
-use joule_profiler_cli::config::GlobalConfig;
+use anyhow::Result;
+use joule_profiler_cli::config::load_global_config;
 use joule_profiler_cli::config::source::{register_source, register_source_override};
 use joule_profiler_cli::config::table::ConfigTable;
 use joule_profiler_cli::{
     CliArgs, ProfilerCommand, RaplBackend, config_table_to_displayer, init_logging,
-    parse_sockets_spec,
 };
 use joule_profiler_core::JouleProfiler;
 use joule_profiler_core::config::Command;
@@ -24,47 +23,23 @@ async fn main() -> Result<()> {
 
     let mut profiler = JouleProfiler::new();
 
-    let mut config_table = if let Some(config_file) = &cli.config_file {
-        let content = std::fs::read_to_string(config_file)
-            .map_err(|e| anyhow!("configuration file error. Cause: {e}"))?;
-        let value: GlobalConfig = toml::from_str(&content)
-            .map_err(|e| anyhow!("error parsing configuration file. Cause: {e}"))?;
-
-        ConfigTable::new(value, &cli.sources)
-    } else {
-        ConfigTable::new(GlobalConfig::default(), &cli.sources)
-    };
+    let global_config = load_global_config(cli.config_file.as_deref(), &cli.overrides)?;
+    let mut config_table = ConfigTable::new(global_config, &cli.sources);
 
     config_table.apply_cli(&mut cli);
 
     match config_table.profiler_config.rapl_backend {
-        RaplBackend::Perf => register_source_override::<perf::Rapl, CliArgs>(
-            &mut profiler,
-            &mut config_table,
-            |config| {
-                if let Some(sockets_spec) = &cli.sockets {
-                    config.sockets_spec = Some(parse_sockets_spec(sockets_spec));
-                }
-            },
-        ),
+        RaplBackend::Perf => register_source::<perf::Rapl>(&mut profiler, &mut config_table),
 
-        RaplBackend::Powercap => register_source_override::<powercap::Rapl, CliArgs>(
-            &mut profiler,
-            &mut config_table,
-            |config| {
-                if let Some(rapl_path) = cli.rapl_path.take() {
-                    config.rapl_path = Some(rapl_path);
-                }
-                if let Some(sockets_spec) = &cli.sockets {
-                    config.sockets_spec = Some(parse_sockets_spec(sockets_spec));
-                }
+        RaplBackend::Powercap => {
+            register_source_override::<powercap::Rapl>(&mut profiler, &mut config_table, |config| {
                 if let ProfilerCommand::Profile(profile_args) = &cli.command
                     && let Some(rapl_polling) = profile_args.rapl_polling
                 {
                     config.poll_interval = Some(rapl_polling);
                 }
-            },
-        ),
+            })
+        }
     }?;
 
     register_source::<PerfEvent>(&mut profiler, &mut config_table)?;
@@ -72,6 +47,8 @@ async fn main() -> Result<()> {
     register_source::<Procfs>(&mut profiler, &mut config_table)?;
     register_source::<Nvml>(&mut profiler, &mut config_table)?;
     register_source::<AmdSmi>(&mut profiler, &mut config_table)?;
+
+    config_table.ensure_sources_are_known()?;
 
     let mut displayer = config_table_to_displayer(&config_table)?;
     let config = config_table.to_config(cli)?;

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,10 +1,8 @@
 use anyhow::Result;
 use joule_profiler_cli::config::load_global_config;
-use joule_profiler_cli::config::source::{register_source, register_source_override};
+use joule_profiler_cli::config::source::register_source;
 use joule_profiler_cli::config::table::ConfigTable;
-use joule_profiler_cli::{
-    CliArgs, ProfilerCommand, RaplBackend, config_table_to_displayer, init_logging,
-};
+use joule_profiler_cli::{CliArgs, RaplBackend, config_table_to_displayer, init_logging};
 use joule_profiler_core::JouleProfiler;
 use joule_profiler_core::config::Command;
 use joule_profiler_source_amdsmi::AmdSmi;
@@ -30,15 +28,8 @@ async fn main() -> Result<()> {
 
     match config_table.profiler_config.rapl_backend {
         RaplBackend::Perf => register_source::<perf::Rapl>(&mut profiler, &mut config_table),
-
         RaplBackend::Powercap => {
-            register_source_override::<powercap::Rapl>(&mut profiler, &mut config_table, |config| {
-                if let ProfilerCommand::Profile(profile_args) = &cli.command
-                    && let Some(rapl_polling) = profile_args.rapl_polling
-                {
-                    config.poll_interval = Some(rapl_polling);
-                }
-            })
+            register_source::<powercap::Rapl>(&mut profiler, &mut config_table)
         }
     }?;
 

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -25,11 +25,6 @@ pub struct ProfileArgs {
     #[arg(last = true, required = true)]
     pub cmd: Vec<String>,
 
-    /// Rapl polling frequency in second. (default: 1s)
-    #[arg(long = "rapl-polling")]
-    #[clap(value_parser = humantime::parse_duration)]
-    pub rapl_polling: Option<Duration>,
-
     /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
     #[arg(long = "use-root")]
     pub use_root: bool,

--- a/cli/src/config/mod.rs
+++ b/cli/src/config/mod.rs
@@ -1,9 +1,11 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, fs, path::Path, time::Duration};
 
+use anyhow::{Context, Result};
 use serde::Deserialize;
 
-use crate::{RaplBackend, output::formats::OutputFormat};
+use crate::{RaplBackend, config::overrides::ConfigOverride, output::formats::OutputFormat};
 
+pub mod overrides;
 pub mod source;
 pub mod table;
 
@@ -18,7 +20,10 @@ fn default_token_pattern() -> String {
     DEFAULT_TOKEN_PATTERN.to_owned()
 }
 
+/// Unknown keys are rejected: a misspelled one would otherwise be dropped
+/// without a trace, which is easy to miss on a `-D` override.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProfilerConfig {
     /// Optional file to redirect the profiled program stdout.
     pub stdout_file: Option<String>,
@@ -61,6 +66,7 @@ impl Default for ProfilerConfig {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GlobalConfig {
     /// The global configuration of the profiler.
     #[serde(default)]
@@ -69,4 +75,154 @@ pub struct GlobalConfig {
     /// The sources configurations.
     #[serde(default)]
     pub sources: HashMap<String, toml::Value>,
+}
+
+/// Loads the configuration from `config_file`, with the `-D` overrides applied
+/// on top of it.
+///
+/// Overrides are applied to the raw TOML rather than to the deserialized
+/// configuration, so a `-D` reaches any key a configuration file can set,
+/// including per-source ones, and goes through the same checks.
+pub fn load_global_config(
+    config_file: Option<&Path>,
+    overrides: &[ConfigOverride],
+) -> Result<GlobalConfig> {
+    let mut value = match config_file {
+        Some(path) => {
+            let content = fs::read_to_string(path)
+                .with_context(|| format!("configuration file error on `{}`", path.display()))?;
+            toml::from_str(&content).context("error parsing configuration file")?
+        }
+        None => toml::Value::Table(toml::map::Map::new()),
+    };
+
+    for config_override in overrides {
+        config_override.apply(&mut value)?;
+    }
+
+    value
+        .try_into()
+        .context("error applying the configuration. Check the `-D` overrides")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    fn overrides(raw: &[&str]) -> Vec<ConfigOverride> {
+        raw.iter().map(|s| s.parse().unwrap()).collect()
+    }
+
+    fn config_file(content: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{content}").unwrap();
+        file
+    }
+
+    #[test]
+    fn load_without_a_file_nor_overrides_is_the_default_config() {
+        let config = load_global_config(None, &[]).unwrap();
+
+        assert_eq!(config.profiler.token_pattern, DEFAULT_TOKEN_PATTERN);
+        assert!(config.sources.is_empty());
+    }
+
+    #[test]
+    fn load_applies_overrides_without_a_config_file() {
+        let config = load_global_config(
+            None,
+            &overrides(&[
+                "profiler.token_pattern=__CLI__",
+                "sources.cgroup.create_cgroup=false",
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(config.profiler.token_pattern, "__CLI__");
+        assert_eq!(
+            config.sources["cgroup"]["create_cgroup"],
+            toml::Value::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn load_overrides_take_precedence_over_the_file() {
+        let file = config_file(
+            "[profiler]\ntoken_pattern = \"__FILE__\"\nuse_root = true\n\
+             [sources.cgroup]\ncgroup_name = \"from-file\"\n",
+        );
+
+        let config = load_global_config(
+            Some(file.path()),
+            &overrides(&["profiler.token_pattern=__CLI__"]),
+        )
+        .unwrap();
+
+        assert_eq!(config.profiler.token_pattern, "__CLI__");
+        assert!(config.profiler.use_root);
+        assert_eq!(
+            config.sources["cgroup"]["cgroup_name"],
+            toml::Value::String("from-file".to_owned())
+        );
+    }
+
+    #[test]
+    fn load_overrides_a_source_absent_from_the_file() {
+        let file = config_file("[sources.rapl]\nsockets_spec = [0]\n");
+
+        let config = load_global_config(
+            Some(file.path()),
+            &overrides(&["sources.cgroup.poll_interval=20ms"]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.sources["cgroup"]["poll_interval"],
+            toml::Value::String("20ms".to_owned())
+        );
+        assert_eq!(
+            config.sources["rapl"]["sockets_spec"][0],
+            toml::Value::Integer(0)
+        );
+    }
+
+    #[test]
+    fn load_reports_a_missing_config_file() {
+        let err = load_global_config(Some(Path::new("/does/not/exist.toml")), &[]).unwrap_err();
+
+        assert!(err.to_string().contains("/does/not/exist.toml"));
+    }
+
+    #[test]
+    fn load_reports_an_override_of_the_wrong_type() {
+        let err = load_global_config(None, &overrides(&["profiler.use_root=42"])).unwrap_err();
+
+        assert!(err.to_string().contains("-D"));
+    }
+
+    #[test]
+    fn load_rejects_an_unknown_profiler_key() {
+        let err =
+            load_global_config(None, &overrides(&["profiler.output_forrmat=json"])).unwrap_err();
+
+        assert!(format!("{err:#}").contains("output_forrmat"));
+    }
+
+    #[test]
+    fn load_rejects_an_unknown_top_level_key() {
+        let err = load_global_config(None, &overrides(&["profilr.use_root=true"])).unwrap_err();
+
+        assert!(format!("{err:#}").contains("profilr"));
+    }
+
+    #[test]
+    fn load_rejects_an_unknown_key_of_a_config_file() {
+        let file = config_file("[profiler]\nuse_rooot = true\n");
+
+        let err = load_global_config(Some(file.path()), &[]).unwrap_err();
+
+        assert!(format!("{err:#}").contains("use_rooot"));
+    }
 }

--- a/cli/src/config/overrides.rs
+++ b/cli/src/config/overrides.rs
@@ -1,0 +1,212 @@
+//! CLI overrides of the TOML configuration (`-D KEY=VALUE`).
+
+use std::str::FromStr;
+
+use anyhow::{Result, anyhow, bail};
+use toml::{Value, map::Map};
+
+/// A single `-D KEY=VALUE` override, `KEY` being the dotted path of the key in
+/// the configuration file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigOverride {
+    path: Vec<String>,
+    value: Value,
+}
+
+impl ConfigOverride {
+    /// Writes the override into `root`, creating the tables it goes through.
+    ///
+    /// Returns an error if the path traverses a key that is not a table.
+    pub fn apply(&self, root: &mut Value) -> Result<()> {
+        let (key, parents) = self
+            .path
+            .split_last()
+            .expect("an override path always has at least one segment");
+
+        let key_path = self.path.join(".");
+
+        let mut table = root.as_table_mut().ok_or_else(|| {
+            anyhow!("cannot override `{key_path}`: the configuration is not a table.")
+        })?;
+
+        for (depth, segment) in parents.iter().enumerate() {
+            let node = table
+                .entry(segment.clone())
+                .or_insert_with(|| Value::Table(Map::new()));
+            let kind = node.type_str();
+
+            table = node.as_table_mut().ok_or_else(|| {
+                anyhow!(
+                    "cannot override `{key_path}`: `{}` is a {kind}, not a table.",
+                    self.path[..=depth].join("."),
+                )
+            })?;
+        }
+
+        table.insert(key.clone(), self.value.clone());
+
+        Ok(())
+    }
+}
+
+impl FromStr for ConfigOverride {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let Some((key, value)) = s.split_once('=') else {
+            bail!("expected KEY=VALUE, got `{s}`.");
+        };
+
+        let path: Vec<String> = key
+            .trim()
+            .split('.')
+            .map(|segment| segment.trim().to_owned())
+            .collect();
+
+        if path.iter().any(String::is_empty) {
+            bail!("`{key}` is not a valid configuration key.");
+        }
+
+        Ok(Self {
+            path,
+            value: parse_value(value),
+        })
+    }
+}
+
+/// Parses a `-D` value as a TOML value, falling back to a bare string.
+///
+/// The fallback is what lets durations, regexes and paths go unquoted while
+/// `false`, `10` or `[0,1]` keep the type the sources expect.
+fn parse_value(raw: &str) -> Value {
+    let raw = raw.trim();
+
+    toml::from_str::<Value>(&format!("value = {raw}"))
+        .ok()
+        .and_then(|mut parsed| parsed.as_table_mut()?.remove("value"))
+        .unwrap_or_else(|| Value::String(raw.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> ConfigOverride {
+        s.parse::<ConfigOverride>().unwrap()
+    }
+
+    fn applied(overrides: &[&str]) -> Value {
+        let mut root = Value::Table(Map::new());
+        for raw in overrides {
+            parse(raw).apply(&mut root).unwrap();
+        }
+        root
+    }
+
+    #[test]
+    fn parses_a_dotted_key_path() {
+        let parsed = parse("sources.rapl.rapl_path=/sys/class/powercap");
+
+        assert_eq!(parsed.path, ["sources", "rapl", "rapl_path"]);
+        assert_eq!(
+            parsed.value,
+            Value::String("/sys/class/powercap".to_owned())
+        );
+    }
+
+    #[test]
+    fn parses_toml_typed_values() {
+        assert_eq!(parse("a=42").value, Value::Integer(42));
+        assert_eq!(parse("a=false").value, Value::Boolean(false));
+        assert_eq!(
+            parse("a=[0, 1]").value,
+            Value::Array(vec![Value::Integer(0), Value::Integer(1)])
+        );
+    }
+
+    #[test]
+    fn falls_back_to_a_string_value() {
+        assert_eq!(parse("a=10ms").value, Value::String("10ms".to_owned()));
+        assert_eq!(
+            parse("a=__[A-Z]+__").value,
+            Value::String("__[A-Z]+__".to_owned())
+        );
+    }
+
+    #[test]
+    fn quoting_forces_a_string_value() {
+        assert_eq!(parse("a=\"42\"").value, Value::String("42".to_owned()));
+    }
+
+    #[test]
+    fn keeps_equal_signs_of_the_value() {
+        assert_eq!(parse("a=b=c").value, Value::String("b=c".to_owned()));
+    }
+
+    #[test]
+    fn rejects_a_value_less_override() {
+        assert!("profiler.use_root".parse::<ConfigOverride>().is_err());
+    }
+
+    #[test]
+    fn rejects_an_empty_key_segment() {
+        assert!("sources..rapl=1".parse::<ConfigOverride>().is_err());
+        assert!("=1".parse::<ConfigOverride>().is_err());
+    }
+
+    #[test]
+    fn apply_creates_the_intermediate_tables() {
+        let root = applied(&["sources.cgroup.create_cgroup=false"]);
+
+        assert_eq!(
+            root["sources"]["cgroup"]["create_cgroup"],
+            Value::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn apply_keeps_the_neighbouring_keys() {
+        let root = applied(&[
+            "sources.cgroup.cgroup_name=first",
+            "sources.cgroup.create_cgroup=false",
+            "sources.rapl.sockets_spec=[0]",
+            "profiler.use_root=true",
+        ]);
+
+        assert_eq!(
+            root["sources"]["cgroup"]["cgroup_name"],
+            Value::String("first".to_owned())
+        );
+        assert_eq!(
+            root["sources"]["cgroup"]["create_cgroup"],
+            Value::Boolean(false)
+        );
+        assert_eq!(
+            root["sources"]["rapl"]["sockets_spec"][0],
+            Value::Integer(0)
+        );
+        assert_eq!(root["profiler"]["use_root"], Value::Boolean(true));
+    }
+
+    #[test]
+    fn apply_replaces_an_existing_value() {
+        let root = applied(&["profiler.output_format=csv", "profiler.output_format=json"]);
+
+        assert_eq!(
+            root["profiler"]["output_format"],
+            Value::String("json".to_owned())
+        );
+    }
+
+    #[test]
+    fn apply_rejects_a_path_through_a_non_table() {
+        let mut root = Value::Table(Map::new());
+        parse("profiler.use_root=true").apply(&mut root).unwrap();
+
+        let err = parse("profiler.use_root.nested=1")
+            .apply(&mut root)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("profiler.use_root"));
+    }
+}

--- a/cli/src/config/source.rs
+++ b/cli/src/config/source.rs
@@ -45,13 +45,13 @@ where
 ///
 /// This is the override variant of [`register_source`], used when another
 /// subsystem needs to inject values into the source's config before it is
-/// constructed. The caller supplies an override object `O` and a closure the source's config.
+/// constructed. The caller supplies a closure applied to the source's config.
 ///
 /// If the source is disabled or its initialization fails with
 /// `ignore_on_failure` set, no source is added and `Ok(())` is returned.
 /// Returns an error if source initialization fails and `ignore_on_failure` is
 /// not set in the source's config.
-pub fn register_source_override<R, O>(
+pub fn register_source_override<R>(
     profiler: &mut JouleProfiler,
     config_table: &mut ConfigTable,
     config_override_fn: impl FnOnce(&mut R::Config),

--- a/cli/src/config/table.rs
+++ b/cli/src/config/table.rs
@@ -418,7 +418,6 @@ mod tests {
             token_pattern: Some("__CLI__".to_owned()),
             init_timeout: Some(Duration::from_secs(9)),
             use_root: true,
-            rapl_polling: None,
         }));
 
         table.apply_cli(&mut cli);

--- a/cli/src/config/table.rs
+++ b/cli/src/config/table.rs
@@ -2,7 +2,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
+use clap::ValueEnum;
 use joule_profiler_core::{
     config::{Command, Config, ProfileConfigBuilder},
     source::MetricReader,
@@ -53,9 +54,9 @@ impl ConfigTable {
     /// in one pass, so [`ConfigTable::to_config`] can read `profiler_config`
     /// directly afterwards instead of re-merging `cli` itself.
     ///
-    /// Per-source overrides (e.g. RAPL's sockets/path/polling) are a separate
-    /// concern and stay as override closures at each source's registration
-    /// call site (see `register_source_override`).
+    /// Only the flags that have no configuration key of their own go through
+    /// here: the `-D` overrides are already merged into the configuration
+    /// before the table is built.
     pub fn apply_cli(&mut self, cli: &mut CliArgs) {
         if let Some(output_format) = cli.output_format.take() {
             self.profiler_config.output_format = output_format;
@@ -63,10 +64,6 @@ impl ConfigTable {
 
         if let Some(output_file) = cli.output_file.take() {
             self.profiler_config.output_file = Some(output_file);
-        }
-
-        if let Some(rapl_backend) = cli.rapl_backend.take() {
-            self.profiler_config.rapl_backend = rapl_backend;
         }
 
         if let ProfilerCommand::Profile(profile_args) = &mut cli.command {
@@ -86,7 +83,7 @@ impl ConfigTable {
         }
     }
 
-    /// Builds a metric source reader of type `R` using the provided configuration
+    /// Builds a metric source reader using the provided configuration
     /// into the config table, or default configuration if not configured.
     ///
     /// It returns an error if the source initialization fails and `ignore_on_failure` is not set.
@@ -121,7 +118,7 @@ impl ConfigTable {
         }
     }
 
-    /// Builds a metric source reader of type `R`, applying an external config
+    /// Builds a metric source reader, applying an external config
     /// override through a caller-supplied closure before construction.
     ///
     /// It returns an error if the source initialization fails and `ignore_on_failure` is not set.
@@ -163,6 +160,31 @@ impl ConfigTable {
 }
 
 impl ConfigTable {
+    /// Errors on the configured sources no registered source claimed.
+    ///
+    /// Must be called once every source has been registered: `build_source`
+    /// takes its own section out of the table, so what is left can only be
+    /// misspelled source names.
+    pub fn ensure_sources_are_known(&self) -> Result<()> {
+        if self.sources_config.is_empty() {
+            return Ok(());
+        }
+
+        let mut unknown: Vec<&str> = self.sources_config.keys().map(String::as_str).collect();
+        unknown.sort_unstable();
+
+        let known: Vec<String> = Source::value_variants()
+            .iter()
+            .map(Source::to_string)
+            .collect();
+
+        bail!(
+            "unknown metric source `{}`. Available sources: {}.",
+            unknown.join("`, `"),
+            known.join(", "),
+        )
+    }
+
     /// Consumes the [`ConfigTable`] and a final [`CliArgs`] to produce the
     /// core [`Config`].
     ///
@@ -266,12 +288,10 @@ mod tests {
     fn cli_args(command: ProfilerCommand) -> CliArgs {
         CliArgs {
             verbose: 0,
-            rapl_path: None,
-            sockets: None,
             output_format: None,
             output_file: None,
-            rapl_backend: None,
             sources: Vec::new(),
+            overrides: Vec::new(),
             config_file: None,
             command,
         }
@@ -387,21 +407,6 @@ mod tests {
             Some("cli_output.csv")
         );
         assert!(cli.output_file.is_none());
-    }
-
-    #[test]
-    fn apply_cli_overrides_rapl_backend_and_consumes_it() {
-        let mut table = config_table_with(ProfilerConfig::default());
-        let mut cli = cli_args(ProfilerCommand::ListSensors);
-        cli.rapl_backend = Some(RaplBackend::Powercap);
-
-        table.apply_cli(&mut cli);
-
-        assert!(matches!(
-            table.profiler_config.rapl_backend,
-            RaplBackend::Powercap
-        ));
-        assert!(cli.rapl_backend.is_none());
     }
 
     #[test]
@@ -535,5 +540,31 @@ mod tests {
             .unwrap();
 
         assert_eq!(source.value, 99);
+    }
+
+    #[test]
+    fn ensure_sources_are_known_accepts_a_fully_consumed_table() {
+        let mut table = config_table_with(ProfilerConfig::default());
+        table.enabled_sources.insert("mock".to_owned());
+        table
+            .sources_config
+            .insert("mock".to_owned(), toml::from_str("value = 1").unwrap());
+
+        table.build_source::<MockSource>().unwrap();
+
+        table.ensure_sources_are_known().unwrap();
+    }
+
+    #[test]
+    fn ensure_sources_are_known_rejects_an_unclaimed_source() {
+        let mut table = config_table_with(ProfilerConfig::default());
+        table
+            .sources_config
+            .insert("cgrp".to_owned(), toml::from_str("value = 1").unwrap());
+
+        let err = table.ensure_sources_are_known().unwrap_err();
+
+        assert!(err.to_string().contains("cgrp"));
+        assert!(err.to_string().contains("cgroup"));
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -7,7 +7,7 @@ pub use commands::ProfilerCommand;
 use serde::Deserialize;
 
 use crate::{
-    config::table::ConfigTable,
+    config::{overrides::ConfigOverride, table::ConfigTable},
     output::{
         displayer::Displayer,
         formats::{OutputFormat, csv::CsvOutput, json::JsonOutput, terminal::TerminalOutput},
@@ -32,17 +32,6 @@ pub struct CliArgs {
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
     pub verbose: u8,
 
-    /// Override the base path used to read Intel RAPL counters (powercap backend only).
-    ///
-    /// Resolved by priority: this flag, then the config file's `rapl_path`,
-    /// then `$JOULE_PROFILER_RAPL_PATH`, then `/sys/devices/virtual/powercap/intel-rapl`.
-    #[arg(long = "rapl-path")]
-    pub rapl_path: Option<String>,
-
-    /// Sockets to measure. (e.g., 0 or 0,1)
-    #[arg(short = 's', long = "sockets")]
-    pub sockets: Option<String>,
-
     /// Output format to export the results in. (e.g., terminal, json, csv)
     #[arg(long = "output-format")]
     pub output_format: Option<OutputFormat>,
@@ -51,14 +40,31 @@ pub struct CliArgs {
     #[arg(short = 'o', long = "output-file")]
     pub output_file: Option<String>,
 
-    /// Choose RAPL backend between powercap or perf. (default: perf)
-    #[arg(long = "rapl-backend", value_enum)]
-    pub rapl_backend: Option<RaplBackend>,
-
     /// Sources activation list. All sources must be separated with a comma (e.g., "perf,nvml").
     #[arg(long, value_delimiter = ',', default_value = "rapl")]
     pub sources: Vec<Source>,
 
+    #[allow(clippy::doc_markdown)]
+    /// Override a configuration key, repeatable. (e.g., -D profiler.rapl_backend=powercap)
+    ///
+    /// KEY is the dotted path of the key in the configuration file, so any
+    /// key a configuration file can set is settable here:
+    ///   -D profiler.output_format=json
+    ///   -D sources.rapl.sockets_spec=[0,1]
+    ///   -D sources.cgroup.create_cgroup=false
+    ///
+    /// VALUE is read as TOML, falling back to a plain string, so durations,
+    /// regexes and paths need no quoting. Overrides are applied on top of the
+    /// --config file, and configuring a source enables it.
+    #[arg(
+        short = 'D',
+        long = "define",
+        value_name = "KEY=VALUE",
+        verbatim_doc_comment
+    )]
+    pub overrides: Vec<ConfigOverride>,
+
+    /// TOML configuration file. Every key it sets can also be set with -D.
     #[arg(long = "config")]
     pub config_file: Option<PathBuf>,
 
@@ -111,7 +117,8 @@ impl std::fmt::Display for Source {
     }
 }
 
-#[derive(Debug, Default, Clone, ValueEnum, Deserialize)]
+/// RAPL backend, selected with `profiler.rapl_backend` in the configuration.
+#[derive(Debug, Default, Clone, Deserialize)]
 pub enum RaplBackend {
     #[default]
     #[serde(rename = "perf")]
@@ -140,13 +147,6 @@ pub fn init_logging(verbose: u8) {
     logging::init_logging(verbose);
 }
 
-pub fn parse_sockets_spec(sockets_spec: &str) -> HashSet<u32> {
-    sockets_spec
-        .split(',')
-        .filter_map(|x| x.trim().parse::<u32>().ok())
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use clap::ValueEnum;
@@ -157,12 +157,10 @@ mod tests {
     fn cli_args_with_sources(sources: Vec<Source>) -> CliArgs {
         CliArgs {
             verbose: 0,
-            rapl_path: None,
-            sockets: None,
             output_format: None,
             output_file: None,
-            rapl_backend: None,
             sources,
+            overrides: Vec::new(),
             config_file: None,
             command: ProfilerCommand::ListSensors,
         }
@@ -205,29 +203,6 @@ mod tests {
         assert_eq!(Source::from_str("perf", false).unwrap(), Source::Perf);
         assert_eq!(Source::from_str("procfs", false).unwrap(), Source::Procfs);
         assert_eq!(Source::from_str("cgroup", false).unwrap(), Source::Cgroup);
-    }
-
-    #[test]
-    fn parse_sockets_spec_parses_comma_separated_values() {
-        let sockets = parse_sockets_spec("0,1,2");
-        assert_eq!(sockets, HashSet::from([0, 1, 2]));
-    }
-
-    #[test]
-    fn parse_sockets_spec_trims_whitespace() {
-        let sockets = parse_sockets_spec(" 0 , 1 ");
-        assert_eq!(sockets, HashSet::from([0, 1]));
-    }
-
-    #[test]
-    fn parse_sockets_spec_ignores_invalid_entries() {
-        let sockets = parse_sockets_spec("0,not_a_number,2");
-        assert_eq!(sockets, HashSet::from([0, 2]));
-    }
-
-    #[test]
-    fn parse_sockets_spec_empty_string_returns_empty_set() {
-        assert!(parse_sockets_spec("").is_empty());
     }
 
     #[test]

--- a/examples/example_config.toml
+++ b/examples/example_config.toml
@@ -3,7 +3,12 @@
 # Usage:
 #   joule-profiler --config examples/example_config.toml ...
 #
-# `ignore_on_failure = true` on a configured source ignore the error 
+# Any key below can be overridden on the command line with its dotted path,
+# with or without this file:
+#   joule-profiler --config examples/example_config.toml \
+#     -D profiler.output_format=csv -D sources.cgroup.create_cgroup=false ...
+#
+# `ignore_on_failure = true` on a configured source ignore the error
 # if one occur while building the source.
 #
 # Notes: all fields are optional and Joule Profiler does not require

--- a/sources/rapl/README.md
+++ b/sources/rapl/README.md
@@ -2,7 +2,7 @@
 
 RAPL energy source for [joule-profiler](https://github.com/joule-profiler/joule-profiler).
 
-This crate implements `MetricSource` from `joule-profiler-core` and measures Intel RAPL energy counters via two interchangeable backends: **powercap** (sysfs) and **perf_event** (syscall). The CLI selects the backend automatically or on demand via `--rapl-backend`.
+This crate implements `MetricSource` from `joule-profiler-core` and measures Intel RAPL energy counters via two interchangeable backends: **powercap** (sysfs) and **perf_event** (syscall). The backend is selected with the `profiler.rapl_backend` configuration key, from a configuration file or with `-D profiler.rapl_backend=powercap` on the command line.
 
 ## What is RAPL?
 


### PR DESCRIPTION
## Description

This pull request adds a way to override the configuration of Joule Profiler or to specify complex configuration options without needing a configuration file.
It adds a CLI flag -D or --define to specify a toml KEY=VALUE and configure an option.

Example:
```bash
joule-profiler -D profiler.rapl_backend=powercap -D "sources.rapl.sockets_spec=[0]" profile -- <COMMAND>
```

Careful, if a config option is not in string format, then you must add brackets.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Improvement
* [ ] Documentation
* [ ] Other (please specify):

## Related Issues

The issue related is #68.

## Changes Made

* Added a CLI flag -D to be able to specify a config argument in toml format.

## Checklist

* [x] My code follows the project style
* [x] I have tested my changes
* [x] I have added/updated documentation if needed
* [x] All tests pass
